### PR TITLE
Fix flaky case export spec

### DIFF
--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -2,9 +2,11 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.feature "Case export", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
-  let(:user) { create :user, :all_data_exporter, :activated }
-  let(:other_user_same_team) { create :user, :activated, team: user.team, organisation: user.organisation }
-  let(:other_user) { create :user, :activated }
+  let(:user_team) { create :team, name: "User Team" }
+  let(:user) { create :user, :all_data_exporter, :activated, team: user_team, organisation: user_team.organisation }
+  let(:other_user_same_team) { create :user, :activated, team: user_team, organisation: user_team.organisation }
+  let(:other_user_team) { create :team, name: "Other User Team" }
+  let(:other_user) { create :user, :activated, team: other_user_team, organisation: other_user_team.organisation }
   let(:email) { delivered_emails.last }
   let(:export) { CaseExport.find_by(user:) }
   let(:spreadsheet) do


### PR DESCRIPTION
Fixes a common flaky test failure caused by Faker generating two different teams with the same name. This PR sets an explicit name for each team.

```
1) Case export with filtering on cases owned by another team
   Failure/Error: select other_user.team.name

   Capybara::Ambiguous:
     Ambiguous match, found 2 elements matching visible option "Aviato" within #<Capybara::Node::Element tag="fieldset" path="/html/body/div[2]/main/form/div/section[1]/details/div/div[1]/fieldset">
   # ./spec/features/export_cases_spec.rb:224
```