### PR TITLE
Add options to the ERD for readability

### DIFF
--- a/.erdconfig
+++ b/.erdconfig
@@ -6,3 +6,6 @@ attributes:
   - content
 indirect: false
 cluster: true
+prepend_primary: true
+splines: ortho
+notation: uml


### PR DESCRIPTION
Adds ORM cardinality markers to associations, uses ortho line routing for fewer overlapping lines, and moves primary keys to the top of the table.

Before:
![image](https://user-images.githubusercontent.com/85587097/191302994-59e9b2f0-6519-4613-8454-d89821ae501f.png)

After:
![image](https://user-images.githubusercontent.com/85587097/191303323-782b8404-e57e-40f2-812a-b3e265d8289f.png)