### PR TITLE
Move owned products to the new team when deleting a team

### DIFF
--- a/app/services/delete_team.rb
+++ b/app/services/delete_team.rb
@@ -13,6 +13,7 @@ class DeleteTeam
     ActiveRecord::Base.transaction do
       team.mark_as_deleted!
       team.users.update_all(team_id: new_team.id)
+      team.owned_products.update_all(owning_team_id: new_team.id)
       remove_team_as_owner_from_cases
       remove_team_as_collaborator_from_cases
     end

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -268,6 +268,21 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_opensearch do
           end
         end
       end
+
+      context "when the team owns products" do
+        let!(:owned_product_1) { create(:product, owning_team: team) }
+        let!(:owned_product_2) { create(:product, owning_team: team) }
+        let!(:unowned_product) { create(:product, owning_team: nil) }
+        let!(:other_team_product) { create(:product, owning_team: create(:team)) }
+
+        it "sets the new team to own the currently owned products", :aggregate_failures do
+          result
+          expect(owned_product_1.reload.owning_team).to eq(new_team)
+          expect(owned_product_2.reload.owning_team).to eq(new_team)
+          expect(unowned_product.reload.owning_team).to eq(nil)
+          expect(other_team_product.reload.owning_team).not_to eq(new_team)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/Cql6ces5/1547-deleting-a-team-and-the-product-record-ownership-rules

## Description

When a team is deleted, the new team which takes on their users and cases, now also takes on their products.