### PR TITLE
Remove the character count and lower limit on case summaries

### DIFF
--- a/app/views/investigations/summary/edit.html.erb
+++ b/app/views/investigations/summary/edit.html.erb
@@ -21,25 +21,18 @@
                   builder: ApplicationFormBuilder,
                   local: true) do |form| %>
 
-      <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="800">
-        <%= form.govuk_text_area(:summary,
-                                 classes: "govuk-js-character-count",
-                                 rows: 11,
-                                 label: "Edit the summary",
-                                 label_classes: "govuk-label--l govuk-!-margin-bottom-2",
-                                 hint: "You can add and edit a general summary about the case.",
-                                 hint_classes: "govuk-!-margin-bottom-6",
-                                 attributes: { maxlength: 800 },
-                                 described_by: "summary-info") %>
-        <div id="summary-info" class="govuk-hint govuk-character-count__message govuk-!-font-size-16">
-          You can enter up to 800 characters
-        </div>
-      </div>
+      <%= form.govuk_text_area(:summary,
+                               rows: 11,
+                               label: "Edit the summary",
+                               label_classes: "govuk-label--l govuk-!-margin-bottom-2",
+                               hint: "You can add and edit a general summary about the case.",
+                               hint_classes: "govuk-!-margin-bottom-6") %>
 
       <div class="govuk-button-group">
         <%= form.submit "Save", class: "govuk-button govuk-link--no-visited-state" %>
         <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
       </div>
+
     <% end %>
 
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,7 +517,7 @@ en:
           attributes:
             summary:
               blank: Enter the case summary
-              too_long: Summary must be 800 characters or fewer
+              too_long: Summary must be 10,000 characters or fewer
         change_case_status_form:
           attributes:
             new_status:

--- a/spec/forms/change_case_summary_form_spec.rb
+++ b/spec/forms/change_case_summary_form_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ChangeCaseSummaryForm do
     context "when summary is too long" do
       let(:summary) { rand(36**20_000).to_s(36) }
 
-      include_examples "invalid form", [:summary, "Summary must be 800 characters or fewer"]
+      include_examples "invalid form", [:summary, "Summary must be 10,000 characters or fewer"]
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/f5lVcGj8/1507-remove-character-count-for-the-summary-field

## Description

#1952 and #1971 made some changes to case summaries, reducing their length. We have decided to revert these changes pending further research into how summaries are being used by our users. This PR restores the summary character limit to 10,000 characters, but removes the new character count design as this was determined to be a distraction.