### PR TITLE
Add the concept of products being owned by a team

### DIFF
--- a/app/decorators/products_decorator.rb
+++ b/app/decorators/products_decorator.rb
@@ -15,6 +15,6 @@ private
   end
 
   def attributes_for_export
-    Product.attribute_names.dup.concat(%w[case_ids]).sort
+    Product.attribute_names.dup.concat(%w[case_ids]).without("owning_team_id").sort
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -48,7 +48,7 @@ class ProductForm
   validate :markings_validity, if: -> { has_markings == "markings_yes" }
 
   def self.from(product)
-    new(product.serializable_hash(except: %i[updated_at])).tap do |product_form|
+    new(product.serializable_hash(except: %i[owning_team_id updated_at])).tap do |product_form|
       if product.affected_units_status == Product.affected_units_statuses["approx"]
         product_form.approx_units = product.number_of_affected_units
       elsif product.affected_units_status == Product.affected_units_statuses["exact"]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -65,6 +65,8 @@ class Product < ApplicationRecord
 
   has_one :source, as: :sourceable, dependent: :destroy
 
+  belongs_to :owning_team, class_name: "Team", inverse_of: :owned_products, optional: true
+
   redacted_export_with :id, :affected_units_status, :authenticity, :barcode, :batch_number,
                        :brand, :category, :country_of_origin, :created_at, :customs_code, :description,
                        :has_markings, :markings, :name, :number_of_affected_units, :product_code,

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -70,7 +70,7 @@ class Product < ApplicationRecord
   redacted_export_with :id, :affected_units_status, :authenticity, :barcode, :batch_number,
                        :brand, :category, :country_of_origin, :created_at, :customs_code, :description,
                        :has_markings, :markings, :name, :number_of_affected_units, :product_code,
-                       :subcategory, :updated_at, :webpage, :when_placed_on_market
+                       :subcategory, :updated_at, :webpage, :when_placed_on_market, :owning_team_id
 
   def supporting_information
     tests + corrective_actions + unexpected_events + risk_assessments

--- a/app/models/product_export.rb
+++ b/app/models/product_export.rb
@@ -44,7 +44,7 @@ private
 
   def find_products(ids)
     Product
-      .includes([:investigations, :test_results, { corrective_actions: [:business], risk_assessments: %i[assessed_by_business assessed_by_team] }])
+      .includes([:investigations, :test_results, :owning_team, { corrective_actions: [:business], risk_assessments: %i[assessed_by_business assessed_by_team] }])
       .find(ids)
   end
 
@@ -98,7 +98,7 @@ private
                      hazard_type
                      non_compliant_reason
                      risk_level
-                     name]
+                     owning_team]
 
     @product_info_sheet = sheet
   end
@@ -168,7 +168,8 @@ private
       product.investigations.first.try(:reported_reason),
       product.investigations.first.try(:hazard_type),
       product.investigations.first.try(:non_compliant_reason),
-      product.investigations.first.try(:risk_level)
+      product.investigations.first.try(:risk_level),
+      product.owning_team.try(:name)
     ]
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,6 +12,8 @@ class Team < ApplicationRecord
 
   has_many :roles, dependent: :destroy, as: :entity
 
+  has_many :owned_products, class_name: "Product", foreign_key: "owning_team_id", inverse_of: :owning_team, dependent: :nullify
+
   validates :name, presence: true
   validates :country, presence: true
 

--- a/db/migrate/20220822125733_add_owning_team_to_products.rb
+++ b/db/migrate/20220822125733_add_owning_team_to_products.rb
@@ -1,0 +1,6 @@
+class AddOwningTeamToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :products, :owning_team, type: :uuid, null: true, index: false
+    add_foreign_key :products, :teams, column: :owning_team_id, validate: false
+  end
+end

--- a/db/migrate/20220822125733_add_owning_team_to_products.rb
+++ b/db/migrate/20220822125733_add_owning_team_to_products.rb
@@ -1,6 +1,8 @@
 class AddOwningTeamToProducts < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
   def change
-    add_reference :products, :owning_team, type: :uuid, null: true, index: false
+    add_reference :products, :owning_team, type: :uuid, null: true, index: { algorithm: :concurrently }
     add_foreign_key :products, :teams, column: :owning_team_id, validate: false
   end
 end

--- a/db/migrate/20220823094633_validate_foreign_key_products_to_owning_team.rb
+++ b/db/migrate/20220823094633_validate_foreign_key_products_to_owning_team.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyProductsToOwningTeam < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :products, :teams, column: :owning_team_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -285,6 +285,7 @@ ActiveRecord::Schema.define(version: 2022_08_23_094633) do
     t.datetime "updated_at", null: false
     t.string "webpage"
     t.enum "when_placed_on_market", as: "when_placed_on_markets"
+    t.index ["owning_team_id"], name: "index_products_on_owning_team_id"
   end
 
   create_table "rapex_imports", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_133518) do
+ActiveRecord::Schema.define(version: 2022_08_23_094633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -279,6 +279,7 @@ ActiveRecord::Schema.define(version: 2022_05_16_133518) do
     t.text "markings", array: true
     t.string "name"
     t.text "number_of_affected_units"
+    t.uuid "owning_team_id"
     t.string "product_code"
     t.string "subcategory"
     t.datetime "updated_at", null: false
@@ -450,6 +451,7 @@ ActiveRecord::Schema.define(version: 2022_05_16_133518) do
   add_foreign_key "corrective_actions", "products"
   add_foreign_key "correspondences", "investigations"
   add_foreign_key "locations", "businesses"
+  add_foreign_key "products", "teams", column: "owning_team_id"
   add_foreign_key "risk_assessed_products", "products"
   add_foreign_key "risk_assessed_products", "risk_assessments"
   add_foreign_key "risk_assessments", "businesses", column: "assessed_by_business_id"

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -13,4 +13,12 @@ RSpec.describe Product do
       expect(product.psd_ref).to eq("psd-#{id}")
     end
   end
+
+  describe "#owning_team" do
+    let(:product) { build :product }
+
+    it "returns nil for a new product" do
+      expect(product.owning_team).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/9FcZdj4F/1526-creating-a-product-record-in-the-database-rules

## Description

- Adds a database column, attribute, relationships and foreign key to represent the Team which owns a Product
- Products have no owning team by default

```rb
Product.owning_team
# => <Team ...>
Team.owned_products
# => [...]
```