### PR TITLE
Edit reference number and case name

### DIFF
--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -1,0 +1,30 @@
+module Investigations
+  class CaseNamesController < ApplicationController
+    def edit
+      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      authorize @investigation, :update?
+
+      @case_name_form = CaseNameForm.new(user_title: @investigation.user_title, current_user: current_user)
+    end
+
+    def update
+      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      authorize @investigation, :update?
+
+      @case_name_form = CaseNameForm.new(reference_number_params.merge(current_user: current_user))
+
+      if @case_name_form.valid?
+        @investigation.update!(user_title: @case_name_form.user_title )
+        return redirect_to investigation_path(@investigation), flash: { success: "The case name has been updated." }
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def reference_number_params
+      params.require(:investigation).permit(:user_title)
+    end
+  end
+end

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -15,7 +15,7 @@ module Investigations
 
       if @case_name_form.valid?
         @investigation.update!(user_title: @case_name_form.user_title )
-        return redirect_to investigation_path(@investigation), flash: { success: "The case name has been updated." }
+        return redirect_to investigation_path(@investigation), flash: { success: "Case name was successfully updated" }
       else
         render :edit
       end

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -1,14 +1,14 @@
 module Investigations
   class CaseNamesController < ApplicationController
     def edit
-      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
       authorize @investigation, :update?
 
       @case_name_form = CaseNameForm.new(user_title: @investigation.user_title, current_user:)
     end
 
     def update
-      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
       authorize @investigation, :update?
 
       @case_name_form = CaseNameForm.new(reference_number_params.merge(current_user:))

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -11,7 +11,7 @@ module Investigations
       @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
       authorize @investigation, :update?
 
-      @case_name_form = CaseNameForm.new(reference_number_params.merge(current_user:))
+      @case_name_form = CaseNameForm.new(case_name_params.merge(current_user:))
 
       if @case_name_form.valid?
         @investigation.update!(user_title: @case_name_form.user_title)
@@ -23,7 +23,7 @@ module Investigations
 
   private
 
-    def reference_number_params
+    def case_name_params
       params.require(:investigation).permit(:user_title)
     end
   end

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -4,24 +4,24 @@ module Investigations
       @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
       authorize @investigation, :update?
 
-      @case_name_form = CaseNameForm.new(user_title: @investigation.user_title, current_user: current_user)
+      @case_name_form = CaseNameForm.new(user_title: @investigation.user_title, current_user:)
     end
 
     def update
       @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
       authorize @investigation, :update?
 
-      @case_name_form = CaseNameForm.new(reference_number_params.merge(current_user: current_user))
+      @case_name_form = CaseNameForm.new(reference_number_params.merge(current_user:))
 
       if @case_name_form.valid?
-        @investigation.update!(user_title: @case_name_form.user_title )
-        return redirect_to investigation_path(@investigation), flash: { success: "Case name was successfully updated" }
+        @investigation.update!(user_title: @case_name_form.user_title)
+        redirect_to investigation_path(@investigation), flash: { success: "Case name was successfully updated" }
       else
         render :edit
       end
     end
 
-    private
+  private
 
     def reference_number_params
       params.require(:investigation).permit(:user_title)

--- a/app/controllers/investigations/reference_numbers_controller.rb
+++ b/app/controllers/investigations/reference_numbers_controller.rb
@@ -12,12 +12,12 @@ module Investigations
       if @investigation.complainant_reference == reference_number_params[:complainant_reference]
         redirect_to investigation_path(@investigation)
       else
-        @investigation.update(reference_number_params)
+        @investigation.update!(reference_number_params)
         redirect_to investigation_path(@investigation), flash: { success: "Reference number was successfully updated" }
       end
     end
 
-    private
+  private
 
     def reference_number_params
       params.require(:investigation).permit(:complainant_reference)

--- a/app/controllers/investigations/reference_numbers_controller.rb
+++ b/app/controllers/investigations/reference_numbers_controller.rb
@@ -1,12 +1,12 @@
 module Investigations
   class ReferenceNumbersController < ApplicationController
     def edit
-      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
       authorize @investigation, :update?
     end
 
     def update
-      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
       authorize @investigation, :update?
 
       if @investigation.complainant_reference == reference_number_params[:complainant_reference]

--- a/app/controllers/investigations/reference_numbers_controller.rb
+++ b/app/controllers/investigations/reference_numbers_controller.rb
@@ -1,0 +1,26 @@
+module Investigations
+  class ReferenceNumbersController < ApplicationController
+    def edit
+      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      authorize @investigation, :update?
+    end
+
+    def update
+      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      authorize @investigation, :update?
+
+      if @investigation.complainant_reference == reference_number_params[:complainant_reference]
+        redirect_to investigation_path(@investigation)
+      else
+        @investigation.update(reference_number_params)
+        redirect_to investigation_path(@investigation), flash: { success: "Reference number was successfully updated" }
+      end
+    end
+
+    private
+
+    def reference_number_params
+      params.require(:investigation).permit(:complainant_reference)
+    end
+  end
+end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -168,7 +168,8 @@ module InvestigationsHelper
       {
         items: [
           href: edit_investigation_reference_numbers_path(investigation.pretty_id),
-          text: "Edit"
+          text: "Edit",
+          visuallyHiddenText: "reference number"
         ]
       }
     else
@@ -181,7 +182,8 @@ module InvestigationsHelper
       {
         items: [
           href: edit_investigation_case_names_path(investigation.pretty_id),
-          text: "Edit"
+          text: "Edit",
+          visuallyHiddenText: "case name"
         ]
       }
     else

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -163,6 +163,19 @@ module InvestigationsHelper
     end
   end
 
+  def reference_number_actions(investigation, user)
+    if policy(investigation).update?(user:)
+      {
+        items: [
+          href: edit_investigation_reference_numbers_path(investigation.pretty_id),
+          text: "Edit"
+        ]
+      }
+    else
+      {}
+    end
+  end
+
   def search_result_statement(search_terms, number_of_results)
     search_result_values = search_result_values(search_terms, number_of_results)
 
@@ -245,7 +258,8 @@ module InvestigationsHelper
     if investigation.complainant_reference.present?
       rows << {
         key: { text: "Trading Standards reference" },
-        value: { text: investigation.complainant_reference }
+        value: { text: investigation.complainant_reference },
+        actions: reference_number_actions(investigation, user)
       }
     end
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -176,6 +176,19 @@ module InvestigationsHelper
     end
   end
 
+  def case_name_actions(investigation, user)
+    if policy(investigation).update?(user:)
+      {
+        items: [
+          href: edit_investigation_case_names_path(investigation.pretty_id),
+          text: "Edit"
+        ]
+      }
+    else
+      {}
+    end
+  end
+
   def search_result_statement(search_terms, number_of_results)
     search_result_values = search_result_values(search_terms, number_of_results)
 
@@ -225,6 +238,11 @@ module InvestigationsHelper
     end
 
     rows = [
+      {
+        key: { text: "Case name" },
+        value: { text: investigation.title },
+        actions: case_name_actions(investigation, user)
+      },
       {
         key: { text: "Status" },
         value: { text: investigation.status },

--- a/app/views/investigations/case_names/_form.html.erb
+++ b/app/views/investigations/case_names/_form.html.erb
@@ -9,13 +9,16 @@
         isPageHeading: true
       },
       hint: {
-        text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".'
+        text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".',
+        classes: "govuk-!-margin-bottom-5"
       },
       id: "user_title",
       key: :user_title,
       name: "investigation[user_title]",
       attributes: { maxlength: 45 },
       classes: "govuk-!-width-two-thirds",
-      errorMessage: error_message
+      formGroup: {
+        errorMessage: error_message
+      }
     )
  %>

--- a/app/views/investigations/case_names/_form.html.erb
+++ b/app/views/investigations/case_names/_form.html.erb
@@ -1,0 +1,21 @@
+<%= error_summary @case_name_form.errors %>
+<% error_message = { text: @case_name_form.errors.full_messages_for("user_title").first } if @case_name_form.errors.any? %>
+
+<%= govukInput(
+      form: form,
+      label: {
+        text: heading,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+      hint: {
+        text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".'
+      },
+      id: "user_title",
+      key: :user_title,
+      name: "investigation[user_title]",
+      attributes: { maxlength: 45 },
+      classes: "govuk-!-width-two-thirds",
+      errorMessage: error_message
+    )
+ %>

--- a/app/views/investigations/case_names/edit.html.erb
+++ b/app/views/investigations/case_names/edit.html.erb
@@ -1,0 +1,39 @@
+<% page_heading = "What is the case name?" %>
+
+<%= page_title page_heading, errors: @case_name_form.errors.any? %>
+<%= govukBackLink(
+  text: "Back",
+  href: investigation_path(@investigation)
+) %>
+
+<%= form_with model: @case_name_form, url: investigation_case_names_path, method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= error_summary @case_name_form.errors %>
+      <% error_message = { text: @case_name_form.errors.full_messages_for("user_title").first } if @case_name_form.errors.any? %>
+      <%= govukInput(
+            form: form,
+            label: {
+              text: "What is the case name?",
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".'
+            },
+            id: "user_title",
+            key: :user_title,
+            name: "investigation[user_title]",
+            attributes: { maxlength: 45 },
+            classes: "govuk-!-width-two-thirds",
+            errorMessage: error_message
+          )
+       %>
+
+       <div class="govuk-button-group">
+         <%= form.submit "Save", class: "govuk-button" %>
+         <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+       </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/investigations/case_names/edit.html.erb
+++ b/app/views/investigations/case_names/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_heading = "What is the case name?" %>
+<% page_heading = "Edit the case name?" %>
 
 <%= page_title page_heading, errors: @case_name_form.errors.any? %>
 <%= govukBackLink(
@@ -14,7 +14,7 @@
       <%= govukInput(
             form: form,
             label: {
-              text: "What is the case name?",
+              text: "Edit the case name?",
               classes: "govuk-label--l",
               isPageHeading: true
             },

--- a/app/views/investigations/case_names/edit.html.erb
+++ b/app/views/investigations/case_names/edit.html.erb
@@ -9,26 +9,7 @@
 <%= form_with model: @case_name_form, url: investigation_case_names_path, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= error_summary @case_name_form.errors %>
-      <% error_message = { text: @case_name_form.errors.full_messages_for("user_title").first } if @case_name_form.errors.any? %>
-      <%= govukInput(
-            form: form,
-            label: {
-              text: "Edit the case name?",
-              classes: "govuk-label--l",
-              isPageHeading: true
-            },
-            hint: {
-              text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".'
-            },
-            id: "user_title",
-            key: :user_title,
-            name: "investigation[user_title]",
-            attributes: { maxlength: 45 },
-            classes: "govuk-!-width-two-thirds",
-            errorMessage: error_message
-          )
-       %>
+      <%= render "form", form: form, heading: "Edit the case name" %>
 
        <div class="govuk-button-group">
          <%= form.submit "Save", class: "govuk-button" %>

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -6,30 +6,38 @@
   href: investigation_path(@investigation)
 ) %>
 
-<h1 class="govuk-heading-l"><%= page_heading %></h1>
-<div id="ref-number-hint" class="govuk-hint">
-  You can add your own reference number to this case.
-</div>
+<% hint_html = capture do %>
+  <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this case.</div>
 
-<%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
-  <p class="govuk-body-s">
-    This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case.
-    The reference number will be searchable in the <abbr title="Product Safety Database">PSD</abbr> case search page. (You can add or edit this number later).
-  </p>
+  <%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
+    <p class="govuk-body-s">
+      This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case.
+      The reference number will be searchable in the <abbr title="Product Safety Database">PSD</abbr> case search page. (You can add or edit this number later).
+    </p>
+  <% end %>
 <% end %>
 
-<%= form_with scope: :investigation, model: @investigation, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
-  <%= govukInput(
-    key: :complainant_reference,
-    id: "complainant_reference",
-    form: form,
-    label: { text: nil },
-    classes: "govuk-input--width-20"
-  ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with scope: :investigation, model: @investigation, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
+      <%= govukInput(
+        key: :complainant_reference,
+        id: "complainant_reference",
+        form: form,
+        hint: { html: hint_html},
+        label: { 
+          text: "Edit the reference number",
+          isPageHeading: true,
+          classes: "govuk-label--l govuk-!-margin-bottom-2"
+        },
+        classes: "govuk-input--width-20"
+      ) %>
 
 
-  <div class="govuk-button-group">
-    <%= form.submit "Save", class: "govuk-button" %>
-    <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+      <div class="govuk-button-group">
+        <%= form.submit "Save", class: "govuk-button" %>
+        <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -27,5 +27,8 @@
   ) %>
 
 
-  <%= form.submit "Continue", class: "govuk-button" %>
+  <div class="govuk-button-group">
+    <%= form.submit "Save", class: "govuk-button" %>
+    <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+  </div>
 <% end %>

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -1,4 +1,5 @@
 <% page_heading = "Edit the reference number" %>
+<%= page_title page_heading, errors: @investigation.errors.any? %>
 
 <%= govukBackLink(
   text: "Back",

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -1,0 +1,31 @@
+<% page_heading = "Edit the reference number" %>
+
+<%= govukBackLink(
+  text: "Back",
+  href: investigation_path(@investigation)
+) %>
+
+<h1 class="govuk-heading-l"><%= page_heading %></h1>
+<div id="ref-number-hint" class="govuk-hint">
+  You can add your own reference number to this case.
+</div>
+
+<%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
+  <p class="govuk-body-s">
+    This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case.
+    The reference number will be searchable in the <abbr title="Product Safety Database">PSD</abbr> case search page. (You can add or edit this number later).
+  </p>
+<% end %>
+
+<%= form_with scope: :investigation, model: @investigation, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
+  <%= govukInput(
+    key: :complainant_reference,
+    id: "complainant_reference",
+    form: form,
+    label: { text: nil },
+    classes: "govuk-input--width-20"
+  ) %>
+
+
+  <%= form.submit "Continue", class: "govuk-button" %>
+<% end %>

--- a/app/views/investigations/ts_investigations/case_name.html.erb
+++ b/app/views/investigations/ts_investigations/case_name.html.erb
@@ -9,24 +9,8 @@
 <%= form_with scope: :investigation, model: @case_name_form, url: wizard_path, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= error_summary @case_name_form.errors %>
-      <% error_message = { text: @case_name_form.errors.full_messages_for("user_title").first } if @case_name_form.errors.any? %>
-      <%= govukInput(
-            label: {
-              text: "What is the case name?",
-              classes: "govuk-label--l",
-              isPageHeading: true
-            },
-            hint: {
-              text: 'Give the case a short descriptive title. For example, "Overheating handheld Minolta camera".'
-            },
-            id: "user_title",
-            name: "investigation[user_title]",
-            attributes: { maxlength: 45 },
-            classes: "govuk-!-width-two-thirds",
-            errorMessage: error_message
-          )
-       %>
+      <%= render "/investigations/case_names/form", form: form, heading: "What is the case name?" %>
+
 
        <div class="govuk-button-group">
          <%= form.submit "Save", class: "govuk-button" %>

--- a/app/views/investigations/ts_investigations/reference_number.html.erb
+++ b/app/views/investigations/ts_investigations/reference_number.html.erb
@@ -5,51 +5,54 @@
   text: "Back",
   href: wizard_path(:reason_for_creating)
 ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with scope: :investigation, model: @reference_number_form, url: wizard_path, method: :put, local: true do |form| %>
+      <%= error_summary @reference_number_form.errors %>
+      <% has_complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("has_complainant_reference").first } if @reference_number_form.errors.any? %>
+      <% complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("complainant_reference").first } if @reference_number_form.errors.any? %>
 
-<%= form_with scope: :investigation, model: @reference_number_form, url: wizard_path, method: :put, local: true do |form| %>
-  <%= error_summary @reference_number_form.errors %>
-  <% has_complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("has_complainant_reference").first } if @reference_number_form.errors.any? %>
-  <% complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("complainant_reference").first } if @reference_number_form.errors.any? %>
+      <% existing_reference_field_html = capture do %>
+        <%= govukInput(
+          key: :complainant_reference,
+          id: "complainant_reference",
+          form: form,
+          label: { text: "Reference number" },
+          classes: "govuk-input--width-20",
+          error_message: complainant_reference_error_message
+        ) %>
+      <% end %>
 
-  <% existing_reference_field_html = capture do %>
-    <%= govukInput(
-      key: :complainant_reference,
-      id: "complainant_reference",
-      form: form,
-      label: { text: "Reference number" },
-      classes: "govuk-input--width-20",
-      error_message: complainant_reference_error_message
-    ) %>
-  <% end %>
+      <% hint_html = capture do %>
+        <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this case.</div>
 
-  <% hint_html = capture do %>
-    <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this case.</div>
+        <%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
+          <p class="govuk-body-s">
+            This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case.
+            The reference number will be searchable in the <abbr title="Product Safety Database">PSD</abbr> case search page. (You can add or edit this number later).
+          </p>
+        <% end %>
+      <% end %>
 
-    <%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
-      <p class="govuk-body-s">
-        This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case.
-        The reference number will be searchable in the <abbr title="Product Safety Database">PSD</abbr> case search page. (You can add or edit this number later).
-      </p>
+      <%= govukRadios(
+        form: form,
+        error_message: has_complainant_reference_error_message,
+        key: :has_complainant_reference,
+        fieldset: { legend: { text: "Do you want to add a reference number?",
+                            classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-4",
+                            isPageHeading: true
+                          } },
+        hint: { html: hint_html},
+        items: [{ text: "Yes",
+                  value: true,
+                  checked: @has_reference_number == "Yes",
+                  id: "has_complainant_reference",
+                  conditional: { html: existing_reference_field_html } },
+                { text: "No",
+                  value: false }]
+      ) %>
+
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
-  <% end %>
-
-  <%= govukRadios(
-    form: form,
-    error_message: has_complainant_reference_error_message,
-    key: :has_complainant_reference,
-    fieldset: { legend: { text: "Do you want to add a reference number?",
-                         classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-4",
-                         isPageHeading: true
-                       } },
-    hint: { html: hint_html},
-    items: [{ text: "Yes",
-              value: true,
-              checked: @has_reference_number == "Yes",
-              id: "has_complainant_reference",
-              conditional: { html: existing_reference_field_html } },
-            { text: "No",
-              value: false }]
-  ) %>
-
-  <%= form.submit "Continue", class: "govuk-button" %>
-<% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
     resource :risk_level, only: %i[update show], path: "edit-risk-level", controller: "investigations/risk_level"
     resource :risk_validations, only: %i[edit update], path: "validate-risk-level", controller: "investigations/risk_validations"
     resource :reference_numbers, only: %i[edit update], controller: "investigations/reference_numbers"
+    resource :case_names, only: %i[edit update], controller: "investigations/case_names"
     resource :safety_and_compliance, only: %i[edit update], path: "edit-safety-and-compliance", controller: "investigations/safety_and_compliance"
     resource :reported_reason, only: %i[edit update], path: "edit-reported-reason", controller: "investigations/reported_reason"
     resources :images, controller: "investigations/images", only: %i[index], path: "images"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
     resource :notifying_country, only: %i[update edit], path: "edit-notifying-country", controller: "investigations/notifying_country"
     resource :risk_level, only: %i[update show], path: "edit-risk-level", controller: "investigations/risk_level"
     resource :risk_validations, only: %i[edit update], path: "validate-risk-level", controller: "investigations/risk_validations"
+    resource :reference_numbers, only: %i[edit update], controller: "investigations/reference_numbers"
     resource :safety_and_compliance, only: %i[edit update], path: "edit-safety-and-compliance", controller: "investigations/safety_and_compliance"
     resource :reported_reason, only: %i[edit update], path: "edit-reported-reason", controller: "investigations/reported_reason"
     resources :images, controller: "investigations/images", only: %i[index], path: "images"

--- a/spec/features/edit_investigation_case_name_spec.rb
+++ b/spec/features/edit_investigation_case_name_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Edit an investigation's case name", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:original_case_name) { 'the original case name' }
+  let(:new_case_name) { 'new name' }
+  let(:taken_case_name) { 'case name that has already been taken' }
+  let(:investigation) { create(:allegation, user_title: original_case_name, creator: user) }
+  let!(:other_investigation) { create(:allegation, user_title: taken_case_name, creator: user) }
+
+  it 'allows user to edit reference number' do
+    sign_in(user)
+    visit "/cases/#{investigation.pretty_id}"
+
+    click_link "Edit case name"
+
+    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}/case_names/edit"
+    expect(page).to have_css("h1", text: "Edit the case name")
+
+    expect(page).to have_field("user_title", with: original_case_name)
+
+    fill_in :user_title, with: ''
+
+    click_button "Save"
+
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Enter a case name"
+
+    fill_in :user_title, with: taken_case_name
+
+    click_button "Save"
+
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "The case name has already been used in an open case by your team"
+
+    fill_in :user_title, with: new_case_name
+
+    click_button "Save"
+
+    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}"
+    expect(page).to have_content "Case name was successfully updated"
+
+    expect(page.find("dt", text: "Case name")).to have_sibling("dd", text: new_case_name)
+  end
+end

--- a/spec/features/edit_investigation_case_name_spec.rb
+++ b/spec/features/edit_investigation_case_name_spec.rb
@@ -2,24 +2,27 @@ require "rails_helper"
 
 RSpec.feature "Edit an investigation's case name", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
-  let(:original_case_name) { 'the original case name' }
-  let(:new_case_name) { 'new name' }
-  let(:taken_case_name) { 'case name that has already been taken' }
+  let(:original_case_name) { "the original case name" }
+  let(:new_case_name) { "new name" }
+  let(:taken_case_name) { "case name that has already been taken" }
   let(:investigation) { create(:allegation, user_title: original_case_name, creator: user) }
-  let!(:other_investigation) { create(:allegation, user_title: taken_case_name, creator: user) }
 
-  it 'allows user to edit reference number' do
+  before do
+    create(:allegation, user_title: taken_case_name, creator: user)
+  end
+
+  it "allows user to edit reference number" do
     sign_in(user)
     visit "/cases/#{investigation.pretty_id}"
 
     click_link "Edit case name"
 
-    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}/case_names/edit"
+    expect(page).to have_current_path "/cases/#{investigation.pretty_id}/case_names/edit", ignore_query: true
     expect(page).to have_css("h1", text: "Edit the case name")
 
     expect(page).to have_field("user_title", with: original_case_name)
 
-    fill_in :user_title, with: ''
+    fill_in :user_title, with: ""
 
     click_button "Save"
 
@@ -37,7 +40,7 @@ RSpec.feature "Edit an investigation's case name", :with_stubbed_opensearch, :wi
 
     click_button "Save"
 
-    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}"
+    expect(page).to have_current_path "/cases/#{investigation.pretty_id}", ignore_query: true
     expect(page).to have_content "Case name was successfully updated"
 
     expect(page.find("dt", text: "Case name")).to have_sibling("dd", text: new_case_name)

--- a/spec/features/edit_investigation_reference_number_spec.rb
+++ b/spec/features/edit_investigation_reference_number_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Edit an investigation's reference number", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:original_reference_number) { '123' }
+  let(:new_reference_number) { '999' }
+  let(:investigation) { create(:allegation, complainant_reference: original_reference_number, creator: user) }
+
+  it 'allows user to edit reference number' do
+    sign_in(user)
+    visit "/cases/#{investigation.pretty_id}"
+
+    click_link "Edit reference number"
+
+    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}/reference_numbers/edit"
+    expect(page).to have_css("h1", text: "Edit the reference number")
+
+    expect(page).to have_field("complainant_reference", with: original_reference_number)
+
+    fill_in :complainant_reference, with: new_reference_number
+
+    click_button "Save"
+
+    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}"
+    expect(page).to have_content "Reference number was successfully updated"
+
+    expect(page.find("dt", text: "Trading Standards reference")).to have_sibling("dd", text: new_reference_number)
+  end
+end

--- a/spec/features/edit_investigation_reference_number_spec.rb
+++ b/spec/features/edit_investigation_reference_number_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.feature "Edit an investigation's reference number", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
-  let(:original_reference_number) { '123' }
-  let(:new_reference_number) { '999' }
+  let(:original_reference_number) { "123" }
+  let(:new_reference_number) { "999" }
   let(:investigation) { create(:allegation, complainant_reference: original_reference_number, creator: user) }
 
-  it 'allows user to edit reference number' do
+  it "allows user to edit reference number" do
     sign_in(user)
     visit "/cases/#{investigation.pretty_id}"
 
     click_link "Edit reference number"
 
-    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}/reference_numbers/edit"
+    expect(page).to have_current_path "/cases/#{investigation.pretty_id}/reference_numbers/edit", ignore_query: true
     expect(page).to have_css("h1", text: "Edit the reference number")
 
     expect(page).to have_field("complainant_reference", with: original_reference_number)
@@ -21,7 +21,7 @@ RSpec.feature "Edit an investigation's reference number", :with_stubbed_opensear
 
     click_button "Save"
 
-    expect(page.current_path).to eq "/cases/#{investigation.pretty_id}"
+    expect(page).to have_current_path "/cases/#{investigation.pretty_id}", ignore_query: true
     expect(page).to have_content "Reference number was successfully updated"
 
     expect(page.find("dt", text: "Trading Standards reference")).to have_sibling("dd", text: new_reference_number)


### PR DESCRIPTION
https://trello.com/c/epZ5N9G9/1496-edit-links-for-case-specific-information-entered-on-the-new-create-a-case-journey

## Description
This change allows users to edit the case name and reference number for a previously created case.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
