### PR TITLE
Move the join model redacted export declarations into their model files

### DIFF
--- a/app/models/investigation_business.rb
+++ b/app/models/investigation_business.rb
@@ -3,5 +3,6 @@ class InvestigationBusiness < ApplicationRecord
   belongs_to :business
   default_scope { order(created_at: :desc) }
 
-  redacted_export_with :id, :business_id, :created_at, :investigation_id, :relationship, :updated_at
+  redacted_export_with :id, :business_id, :created_at, :investigation_id,
+                       :relationship, :updated_at
 end

--- a/app/models/investigation_product.rb
+++ b/app/models/investigation_product.rb
@@ -11,5 +11,7 @@ class InvestigationProduct < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
-  redacted_export_with :affected_units_status, :batch_number, :customs_code, :investigation_id, :number_of_affected_units, :product_id
+  redacted_export_with :id, :affected_units_status, :batch_number, :created_at,
+                       :customs_code, :investigation_id, :number_of_affected_units,
+                       :product_id, :updated_at
 end

--- a/config/initializers/redacted_export.rb
+++ b/config/initializers/redacted_export.rb
@@ -33,13 +33,3 @@ RedactedExport.register_table_attributes(
   "active_storage_variant_records",
   :id, :blob_id
 )
-
-RedactedExport.register_table_attributes(
-  "investigation_businesses",
-  :business_id, :created_at, :investigation_id, :relationship, :updated_at
-)
-
-RedactedExport.register_table_attributes(
-  "investigation_products",
-  :created_at, :investigation_id, :product_id, :updated_at
-)


### PR DESCRIPTION
As models now exist for `InvestigationProduct` and `InvestigationBusiness`, we no longer need static declarations in the initializer.