### PR TITLE
Updates to the "Create a product" page

### DIFF
--- a/app/assets/stylesheets/opss/_opss-psd.scss
+++ b/app/assets/stylesheets/opss/_opss-psd.scss
@@ -240,6 +240,8 @@ ul.opss-radio-list {
         margin-left: govuk-spacing(1);
         &:last-child {
             margin-bottom: 0;
+
+            /*&.opss-tag--risk4 {position: relative; right: 33%; }*/
         }
             @include govuk-media-query($from: desktop) {
             &:nth-of-type(n+11) {
@@ -260,6 +262,20 @@ ul.opss-radio-list {
         border-color: govuk-colour("black");
         background-color: govuk-colour("black");
         color: govuk-colour("white");
+    }
+    &.opss-tag--risk4 {
+        /*border-radius: govuk-spacing(2); border-width: 0.5px; border-color: govuk-colour("red"); padding-left: govuk-spacing(2); padding-right: govuk-spacing(2);*/
+
+        border-width: 0;
+        margin-top: 0.2rem;
+        float: left;
+
+        background-color: govuk-colour("white");
+        color: govuk-colour("red");
+        text-transform: none;
+
+        /* &::before {content: '*** '; vertical-align: middle; }
+        &::after {content: ' ***'; vertical-align: middle; } */
     }
     &.opss-tag--plain {
         @include opss-font-size($s: 14px, $l: 1.3);

--- a/app/assets/stylesheets/opss/_opss-psd.scss
+++ b/app/assets/stylesheets/opss/_opss-psd.scss
@@ -264,7 +264,6 @@ ul.opss-radio-list {
         color: govuk-colour("white");
     }
     &.opss-tag--risk4 {
-        /*border-radius: govuk-spacing(2); border-width: 0.5px; border-color: govuk-colour("red"); padding-left: govuk-spacing(2); padding-right: govuk-spacing(2);*/
 
         border-width: 0;
         margin-top: 0.2rem;

--- a/app/assets/stylesheets/opss/_opss-psd.scss
+++ b/app/assets/stylesheets/opss/_opss-psd.scss
@@ -273,8 +273,6 @@ ul.opss-radio-list {
         color: govuk-colour("red");
         text-transform: none;
 
-        /* &::before {content: '*** '; vertical-align: middle; }
-        &::after {content: ' ***'; vertical-align: middle; } */
     }
     &.opss-tag--plain {
         @include opss-font-size($s: 14px, $l: 1.3);

--- a/app/assets/stylesheets/opss/_opss-search.scss
+++ b/app/assets/stylesheets/opss/_opss-search.scss
@@ -29,3 +29,15 @@ $opss-search-icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGkAAABGCAMAAA
         z-index: 1;
     }
 }
+
+.govuk-label--s + .govuk-hint[class*="font-size-16"][class*="display-inline-block"] {
+        line-height: 1.1 !important;
+
+        &:before {
+            content: ' - '
+        }
+}
+.govuk-fieldset__legend--s + .govuk-hint[class*="font-size-16"][class*="display-inline-block"] {
+    position: relative;
+    top: -1px;
+}

--- a/app/assets/stylesheets/opss/_opss-shared.scss
+++ b/app/assets/stylesheets/opss/_opss-shared.scss
@@ -297,6 +297,9 @@ samp {
 .opss-text-align-center {
     text-align: center;
 }
+*[class^="govuk-heading"].opss-text-align-center {
+    width: 100%;
+}
 
 @include govuk-media-query($from: tablet) {
     .opss-max-width-two-thirds {
@@ -535,7 +538,12 @@ ul.opss-left-nav {
     .opss-border-all {border-width: 1px; }
     /*.opss-border-all--padding-sm {padding: govuk-spacing(1); }
     a.opss-border-all--padding-sm {padding: 7px 13px 8px 11px; }*/
+
+    a[class*="font-size-14"].opss-border-all {
+        line-height: 1.2 !important;
+    }
 }
+
 .opss-details--sm {
     @include govuk-media-query($from: desktop) {
         summary {
@@ -745,26 +753,36 @@ dl.opss-summary-list-aside {
         }
     }
 
-    &.opss-summary-list-mixed--image > div:first-child dt {
-        vertical-align: bottom;
+    &.opss-summary-list-mixed--image {
+        margin-bottom: govuk-spacing(8);
+        border-bottom: 1px solid $govuk-input-border-colour;
 
-        & + dd {
-            padding-right: govuk-spacing(0);
+        .opss-tabs li:last-child & {
+            margin-bottom: govuk-spacing(0);
+            border-bottom: none 0;
+        }
 
-            figure {
-                img {
-                    max-width: 100%;
-                }
+        & > div:first-child dt {
+            vertical-align: bottom;
 
-                a {
-                    display: block;
-                    margin-top: - govuk-spacing(5);
-                    margin-bottom: govuk-spacing(1);
+            & + dd {
+                padding-right: govuk-spacing(0);
 
+                figure {
                     img {
-                        margin-top: -2px;
-                        margin-bottom: -2px;
-                        border: 0;
+                        max-width: 100%;
+                    }
+
+                    a {
+                        display: block;
+                        margin-top: - govuk-spacing(5);
+                        margin-bottom: govuk-spacing(1);
+
+                        img {
+                            margin-top: -2px;
+                            margin-bottom: -2px;
+                            border: 0;
+                        }
                     }
                 }
             }

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -39,23 +39,7 @@ class ProductForm
   validate :markings_validity, if: -> { has_markings == "markings_yes" }
 
   def self.from(product)
-    new(product.serializable_hash(except: %i[owning_team_id updated_at])).tap do |product_form|
-      if product.affected_units_status == Product.affected_units_statuses["approx"]
-        product_form.approx_units = product.number_of_affected_units
-      elsif product.affected_units_status == Product.affected_units_statuses["exact"]
-        product_form.exact_units = product.number_of_affected_units
-      end
-    end
-  end
-
-  def number_of_affected_units
-    return if affected_units_status.blank?
-
-    if affected_units_status.inquiry.exact?
-      exact_units
-    elsif affected_units_status.inquiry.approx?
-      approx_units
-    end
+    new(product.serializable_hash(except: %i[affected_units_status batch_number customs_code number_of_affected_units owning_team_id updated_at]))
   end
 
   def authenticity_not_provided?

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -7,7 +7,6 @@ class ProductForm
 
   attribute :id
   attribute :authenticity
-  attribute :batch_number
   attribute :brand
   attribute :category
   attribute :country_of_origin
@@ -18,13 +17,8 @@ class ProductForm
   attribute :subcategory
   attribute :webpage
   attribute :created_at, :datetime
-  attribute :affected_units_status
-  attribute :number_of_affected_units
   attribute :has_markings
   attribute :markings
-  attribute :customs_code
-
-  attr_accessor :approx_units, :exact_units
 
   attribute :when_placed_on_market
 
@@ -38,9 +32,6 @@ class ProductForm
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :name, presence: true
-  validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
-  validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
-  validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
   validates :when_placed_on_market, presence: true
   validates :description, length: { maximum: 10_000 }
 

--- a/app/helpers/opss_aside_helper.rb
+++ b/app/helpers/opss_aside_helper.rb
@@ -1,0 +1,8 @@
+module OpssAsideHelper
+  def opss_aside(title:, text:, classes: nil)
+    tag.aside(safe_join([
+      tag.h3(title, class: "govuk-heading-s govuk-!-margin-bottom-1 opss-secondary-text"),
+      tag.p(text, class: "govuk-body-s govuk-!-margin-0 opss-secondary-text")
+    ]), class: class_names("govuk-!-padding-3 opss-border-all opss-rounded-corners opss-drop-shadow", classes))
+  end
+end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -6,7 +6,7 @@ module ProductsHelper
   # Never trust parameters from the scary internet, only allow the white list through.
   def product_params
     params.require(:product).permit(
-      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :barcode, :authenticity, :when_placed_on_market, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units, :customs_code, :has_markings, markings: []
+      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :country_of_origin, :barcode, :authenticity, :when_placed_on_market, :has_markings, markings: []
     ).with_defaults(markings: [])
   end
 
@@ -54,27 +54,12 @@ module ProductsHelper
   def items_for_authenticity(product_form)
     items = [
       { text: "Yes",    value: "counterfeit" },
-      { text: "No",     value: "genuine" },
-      { text: "Unsure", value: "unsure" },
+      { text: "No",     value: "genuine" }
     ]
 
     return items if product_form.authenticity.blank?
 
     set_selected_authenticity_option(items, product_form)
-  end
-
-  def items_for_affected_units(product_form, form)
-    items = [
-      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:exact_units, label: "How many units?") } },
-      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:approx_units, label: "How many units?") } },
-      { text: "Unknown",                  value: "unknown" },
-      { divider: "or" },
-      { text: "Not relevant", value: "not_relevant" }
-    ]
-
-    return items if product_form.affected_units_status.blank?
-
-    set_affected_selected_units_status_option(items, product_form)
   end
 
   def items_for_before_2021_radio(product_form)
@@ -107,14 +92,6 @@ private
     end
   end
 
-  def set_affected_selected_units_status_option(items, product_form)
-    items.each do |item|
-      next if skip_selected_item_for_selected_option?(item, product_form)
-
-      item[:selected] = true if affected_units_status_selected?(item, product_form)
-    end
-  end
-
   def set_selected_when_placed_on_market_option(items, product_form)
     items.each do |item|
       next if skip_selected_item_for_selected_option?(item, product_form)
@@ -125,10 +102,6 @@ private
 
   def authenticity_selected?(item, product_form)
     item[:value] == product_form.authenticity
-  end
-
-  def affected_units_status_selected?(item, product_form)
-    item[:value] == product_form.affected_units_status
   end
 
   def when_placed_on_market_option_selected?(item, product_form)

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -18,10 +18,6 @@ class AddProductToCase
            :category,
            :user,
            :product,
-           :affected_units_status,
-           :number_of_affected_units,
-           :exact_units,
-           :approx_units,
            :when_placed_on_market,
            :customs_code,
            to: :context

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -5,7 +5,6 @@ class AddProductToCase
   delegate :authenticity,
            :has_markings,
            :markings,
-           :batch_number,
            :brand,
            :country_of_origin,
            :description,
@@ -19,7 +18,6 @@ class AddProductToCase
            :user,
            :product,
            :when_placed_on_market,
-           :customs_code,
            to: :context
 
   def call
@@ -32,7 +30,6 @@ class AddProductToCase
         authenticity:,
         has_markings:,
         markings:,
-        batch_number:,
         brand:,
         country_of_origin:,
         description:,
@@ -43,10 +40,7 @@ class AddProductToCase
         category:,
         webpage:,
         source: build_user_source,
-        affected_units_status:,
-        number_of_affected_units:,
         when_placed_on_market:,
-        customs_code:,
         owning_team: investigation.owner_team
       )
 

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -12,9 +12,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings affected_units_status number_of_affected_units name when_placed_on_market barcode]) %>
-      <%= render "investigation_heading", investigation: @investigation %>
 
-      <h2 class="govuk-heading-m">Add product</h2>
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Create a product record</h2>
+      <p class="govuk-body govuk-!-margin-bottom-7 opss-secondary-text">If a record of a product does not already exist in the Product Safety Database (<abbr>PSD</abbr>), you can create a product record for the product. This will also generate a new <abbr>PSD</abbr> product record reference number.</p>
 
       <%= render "products/form", form: form, product_form: @product_form, countries: @countries, search: true %>
     </div>

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -1,7 +1,7 @@
 <%= page_title "Add product to case", errors: @product_form.errors.any? %>
 <% content_for :back_link do %>
   <%= govukBackLink(
-    text: "Back to #{@investigation.pretty_description.downcase}",
+    text: "Back",
     href: investigation_products_path(@investigation)
   ) %>
 <% end %>

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings affected_units_status number_of_affected_units name when_placed_on_market barcode]) %>
 
-      <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Create a product record</h2>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Create a product record</h1>
       <p class="govuk-body govuk-!-margin-bottom-7 opss-secondary-text">If a record of a product does not already exist in the Product Safety Database (<abbr>PSD</abbr>), you can create a product record for the product. This will also generate a new <abbr>PSD</abbr> product record reference number.</p>
 
       <%= render "products/form", form: form, product_form: @product_form, countries: @countries, search: true %>

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -1,4 +1,4 @@
-<%= page_title "Add product to case", errors: @product_form.errors.any? %>
+<%= page_title "Create a product record", errors: @product_form.errors.any? %>
 <% content_for :back_link do %>
   <%= govukBackLink(
     text: "Back",

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -6,17 +6,17 @@
   key: :category,
   form: form,
   show_all_values: true,
+  include_blank: true,
   id: "category",
   aria_describedby: "report-product-category-hint",
   label: { text: "Product category", classes: label_class },
-  hint: { text: "The product category will be permanent for this product record" }
+  hint: { text: "The product category will be permanent for this product record", classes: "govuk-!-font-size-16" }
 ) %>
 
 <%= govukInput(
   key: :subcategory,
   form: form,
   id: "subcategory",
-  classes: "app-!-max-width-one-half",
   label: { text: "Product subcategory", classes: label_class },
   hint: { text: "For example, ‘Face mask’ or ‘Washing machine’" }
 ) %>
@@ -48,7 +48,6 @@
 <%= govukInput(
   key: :brand,
   form: form,
-  classes: "app-!-max-width-one-half",
   label: { text: "Manufacturer's brand name", classes: label_class },
   hint: { html: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe }
 ) %>
@@ -56,7 +55,6 @@
 <%= govukInput(
   key: :name,
   form: form,
-  classes: "app-!-max-width-three-quarters",
   label: { text: "Product name", classes: label_class },
   id: "name",
   hint: { html: 'Include model name and model number, for example \'PlayStation 5\'<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The product name will be permanent for this product record</span>'.html_safe }
@@ -68,7 +66,6 @@
   key: :barcode,
   id: "barcode",
   form: form,
-  classes: "app-!-max-width-one-half",
   label: { text: "Barcode number (GTIN, EAN or UPC)", classes: label_class },
   hint: {text: "Normally 8, 12, or 13 digits"}
 ) %>
@@ -82,7 +79,6 @@
 <%= govukTextarea(
   key: :product_code,
   form: form,
-  classes: "app-!-max-width-one-half",
   label: { text: "Other product identifiers", classes: label_class },
   hint: { text: "For example, serial number, Amazon ID (ASIN) or eBay ID. Use a comma to separate multiple identifiers, and a hyphen to indicate ranges." }
 ) %>
@@ -90,7 +86,6 @@
 <%= govukInput(
   key: :webpage,
   form: form,
-  classes: "app-!-max-width-three-quarters",
   label: { text: "Webpage", classes: label_class },
   hint: { text: "The manufacturer’s page for the product, or a link to where it can be bought" }
 ) %>
@@ -114,9 +109,8 @@
   key: :description,
   form: form,
   attributes: { maxlength: 10_000 },
-  classes: "app-!-max-width-three-quarters",
   label: { text: "Description of product", classes: label_class },
   hint: { text: "Details about the product you haven’t included above. For example, colour, size, packaging description. Do not include details of damage or incidents" }
 ) %>
 
-<%= form.submit local_assigns[:submit_text] || "Save product", class: "govuk-button" %>
+<%= form.submit local_assigns[:submit_text] || "Save", class: "govuk-button" %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -21,7 +21,7 @@
   hint: { text: "For example, ‘Face mask’ or ‘Washing machine’" }
 ) %>
 
-<%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", hint: { text: "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required" }, items: items_for_authenticity(product_form) %>
+<%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", hint: { text: "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", classes: "govuk-!-font-size-16" }, items: items_for_authenticity(product_form) %>
 
 <% product_marking_fields = capture do %>
   <%= form.govuk_checkboxes :markings,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -9,7 +9,7 @@
   id: "category",
   aria_describedby: "report-product-category-hint",
   label: { text: "Product category", classes: label_class },
-  hint: { text: "COVID-19 categories added: ‘PPE’ and ‘Hand sanitiser’" }
+  hint: { text: "The product category will be permanent for this product record" }
 ) %>
 
 <%= govukInput(
@@ -21,7 +21,7 @@
   hint: { text: "For example, ‘Face mask’ or ‘Washing machine’" }
 ) %>
 
-<%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", items: items_for_authenticity(product_form) %>
+<%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", hint: { text: "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required" }, items: items_for_authenticity(product_form) %>
 
 <% product_marking_fields = capture do %>
   <%= form.govuk_checkboxes :markings,
@@ -44,14 +44,13 @@
     <%= opss_aside title: "Number of units affected?", text: "The number of units affected is case related data (and has now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
   </div>
 </div>
-<%= form.govuk_radios :affected_units_status, legend: "How many units are affected?", items: items_for_affected_units(product_form, form) %>
 
 <%= govukInput(
   key: :brand,
   form: form,
   classes: "app-!-max-width-one-half",
-  label: { text: "Product brand (if branded)", classes: label_class },
-  hint: { text: "For example, ‘Dyson’ or ‘Sony’" }
+  label: { text: "Manufacturer's brand name", classes: label_class },
+  hint: { html: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe }
 ) %>
 
 <%= govukInput(
@@ -60,7 +59,7 @@
   classes: "app-!-max-width-three-quarters",
   label: { text: "Product name", classes: label_class },
   id: "name",
-  hint: { text: "Include model name and model number, for example ‘PlayStation 5’" }
+  hint: { html: 'Include model name and model number, for example \'PlayStation 5\'<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The product name will be permanent for this product record</span>'.html_safe }
 ) %>
 
 <%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
@@ -79,12 +78,6 @@
     <%= opss_aside title: "Batch numbers", text: "Batch numbers are case related data (and have now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
   </div>
 </div>
-<%= govukInput(
-  key: :batch_number,
-  form: form,
-  classes: "app-!-max-width-one-half",
-  label: { text: "Batch number", classes: label_class }
-) %>
 
 <%= govukTextarea(
   key: :product_code,
@@ -105,10 +98,9 @@
 <%= govukSelect(
   form: form,
   key: :country_of_origin,
-  formGroup: { classes: "app-!-autocomplete--max-width-one-half" },
   items: options_for_country_of_origin(countries, product_form),
   include_blank: true,
-  id: "location-autocomplete",
+  id: "location",
   label: { text: "Country of origin", classes: label_class },
   hint: { text: "Where the product was manufactured" }
 ) %>
@@ -118,13 +110,6 @@
     <%= opss_aside title: "Customs codes", text: "Customs codes are case related data (and have now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
   </div>
 </div>
-<%= govukInput(
-  key: :customs_code,
-  form: form,
-  classes: "app-!-max-width-three-quarters",
-  label: { text: "Customs code", classes: label_class },
-  hint: { text: "For example, CN code (8 digits) or TARIC code (10 digits). Use a comma to separate multiple codes" }
-) %>
 
 <%= govukTextarea(
   key: :description,
@@ -132,7 +117,7 @@
   attributes: { maxlength: 10_000 },
   classes: "app-!-max-width-three-quarters",
   label: { text: "Description of product", classes: label_class },
-  hint: { text: "Details about the product you haven’t included above. For example, colour, size, packaging description. You don’t need to include details of damage or incidents" }
+  hint: { text: "Details about the product you haven’t included above. For example, colour, size, packaging description. Do not include details of damage or incidents" }
 ) %>
 
 <%= form.submit local_assigns[:submit_text] || "Save product", class: "govuk-button" %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -8,7 +8,6 @@
   show_all_values: true,
   id: "category",
   aria_describedby: "report-product-category-hint",
-  is_autocomplete: true,
   label: { text: "Product category", classes: label_class },
   hint: { text: "COVID-19 categories added: ‘PPE’ and ‘Hand sanitiser’" }
 ) %>
@@ -40,7 +39,11 @@
   ]
 %>
 
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= opss_aside title: "Number of units affected?", text: "The number of units affected is case related data (and has now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
+  </div>
+</div>
 <%= form.govuk_radios :affected_units_status, legend: "How many units are affected?", items: items_for_affected_units(product_form, form) %>
 
 <%= govukInput(
@@ -50,7 +53,6 @@
   label: { text: "Product brand (if branded)", classes: label_class },
   hint: { text: "For example, ‘Dyson’ or ‘Sony’" }
 ) %>
-
 
 <%= govukInput(
   key: :name,
@@ -72,7 +74,11 @@
   hint: {text: "Normally 8, 12, or 13 digits"}
 ) %>
 
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= opss_aside title: "Batch numbers", text: "Batch numbers are case related data (and have now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
+  </div>
+</div>
 <%= govukInput(
   key: :batch_number,
   form: form,
@@ -107,6 +113,11 @@
   hint: { text: "Where the product was manufactured" }
 ) %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= opss_aside title: "Customs codes", text: "Customs codes are case related data (and have now moved to the case page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
+  </div>
+</div>
 <%= govukInput(
   key: :customs_code,
   form: form,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -100,7 +100,6 @@
   key: :country_of_origin,
   items: options_for_country_of_origin(countries, product_form),
   include_blank: true,
-  id: "location",
   label: { text: "Country of origin", classes: label_class },
   hint: { text: "Where the product was manufactured" }
 ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -457,12 +457,6 @@ en:
               too_short: "The barcode must be between 5 and 15 digits"
               only_integer: "Enter a valid barcode number"
               not_a_number: "Enter a valid barcode number"
-            affected_units_status:
-              inclusion: "You must state how many units are affected"
-            approx_units:
-              not_a_number: "Give the number of units affected"
-            exact_units:
-              not_a_number: "Give the number of units affected"
             has_markings:
               inclusion: "Select yes if the product has UKCA, UKNI or CE marking"
             markings:

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     category { Rails.application.config.product_constants["product_category"].sample }
     subcategory { "subcategory" }
     barcode { "9781529034523" }
-    authenticity { Product.authenticities.keys.sample }
+    authenticity { [Product.authenticities.keys - "unsure"].sample }
     brand { Faker::Company.name }
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     category { Rails.application.config.product_constants["product_category"].sample }
     subcategory { "subcategory" }
     barcode { "9781529034523" }
-    authenticity { [Product.authenticities.keys - "unsure"].sample }
+    authenticity { Product.authenticities.keys.without("unsure").sample }
     brand { Faker::Company.name }
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -6,9 +6,7 @@ FactoryBot.define do
     subcategory { "subcategory" }
     barcode { "9781529034523" }
     authenticity { Product.authenticities.keys.sample }
-    batch_number { "123123123" }
     brand { Faker::Company.name }
-    affected_units_status { "unknown" }
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }
     when_placed_on_market { "before_2021" }
@@ -21,7 +19,6 @@ FactoryBot.define do
       category { "Communication and media equipment" }
       description { "iphone description" }
       country_of_origin { "United States" }
-      batch_number { "1234" }
     end
 
     factory :product_iphone_3g do

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
   let(:user)          { create(:user, :activated) }
   let(:investigation) { create(:enquiry, creator: user) }
   let(:attributes)    do
-    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing").sample)
+    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
   end
   let(:other_user) { create(:user, :activated) }
 
@@ -18,7 +18,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
 
     fill_in "Barcode number (GTIN, EAN or UPC)", with: "invalid"
 
-    click_button "Save product"
+    click_button "Save"
 
     # Expected validation errors
     expect(page).to have_error_messages
@@ -27,10 +27,9 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     expect(errors_list[1].text).to eq "Subcategory cannot be blank"
     expect(errors_list[2].text).to eq "You must state whether the product is a counterfeit"
     expect(errors_list[3].text).to eq "Select yes if the product has UKCA, UKNI or CE marking"
-    expect(errors_list[4].text).to eq "You must state how many units are affected"
-    expect(errors_list[5].text).to eq "Name cannot be blank"
-    expect(errors_list[6].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
-    expect(errors_list[7].text).to eq "Enter a valid barcode number"
+    expect(errors_list[4].text).to eq "Name cannot be blank"
+    expect(errors_list[5].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
+    expect(errors_list[6].text).to eq "Enter a valid barcode number"
 
     select attributes[:category], from: "Product category"
 
@@ -61,7 +60,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
 
     fill_in "Description of product", with: attributes[:description]
 
-    click_on "Save product"
+    click_on "Save"
 
     expect_to_be_on_investigation_products_page(case_id: investigation.pretty_id)
     expect(page).not_to have_error_messages
@@ -72,7 +71,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
                         when "markings_unknown" then "Unknown"
                         end
 
-    expect(page).to have_summary_item(key: "Manufacturer's brand name", value: attributes[:brand])
+    expect(page).to have_summary_item(key: "Product brand",             value: attributes[:brand])
     expect(page).to have_summary_item(key: "Product name",              value: attributes[:name])
     expect(page).to have_summary_item(key: "Category",                  value: attributes[:category])
     expect(page).to have_summary_item(key: "Product subcategory",       value: attributes[:subcategory])

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -4,9 +4,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
   let(:user)          { create(:user, :activated) }
   let(:investigation) { create(:enquiry, creator: user) }
   let(:attributes)    do
-    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing").sample,
-                                    affected_units_status: Product.affected_units_statuses.keys.sample,
-                                    customs_code: "12345678, abc123, xyz987")
+    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing").sample)
   end
   let(:other_user) { create(:user, :activated) }
 
@@ -37,13 +35,11 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     select attributes[:category], from: "Product category"
 
     fill_in "Product subcategory",               with: attributes[:subcategory]
-    fill_in "Product brand",                     with: attributes[:brand]
+    fill_in "Manufacturer's brand name",         with: attributes[:brand]
     fill_in "Product name",                      with: attributes[:name]
     fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
     fill_in "Other product identifiers",         with: attributes[:product_code]
-    fill_in "Batch number",                      with: attributes[:batch_number]
     fill_in "Webpage",                           with: attributes[:webpage]
-    fill_in "Customs code",                      with: attributes[:customs_code]
 
     within_fieldset("Was the product placed on the market before 1 January 2021?") do
       choose when_placed_on_market_answer(attributes[:when_placed_on_market])
@@ -61,12 +57,6 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
       attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
     end
 
-    within_fieldset("How many units are affected?") do
-      choose affected_units_status_answer(attributes[:affected_units_status])
-      find("#exact_units").set(10) if attributes[:affected_units_status] == "exact"
-      find("#approx_units").set(10) if attributes[:affected_units_status] == "approx"
-    end
-
     select attributes[:country_of_origin], from: "Country of origin"
 
     fill_in "Description of product", with: attributes[:description]
@@ -82,7 +72,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
                         when "markings_unknown" then "Unknown"
                         end
 
-    expect(page).to have_summary_item(key: "Product brand",             value: attributes[:brand])
+    expect(page).to have_summary_item(key: "Manufacturer's brand name", value: attributes[:brand])
     expect(page).to have_summary_item(key: "Product name",              value: attributes[:name])
     expect(page).to have_summary_item(key: "Category",                  value: attributes[:category])
     expect(page).to have_summary_item(key: "Product subcategory",       value: attributes[:subcategory])
@@ -90,12 +80,10 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
     expect(page).to have_summary_item(key: "Barcode number",            value: attributes[:gin13])
     expect(page).to have_summary_item(key: "Other product identifiers", value: attributes[:product_code])
-    expect(page).to have_summary_item(key: "Batch number",              value: attributes[:batch_number])
     expect(page).to have_summary_item(key: "Webpage",                   value: attributes[:webpage])
     expect(page).to have_summary_item(key: "Country of origin",         value: attributes[:country])
     expect(page).to have_summary_item(key: "Description",               value: attributes[:description])
     expect(page).to have_summary_item(key: "When placed on market",     value: I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key))
-    expect(page).to have_summary_item(key: "Customs code",              value: attributes[:customs_code])
   end
 
   scenario "Not being able to add a product to another team’s case" do

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
   let(:new_product_category)  { (Rails.application.config.product_constants["product_category"] - [product.category]).sample }
   let(:new_subcategory) { Faker::Hipster.word }
   let(:new_barcode)           { Faker::Barcode.ean(13) }
-  let(:new_authenticity)      { (Product.authenticities.keys - [product.authenticity]).sample }
+  let(:new_authenticity)      { Product.authenticities.keys.without(product.authenticity, "unsure").sample }
   let(:new_has_markings)      { Product.has_markings.keys.sample }
   let(:new_markings)          { [Product::MARKINGS.sample] }
   let(:new_product_code)      { Faker::Barcode.issn }
@@ -66,7 +66,6 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       within_fieldset "Is the product counterfeit?" do
         expect(page).not_to have_checked_field("Yes")
         expect(page).not_to have_checked_field("No")
-        expect(page).not_to have_checked_field("Unsure")
       end
 
       within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
@@ -85,7 +84,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       expect(page).to have_select("Country of origin",        selected: "France")
       expect(page).to have_field("Description of product",    with: product.description)
 
-      click_on "Save product"
+      click_on "Save"
 
       expect(page).to have_error_messages
       expect(page).to have_error_summary "You must state whether the product is a counterfeit"
@@ -118,7 +117,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       select new_country_of_origin,       from: "Country of origin"
       fill_in "Description of product",   with: new_description
 
-      click_on "Save product"
+      click_on "Save"
 
       expect_to_be_on_product_page(product_id: product.id, product_name: new_name)
 
@@ -132,7 +131,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       expect(page).to have_summary_item(key: "Product subcategory",       value: new_subcategory)
       expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
       expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
-      expect(page).to have_summary_item(key: "Manufacturer's brand name", value: new_brand)
+      expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
       expect(page).to have_summary_item(key: "Product name",              value: new_name)
       expect(page).to have_summary_item(key: "Barcode number",            value: new_barcode)
       expect(page).to have_summary_item(key: "Other product identifiers", value: new_product_code)
@@ -197,7 +196,6 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       within_fieldset "Is the product counterfeit?" do
         expect(page).not_to have_checked_field("Yes")
         expect(page).not_to have_checked_field("No")
-        expect(page).not_to have_checked_field("Unsure")
       end
 
       within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
@@ -216,7 +214,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       expect(page).to have_select("Country of origin",        selected: "France")
       expect(page).to have_field("Description of product",    with: product.description)
 
-      click_on "Save product"
+      click_on "Save"
 
       expect(page).to have_error_messages
       expect(page).to have_error_summary "You must state whether the product is a counterfeit"
@@ -249,7 +247,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       select new_country_of_origin,        from: "Country of origin"
       fill_in "Description of product",    with: new_description
 
-      click_on "Save product"
+      click_on "Save"
 
       expect_to_be_on_product_page(product_id: product.id, product_name: new_name)
 
@@ -265,7 +263,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       expect(page).to have_summary_item(key: "Product subcategory", value: new_subcategory)
       expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
       expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
-      expect(page).to have_summary_item(key: "Manufacturer's brand name", value: new_brand)
+      expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
       expect(page).to have_summary_item(key: "Product name",              value: new_name)
       expect(page).to have_summary_item(key: "Barcode number",            value: new_barcode)
       expect(page).to have_summary_item(key: "Other product identifiers", value: new_product_code)

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -11,28 +11,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
   let(:product) do
     create(:product,
            authenticity: nil,
-           affected_units_status: "exact",
-           number_of_affected_units: 1000,
            brand:,
            product_code:,
            webpage:,
            country_of_origin:,
            has_markings: "markings_yes",
-           customs_code: "initial, customs, code123",
            investigations: [investigation],
            owning_team: user.team)
-  end
-  let(:product_with_no_affected_units_status) do
-    create(:product,
-           authenticity: nil,
-           affected_units_status: nil,
-           number_of_affected_units: nil,
-           brand:,
-           product_code:,
-           webpage:,
-           country_of_origin:,
-           has_markings: "markings_yes",
-           investigations: [investigation])
   end
 
   let(:new_name)              { Faker::Commerce.product_name }
@@ -44,14 +29,10 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
   let(:new_authenticity)      { (Product.authenticities.keys - [product.authenticity]).sample }
   let(:new_has_markings)      { Product.has_markings.keys.sample }
   let(:new_markings)          { [Product::MARKINGS.sample] }
-  let(:new_affected_units_status) { "approx" }
-  let(:new_number_of_affected_units) { "something like 23" }
-  let(:new_batch_number)      { Faker::Number.number(digits: 10) }
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }
   let(:new_country_of_origin) { "South Korea" }
   let(:new_when_placed_on_market) { (Product.when_placed_on_markets.keys - [product.when_placed_on_market]).sample }
-  let(:new_customs_code) { "12345678, abc, 987" }
 
   context "when the user is not in the team which owns the product" do
     before { sign_in other_user }
@@ -96,14 +77,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
         product.markings.each { |marking| expect(page).to have_checked_field(marking) }
       end
 
-      expect(page).to have_field("Product brand",            with: product.brand)
-      expect(page).to have_field("Product name",             with: product.name)
-      expect(page).to have_field("Barcode number",           with: product.barcode)
-      expect(page).to have_field("Batch number",             with: product.batch_number)
-      expect(page).to have_field("Other product identifier", with: product.product_code)
-      expect(page).to have_field("Webpage",                  with: product.webpage)
-      expect(page).to have_select("Country of origin",       selected: "France")
-      expect(page).to have_field("Description of product",   with: product.description)
+      expect(page).to have_field("Manufacturer's brand name", with: product.brand)
+      expect(page).to have_field("Product name",              with: product.name)
+      expect(page).to have_field("Barcode number",            with: product.barcode)
+      expect(page).to have_field("Other product identifier",  with: product.product_code)
+      expect(page).to have_field("Webpage",                   with: product.webpage)
+      expect(page).to have_select("Country of origin",        selected: "France")
+      expect(page).to have_field("Description of product",    with: product.description)
 
       click_on "Save product"
 
@@ -130,20 +110,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
         new_markings.each { |marking| check(marking) } if new_has_markings == "markings_yes"
       end
 
-      within_fieldset("How many units are affected?") do
-        choose affected_units_status_answer(new_affected_units_status)
-        find("#approx_units").set(new_number_of_affected_units)
-      end
-
-      fill_in "Product brand",            with: new_brand
+      fill_in "Manufacturer's brand name", with: new_brand
       fill_in "Product name",             with: new_name
       fill_in "Barcode number",           with: new_barcode
-      fill_in "Batch number",             with: new_batch_number
       fill_in "Other product identifier", with: new_product_code
       fill_in "Webpage",                  with: new_webpage
       select new_country_of_origin,       from: "Country of origin"
       fill_in "Description of product",   with: new_description
-      fill_in "Customs code",             with: new_customs_code
 
       click_on "Save product"
 
@@ -155,20 +128,17 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
                           when "markings_unknown" then "Unknown"
                           end
 
-      expect(page).to have_summary_item(key: "Category", value: new_product_category)
-      expect(page).to have_summary_item(key: "Product subcategory", value: new_subcategory)
+      expect(page).to have_summary_item(key: "Category",                  value: new_product_category)
+      expect(page).to have_summary_item(key: "Product subcategory",       value: new_subcategory)
       expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
       expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
-      expect(page).to have_summary_item(key: "Units affected",            value: "something like 23")
-      expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
+      expect(page).to have_summary_item(key: "Manufacturer's brand name", value: new_brand)
       expect(page).to have_summary_item(key: "Product name",              value: new_name)
       expect(page).to have_summary_item(key: "Barcode number",            value: new_barcode)
-      expect(page).to have_summary_item(key: "Batch number",              value: new_batch_number)
       expect(page).to have_summary_item(key: "Other product identifiers", value: new_product_code)
       expect(page).to have_summary_item(key: "Webpage",                   value: new_webpage)
       expect(page).to have_summary_item(key: "Country of origin",         value: new_country_of_origin)
       expect(page).to have_summary_item(key: "Description",               value: new_description)
-      expect(page).to have_summary_item(key: "Customs code",              value: new_customs_code)
 
       within("header") { click_on "Cases" }
 
@@ -180,104 +150,6 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       click_on "Apply"
 
       expect(page).to have_listed_case(investigation.pretty_id)
-    end
-
-    it "allows to edit a product without an affected_units_status" do
-      visit "/products/#{product_with_no_affected_units_status.id}"
-
-      expect(page).to have_summary_item(key: "Product authenticity", value: "Not provided")
-
-      visit "/products/#{product_with_no_affected_units_status.id}/edit"
-
-      expect(page).to have_select("Product category", selected: product_with_no_affected_units_status.category)
-      expect(page).to have_field("Product subcategory", with: product_with_no_affected_units_status.subcategory)
-
-      within_fieldset "Is the product counterfeit?" do
-        expect(page).not_to have_checked_field("Yes")
-        expect(page).not_to have_checked_field("No")
-        expect(page).not_to have_checked_field("Unsure")
-      end
-
-      within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
-        expect(page).to have_checked_field("Yes")
-      end
-
-      within_fieldset("Select product marking") do
-        product_with_no_affected_units_status.markings.each { |marking| expect(page).to have_checked_field(marking) }
-      end
-
-      expect(page).to have_field("Product brand",            with: product_with_no_affected_units_status.brand)
-      expect(page).to have_field("Product name",             with: product_with_no_affected_units_status.name)
-      expect(page).to have_field("Barcode number",           with: product_with_no_affected_units_status.barcode)
-      expect(page).to have_field("Batch number",             with: product_with_no_affected_units_status.batch_number)
-      expect(page).to have_field("Other product identifier", with: product_with_no_affected_units_status.product_code)
-      expect(page).to have_field("Webpage",                  with: product_with_no_affected_units_status.webpage)
-      expect(page).to have_select("Country of origin",       selected: "France")
-      expect(page).to have_field("Description of product",   with: product_with_no_affected_units_status.description)
-
-      click_on "Save product"
-
-      expect(page).to have_error_messages
-      expect(page).to have_error_summary "You must state whether the product is a counterfeit"
-
-      select new_product_category, from: "Product category"
-      fill_in "Product subcategory", with: new_subcategory
-
-      within_fieldset "Is the product counterfeit?" do
-        choose counterfeit_answer(new_authenticity)
-      end
-
-      within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
-        page.find("input[value='#{new_has_markings}']").choose
-      end
-
-      within_fieldset("Select product marking") do
-        all("input[type=checkbox]").each(&:uncheck)
-        new_markings.each { |marking| check(marking) } if new_has_markings == "markings_yes"
-      end
-
-      within_fieldset("How many units are affected?") do
-        choose affected_units_status_answer(new_affected_units_status)
-        find("#approx_units").set(new_number_of_affected_units)
-      end
-
-      within_fieldset("Was the product placed on the market before 1 January 2021?") do
-        choose when_placed_on_market_answer(new_when_placed_on_market)
-      end
-
-      fill_in "Product brand",            with: new_brand
-      fill_in "Product name",             with: new_name
-      fill_in "Barcode number",           with: new_barcode
-      fill_in "Batch number",             with: new_batch_number
-      fill_in "Other product identifier", with: new_product_code
-      fill_in "Webpage",                  with: new_webpage
-      select new_country_of_origin,       from: "Country of origin"
-      fill_in "Description of product",   with: new_description
-
-      click_on "Save product"
-
-      expect_to_be_on_product_page(product_id: product_with_no_affected_units_status.id, product_name: new_name)
-
-      expected_markings = case new_has_markings
-                          when "markings_yes" then new_markings.join(", ")
-                          when "markings_no" then "None"
-                          when "markings_unknown" then "Unknown"
-                          end
-
-      expect(page).to have_summary_item(key: "Category",                  value: new_product_category)
-      expect(page).to have_summary_item(key: "Product subcategory",       value: new_subcategory)
-      expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
-      expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
-      expect(page).to have_summary_item(key: "Units affected",            value: "something like 23")
-      expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
-      expect(page).to have_summary_item(key: "Product name",              value: new_name)
-      expect(page).to have_summary_item(key: "Barcode number",            value: new_barcode)
-      expect(page).to have_summary_item(key: "Batch number",              value: new_batch_number)
-      expect(page).to have_summary_item(key: "Other product identifiers", value: new_product_code)
-      expect(page).to have_summary_item(key: "Webpage",                   value: new_webpage)
-      expect(page).to have_summary_item(key: "Country of origin",         value: new_country_of_origin)
-      expect(page).to have_summary_item(key: "Description",               value: new_description)
-      expect(page).to have_summary_item(key: "When placed on market",     value: I18n.t(new_when_placed_on_market, scope: Product.model_name.i18n_key))
     end
 
     scenario "upload an document" do
@@ -336,14 +208,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
         product.markings.each { |marking| expect(page).to have_checked_field(marking) }
       end
 
-      expect(page).to have_field("Product brand",            with: product.brand)
-      expect(page).to have_field("Product name",             with: product.name)
-      expect(page).to have_field("Barcode number",           with: product.barcode)
-      expect(page).to have_field("Batch number",             with: product.batch_number)
-      expect(page).to have_field("Other product identifier", with: product.product_code)
-      expect(page).to have_field("Webpage",                  with: product.webpage)
-      expect(page).to have_select("Country of origin",       selected: "France")
-      expect(page).to have_field("Description of product",   with: product.description)
+      expect(page).to have_field("Manufacturer's brand name", with: product.brand)
+      expect(page).to have_field("Product name",              with: product.name)
+      expect(page).to have_field("Barcode number",            with: product.barcode)
+      expect(page).to have_field("Other product identifier",  with: product.product_code)
+      expect(page).to have_field("Webpage",                   with: product.webpage)
+      expect(page).to have_select("Country of origin",        selected: "France")
+      expect(page).to have_field("Description of product",    with: product.description)
 
       click_on "Save product"
 
@@ -370,20 +241,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
         new_markings.each { |marking| check(marking) } if new_has_markings == "markings_yes"
       end
 
-      within_fieldset("How many units are affected?") do
-        choose affected_units_status_answer(new_affected_units_status)
-        find("#approx_units").set(new_number_of_affected_units)
-      end
-
-      fill_in "Product brand",            with: new_brand
-      fill_in "Product name",             with: new_name
-      fill_in "Barcode number",           with: new_barcode
-      fill_in "Batch number",             with: new_batch_number
-      fill_in "Other product identifier", with: new_product_code
-      fill_in "Webpage",                  with: new_webpage
-      select new_country_of_origin,       from: "Country of origin"
-      fill_in "Description of product",   with: new_description
-      fill_in "Customs code",             with: new_customs_code
+      fill_in "Manufacturer's brand name", with: new_brand
+      fill_in "Product name",              with: new_name
+      fill_in "Barcode number",            with: new_barcode
+      fill_in "Other product identifier",  with: new_product_code
+      fill_in "Webpage",                   with: new_webpage
+      select new_country_of_origin,        from: "Country of origin"
+      fill_in "Description of product",    with: new_description
 
       click_on "Save product"
 
@@ -401,16 +265,13 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       expect(page).to have_summary_item(key: "Product subcategory", value: new_subcategory)
       expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
       expect(page).to have_summary_item(key: "Product marking",           value: expected_markings)
-      expect(page).to have_summary_item(key: "Units affected",            value: "something like 23")
-      expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
+      expect(page).to have_summary_item(key: "Manufacturer's brand name", value: new_brand)
       expect(page).to have_summary_item(key: "Product name",              value: new_name)
       expect(page).to have_summary_item(key: "Barcode number",            value: new_barcode)
-      expect(page).to have_summary_item(key: "Batch number",              value: new_batch_number)
       expect(page).to have_summary_item(key: "Other product identifiers", value: new_product_code)
       expect(page).to have_summary_item(key: "Webpage",                   value: new_webpage)
       expect(page).to have_summary_item(key: "Country of origin",         value: new_country_of_origin)
       expect(page).to have_summary_item(key: "Description",               value: new_description)
-      expect(page).to have_summary_item(key: "Customs code",              value: new_customs_code)
 
       within("header") { click_on "Cases" }
 

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -9,11 +9,8 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_op
            category: "Electrical appliances and equipment",
            subcategory: "washing machine",
            product_code: "MBWM01",
-           batch_number: "Batches 0001 to 0231",
            webpage: "http://example.com/mybrand/washing-machines",
-           description: "White with chrome buttons",
-           affected_units_status: "approx",
-           number_of_affected_units: 1)
+           description: "White with chrome buttons")
   end
 
   scenario "Updating a product" do
@@ -30,7 +27,6 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_op
     expect(page).to have_field("Product subcategory", with: "washing machine")
     expect(page).to have_field("Product name", with: "MyBrand washing machine")
     expect(page).to have_field("Other product identifiers", text: "MBWM01")
-    expect(page).to have_field("Batch number", with: "Batches 0001 to 0231")
     expect(page).to have_field("Webpage", with: "http://example.com/mybrand/washing-machines")
     expect(page).to have_field("Description of product", text: "White with chrome buttons")
 
@@ -38,15 +34,10 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_op
     fill_in "Product subcategory", with: "dishwasher"
     fill_in "Product name", with: "MyBrand dishwasher"
     fill_in "Other product identifiers", with: "MBDW01"
-    fill_in "Batch number", with: "Batches 0005 to 1023"
     fill_in "Webpage", with: "http://example.com/mybrand/dishwashers"
     fill_in "Description of product", with: "White with chrome handle"
-    within_fieldset("How many units are affected?") do
-      choose "Approximate number known"
-      find("#approx_units").set(2)
-    end
 
-    click_button "Save product"
+    click_button "Save"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: "MyBrand dishwasher")
 
@@ -57,9 +48,7 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_op
     expect(page).to have_summary_item(key: "Category", value: "Kitchen / cooking accessories")
     expect(page).to have_summary_item(key: "Product subcategory", value: "dishwasher")
     expect(page).to have_summary_item(key: "Other product identifiers", value: "MBDW01")
-    expect(page).to have_summary_item(key: "Batch number", value: "Batches 0005 to 1023")
     expect(page).to have_summary_item(key: "Webpage", value: "http://example.com/mybrand/dishwashers")
     expect(page).to have_summary_item(key: "Description", value: "White with chrome handle")
-    expect(page).to have_summary_item(key: "Units affected", value: "2")
   end
 end

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProductForm do
       end
 
       context "when an authenticity was given" do
-        let(:authenticity) { Product.authenticities.keys.sample }
+        let(:authenticity) { Product.authenticities.keys.sample.without("unsure") }
 
         it { is_expected.not_to be_authenticity_not_provided }
       end

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProductForm do
       end
 
       context "when an authenticity was given" do
-        let(:authenticity) { Product.authenticities.keys.sample.without("unsure") }
+        let(:authenticity) { Product.authenticities.keys.without("unsure").sample }
 
         it { is_expected.not_to be_authenticity_not_provided }
       end

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -158,7 +158,7 @@ module PageExpectations
 
   def expect_to_be_on_add_product_to_investigation_page(investigation)
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/products/new")
-    expect(page).to have_selector("h1", text: investigation.user_title)
+    expect(page).to have_selector("h1", text: "Create a product record")
   end
 
   def expect_to_be_on_case_products_page


### PR DESCRIPTION
https://trello.com/c/SKluPBiG/1512-create-a-product-updates-to-the-create-a-product-page-cap101

## Description

Updates the "Create a product" page (Case > Add product) with newer visual style, and adds hints for fields which have been moved to the Case level.