### PR TITLE
Use automatic GitHub token authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Create GitHub deployment for Staging
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: master
       run: |
         source deploy-github-functions.sh
@@ -30,7 +30,7 @@ jobs:
 
     - name: Initiate Staging deployment status
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
 
@@ -67,7 +67,7 @@ jobs:
     - name: Update Staging deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         environment_url=https://staging.product-safety-database.service.gov.uk/
@@ -76,7 +76,7 @@ jobs:
     - name: Update Staging deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         gh_deploy_failure staging $LOG_URL
@@ -118,7 +118,7 @@ jobs:
     - name: Create GitHub deployment for Production
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: master
       run: |
         source deploy-github-functions.sh
@@ -127,7 +127,7 @@ jobs:
     - name: Initiate Production deployment status
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         gh_deploy_initiate production $LOG_URL
@@ -159,7 +159,7 @@ jobs:
     - name: Update Production deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         environment_url=https://www.product-safety-database.service.gov.uk/
@@ -168,7 +168,7 @@ jobs:
     - name: Update Production deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Deactivate GitHub deployment
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         gh_deploy_deactivate_dangling review-app-$PR_NUMBER

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Create GitHub deployment
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: ${{ github.head_ref }}
       run: |
         source deploy-github-functions.sh
@@ -23,7 +23,7 @@ jobs:
 
     - name: Initiate deployment status
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
 
@@ -78,7 +78,7 @@ jobs:
     - name: Update deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
 
@@ -89,7 +89,7 @@ jobs:
     - name: Update deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source deploy-github-functions.sh
         gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL


### PR DESCRIPTION
Since transferring the repository to the new organisation, the old token is no longer valid. This change uses the new automatic token authentication as described in https://docs.github.com/en/actions/security-guides/automatic-token-authentication.