### PR TITLE
Case search pages changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "validate_email", "~> 0.1"
 gem "webpacker", "~> 5.4"
 gem "wicked", "~> 1.4"
 
-gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.3", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.4", require: "govuk_design_system"
 
 gem "bootsnap"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails
-  revision: edc63c004141ef5979a1ddd143381d49ad0b3a9e
-  tag: 0.9.3
+  revision: 9f34e5e5050f6fb1308c6289addcabf68102fc77
+  tag: 0.9.4
   specs:
-    govuk-design-system-rails (0.9.3)
+    govuk-design-system-rails (0.9.4)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -121,7 +121,7 @@ private
   end
 
   def default_params
-    [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access]].each do |param_value|
+    [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
       return false unless ["all", nil].include? param_value
     end
 

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -122,7 +122,7 @@ private
 
   def default_params
     [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
-      return false unless (param_value == "all" || param_value.blank?)
+      return false unless param_value == "all" || param_value.blank?
     end
 
     params["case_status"] == "all" && params[:q].blank?

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -122,7 +122,7 @@ private
 
   def default_params
     [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
-      return false unless ["all", nil].include? param_value
+      return false unless ["all", nil, ""].include? param_value
     end
 
     params["case_status"] == "all" && params[:q].blank?

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -122,7 +122,7 @@ private
 
   def default_params
     [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
-      return false if param_value == "all" || param_value.blank?
+      return false unless (param_value == "all" || param_value.blank?)
     end
 
     params["case_status"] == "all" && params[:q].blank?

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -122,7 +122,7 @@ private
 
   def default_params
     [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
-      return false unless ["all", nil, ""].include? param_value
+      return false if param_value == "all" || param_value.blank?
     end
 
     params["case_status"] == "all" && params[:q].blank?

--- a/app/helpers/investigation_search_helper.rb
+++ b/app/helpers/investigation_search_helper.rb
@@ -38,7 +38,8 @@ private
       get_status_filter,
       get_creator_filter(user),
       get_owner_filter(user),
-      get_serious_and_high_risk_filter
+      get_serious_and_high_risk_filter,
+      get_hazard_type_filter
     ].compact
 
     { must: filters_to_apply }
@@ -70,6 +71,12 @@ private
     end
 
     { terms: { type: types } }
+  end
+
+  def get_hazard_type_filter
+    return unless @search.hazard_type
+
+    { term: { hazard_type: @search.hazard_type } }
   end
 
   def get_owner_filter(user)

--- a/app/helpers/investigation_search_helper.rb
+++ b/app/helpers/investigation_search_helper.rb
@@ -74,7 +74,7 @@ private
   end
 
   def get_hazard_type_filter
-    return unless @search.hazard_type
+    return if @search.hazard_type.blank?
 
     { term: { hazard_type: @search.hazard_type } }
   end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -21,7 +21,8 @@ module InvestigationsHelper
       :teams_with_access_other_id,
       :created_by,
       :created_by_other_id,
-      :page_name
+      :page_name,
+      :hazard_type
     )
   end
 

--- a/app/models/concerns/investigation_opensearch.rb
+++ b/app/models/concerns/investigation_opensearch.rb
@@ -12,6 +12,7 @@ module InvestigationOpensearch
         indexes :type, type: :keyword
         indexes :owner_id, type: :keyword
         indexes :creator_id, type: :keyword
+        indexes :hazard_type, type: :keyword
         indexes :teams_with_access, type: :nested do
           indexes :id, type: :keyword
         end

--- a/app/views/investigations/_case_hazard_type_filter.html.erb
+++ b/app/views/investigations/_case_hazard_type_filter.html.erb
@@ -1,0 +1,9 @@
+<%= govukSelect(
+  key: "hazard_type",
+  form: form,
+  items: [{ text: "All", value: "", attributes: { class: "govuk-!-font-size-16" }}] + hazard_types.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
+  label: { text: "Hazard type" },
+  formGroup: { classes: "govuk-!-margin-right-1" },
+  is_autocomplete: false,
+  attributes: { "data-opss-clear-on-reset" => "element" }
+) %>

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -20,6 +20,7 @@
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>
       <%= render "investigations/case_type_radios", form: form %>
+      <%= render "investigations/case_hazard_type_filter", form: form %>
     <% end %>
 
     <div class="govuk-button-group">

--- a/app/views/investigations/_full_table_body.html.erb
+++ b/app/views/investigations/_full_table_body.html.erb
@@ -23,6 +23,9 @@
         <%= investigation.owner_display_name_for(viewer: current_user) %>
       </td>
     <% end %>
+    <td headers="haztype item-1 meta-1" class="govuk-table__cell">
+      <%= investigation.hazard_type %>
+    </td>
     <% if sorted_by == SortByHelper::SORT_BY_CREATED_AT %>
       <td headers="created <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
         <%= "#{time_ago_in_words(investigation.created_at)} ago" %>

--- a/app/views/investigations/_full_table_body.html.erb
+++ b/app/views/investigations/_full_table_body.html.erb
@@ -3,7 +3,7 @@
     <th class="govuk-visually-hidden">
       Case title
     </th>
-    <th id="<%= dom_id investigation, :item %>" colspan="3" scope="colgroup" class="govuk-table__header">
+    <th id="<%= dom_id investigation, :item %>" colspan="4" scope="colgroup" class="govuk-table__header">
       <%= link_to investigation.title, investigation_path(investigation), class: "govuk-link govuk-link--no-visited-state" %>
     </th>
   </tr>

--- a/app/views/investigations/_highlight_table_body.html.erb
+++ b/app/views/investigations/_highlight_table_body.html.erb
@@ -5,7 +5,7 @@
     <th class="govuk-visually-hidden">
       Case title
     </th>
-    <th id="<%= dom_id investigation, :item %>" colspan="3" scope="colgroup" class="govuk-table__header">
+    <th id="<%= dom_id investigation, :item %>" colspan="4" scope="colgroup" class="govuk-table__header">
       <%= link_to investigation.title, investigation_path(investigation), class: "govuk-link govuk-link--no-visited-state" %>
     </th>
   </tr>
@@ -35,7 +35,7 @@
       <th headers="<%= dom_id investigation, :item %>" id="<%= dom_id investigation, :keywords %>" class="govuk-visually-hidden">
         Matching keywords
       </th>
-      <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :keywords %>" colspan="3" class="govuk-table__cell">
+      <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :keywords %>" colspan="4" class="govuk-table__cell">
         <% displayable_highlights.each do |highlight| %>
           <span class="govuk-!-font-size-14"><%= highlight[:label] %>: <%= highlight[:content] %>. </span>
         <% end %>

--- a/app/views/investigations/_restricted_table_body.html.erb
+++ b/app/views/investigations/_restricted_table_body.html.erb
@@ -3,7 +3,7 @@
     <th class="govuk-visually-hidden">
       Case title
     </th>
-    <th id="<%= dom_id investigation, :item %>" colspan="3" scope="colgroup" class="govuk-table__header">
+    <th id="<%= dom_id investigation, :item %>" colspan="4" scope="colgroup" class="govuk-table__header">
       <%= "#{investigation.case_type.capitalize} restricted" %>
     </th>
   </tr>

--- a/app/views/investigations/_status_table_row.html.erb
+++ b/app/views/investigations/_status_table_row.html.erb
@@ -34,6 +34,10 @@
   </th>
   <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="4" class="govuk-table__cell">
     <%= tag.span investigation.case_type.upcase_first, class: class_names("opss-tag", "opss-tag--std", investigation.is_closed? && "opss-cross-through") %>
+    <% if investigation.products.count.zero? %>
+      <span class="govuk-visually-hidden"> | </span>
+      <span class="opss-tag opss-tag--risk4">This case has no product</span>
+    <% end %>
     <% badges.each do |badge| %>
       <span class="govuk-visually-hidden"> | </span>
       <%= badge %>

--- a/app/views/investigations/_status_table_row.html.erb
+++ b/app/views/investigations/_status_table_row.html.erb
@@ -32,7 +32,7 @@
   <th headers="<%= dom_id investigation, :item %>" id="<%= dom_id investigation, :status %>" class="govuk-visually-hidden">
     Type
   </th>
-  <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="3" class="govuk-table__cell">
+  <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="4" class="govuk-table__cell">
     <%= tag.span investigation.case_type.upcase_first, class: class_names("opss-tag", "opss-tag--std", investigation.is_closed? && "opss-cross-through") %>
     <% badges.each do |badge| %>
       <span class="govuk-visually-hidden"> | </span>

--- a/app/views/investigations/_status_table_row.html.erb
+++ b/app/views/investigations/_status_table_row.html.erb
@@ -34,7 +34,7 @@
   </th>
   <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="4" class="govuk-table__cell">
     <%= tag.span investigation.case_type.upcase_first, class: class_names("opss-tag", "opss-tag--std", investigation.is_closed? && "opss-cross-through") %>
-    <% if investigation.products.count.zero? %>
+    <% if investigation.products.count.zero? && ["team_cases", "your_cases"].include?(@page_name) %>
       <span class="govuk-visually-hidden"> | </span>
       <span class="opss-tag opss-tag--risk4">This case has no product</span>
     <% end %>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -36,7 +36,7 @@
                   <% else %>
                     <th id="caseowner" scope="col" class="govuk-table__header">Case owner</th>
                   <% end %>
-                  <th id="caseowner" scope="col" class="govuk-table__header">Hazard type</th>
+                  <th id="haztype" scope="col" class="govuk-table__header">Hazard type</th>
                   <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && ["team_cases", "your_cases"].exclude?(@page_name) %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
@@ -67,7 +67,7 @@
                 </tfoot>
               <% end %>
             </table>
-          
+
             <%= paginate @investigations.object %>
           </div>
         </div>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -25,7 +25,7 @@
           <div class="govuk-grid-column-full" role="region" aria-label="Cases">
             <table class="govuk-table opss-table-items opss-table-items--sm">
               <caption class="govuk-visually-hidden">
-                Cases data: 4 columns with each case described across rows within each table body.
+                Cases data: 5 columns with each case described across rows within each table body.
               </caption>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -36,6 +36,7 @@
                   <% else %>
                     <th id="caseowner" scope="col" class="govuk-table__header">Case owner</th>
                   <% end %>
+                  <th id="caseowner" scope="col" class="govuk-table__header">Hazard type</th>
                   <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && ["team_cases", "your_cases"].exclude?(@page_name) %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
@@ -56,6 +57,7 @@
                     <th class="govuk-visually-hidden">&nbsp;</th>
                     <th scope="col" class="govuk-table__header">Case number</th>
                     <th scope="col" class="govuk-table__header">Case <%= ["team_cases", "your_cases"].include?(@page_name) ? "created" : "owner" %></th>
+                    <th scope="col" class="govuk-table__header">Hazard type</th>
                     <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && ["team_cases", "your_cases"].exclude?(@page_name) %>
                       <th scope="col" class="govuk-table__header">Created</th>
                     <% else %>
@@ -65,7 +67,7 @@
                 </tfoot>
               <% end %>
             </table>
-
+          
             <%= paginate @investigations.object %>
           </div>
         </div>

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -43,7 +43,8 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
   context "when there are cases" do
     let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
-    let!(:user_case) { create(:allegation, creator: user) }
+    let!(:user_case) { create(:allegation, :with_products, creator: user) }
+    let!(:user_case_without_products) { create(:allegation, creator: user) }
     let!(:other_case) { create(:allegation) }
     let!(:team_case) { create(:allegation, creator: other_user_same_team) }
 
@@ -58,8 +59,19 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       it "shows cases that are owned by the user" do
         expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
+        expect(page).to have_selector("td.govuk-table__cell", text: user_case_without_products.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
+      end
+
+      it 'indicates which cases do not have a product attached' do
+        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case.id}) do
+          expect(page).not_to have_content("This case has no product")
+        end
+
+        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case_without_products.id}) do
+          expect(page).to have_content("This case has no product")
+        end
       end
 
       context "when less than 12 cases" do
@@ -100,6 +112,18 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
         expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
+      end
+
+      it 'indicates which cases do not have a product attached' do
+        click_on "All cases"
+        click_on "Team cases"
+        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case.id}) do
+          expect(page).not_to have_content("This case has no product")
+        end
+
+        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case_without_products.id}) do
+          expect(page).to have_content("This case has no product")
+        end
       end
 
       context "when less than 12 cases" do

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -64,12 +64,12 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         expect(page).not_to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
       end
 
-      it 'indicates which cases do not have a product attached' do
-        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case.id}) do
+      it "indicates which cases do not have a product attached" do
+        within(sprintf('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]', id: user_case.id)) do
           expect(page).not_to have_content("This case has no product")
         end
 
-        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case_without_products.id}) do
+        within(sprintf('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]', id: user_case_without_products.id)) do
           expect(page).to have_content("This case has no product")
         end
       end
@@ -114,14 +114,14 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
       end
 
-      it 'indicates which cases do not have a product attached' do
+      it "indicates which cases do not have a product attached" do
         click_on "All cases"
         click_on "Team cases"
-        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case.id}) do
+        within(sprintf('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]', id: user_case.id)) do
           expect(page).not_to have_content("This case has no product")
         end
 
-        within('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]' % {id: user_case_without_products.id}) do
+        within(sprintf('td[headers="item_investigation_allegation_%{id} status_investigation_allegation_%{id}"]', id: user_case_without_products.id)) do
           expect(page).to have_content("This case has no product")
         end
       end

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -319,8 +319,6 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
         number_of_total_cases = Investigation.where(hazard_type: "Fire").count
         expect(page).to have_content("#{number_of_total_cases} cases using the current filters, were found.")
-
-        expect(find("details#filter-details")["open"]).to eq(nil)
       end
     end
 

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   let(:other_user_other_team) { create(:user, :activated, name: "other user other team", organisation:, team: other_team) }
 
   let!(:investigation)                       { create(:allegation, creator: user, hazard_type: "Fire") }
-  let!(:other_user_investigation)            { create(:allegation, creator: other_user_same_team, hazard_type: "Fire" ) }
+  let!(:other_user_investigation)            { create(:allegation, creator: other_user_same_team, hazard_type: "Fire") }
   let!(:other_user_other_team_investigation) { create(:allegation, creator: other_user_other_team) }
   let!(:other_team_investigation)            { create(:allegation, creator: yet_another_user_same_team, hazard_type: "Fire") }
   let!(:another_team_investigation)          { create(:allegation, creator: create(:user)) }


### PR DESCRIPTION
https://trello.com/c/TKyYnDaN/1560-tech-debt-changes-for-the-your-team-all-cases-page-cap023

## Description
This ticket implements the following changes to the  all cases, your cases and team cases pages:
- Adds an additional column displaying the hazard type of the case
- Adds warning text on your cases and team cases page if a case does not have an associated product
- Adds the ability for a user to filter cases by hazard type

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
