### PR TITLE
Improve efficiency of Opensearch-dependent specs

### DIFF
--- a/spec/features/businesses_navigation_spec.rb
+++ b/spec/features/businesses_navigation_spec.rb
@@ -4,179 +4,79 @@ RSpec.feature "Searching businesses", :with_opensearch, :with_stubbed_mailer, ty
   let(:team) { create :team }
   let(:user) { create :user, :activated, has_viewed_introduction: true, team: }
 
-  before do
-    sign_in user
+  let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
+  let(:user_business) { create(:business, trading_name: "user_business") }
+  let(:team_business) { create(:business, trading_name: "team_business") }
+  let(:closed_business) { create(:business, trading_name: "closed_business") }
+  let(:other_business) { create(:business, trading_name: "other_business") }
+
+  def create_four_businesses!
+    user_case = create(:allegation, creator: user)
+    team_case = create(:allegation, creator: other_user_same_team)
+    closed_case = create(:allegation, creator: user, is_closed: true)
+    other_case = create(:allegation)
+
+    InvestigationBusiness.create!(business_id: user_business.id, investigation_id: user_case.id)
+    InvestigationBusiness.create!(business_id: team_business.id, investigation_id: team_case.id)
+    InvestigationBusiness.create!(business_id: closed_business.id, investigation_id: closed_case.id)
+    InvestigationBusiness.create!(business_id: other_business.id, investigation_id: other_case.id)
+
+    Investigation.import refresh: true, force: true
+    Business.import refresh: true, force: true
+  end
+
+  scenario "No businesses" do
+    sign_in(user)
     visit "/businesses"
+
+    click_on "Team businesses"
+
+    expect(highlighted_tab).to eq "Team businesses"
+    expect(page).to have_content "There are 0 businesses linked to open cases where the #{team.name} team is the case owner."
+
+    click_on "Your businesses"
+
+    expect(highlighted_tab).to eq "Your businesses"
+    expect(page).to have_content "There are 0 businesses linked to open cases where you are the case owner."
   end
 
-  context "when there are no businesses" do
-    context "when the user is on the your businesses page" do
-      before do
-        click_on "Your businesses"
-      end
+  scenario "Browsing businesses" do
+    create_four_businesses!
 
-      it "explains that the user has no businesses" do
-        expect(page).to have_content "There are 0 businesses linked to open cases where you are the case owner."
-      end
+    sign_in(user)
+    visit "/businesses"
 
-      it "highlights the your businesses tab" do
-        expect(highlighted_tab).to eq "Your businesses"
-      end
-    end
+    expect(highlighted_tab).to eq "All businesses - Search"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_business.company_number)
+    expect(page).to have_selector("td.govuk-table__cell", text: other_business.company_number)
+    expect(page).to have_selector("td.govuk-table__cell", text: closed_business.company_number)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-    context "when the user is on the team businesses page" do
-      before do
-        click_on "All businesses"
-        click_on "Team businesses"
-      end
+    click_on "Team businesses"
 
-      it "explains that the team has no businesses" do
-        visit "/businesses"
-        click_on "Team businesses"
-        expect(page).to have_content "There are 0 businesses linked to open cases where the #{team.name} team is the case owner."
-      end
+    expect(highlighted_tab).to eq "Team businesses"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_business.company_number)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_business.company_number)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: closed_business.company_number)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-      it "highlights the team businesses tab" do
-        expect(highlighted_tab).to eq "Team businesses"
-      end
-    end
-  end
+    click_on "Your businesses"
 
-  context "when there are businesses" do
-    let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
-    let(:user_business) { create(:business, trading_name: "user_business") }
-    let(:team_business) { create(:business, trading_name: "team_business") }
-    let(:closed_business) { create(:business, trading_name: "closed_business") }
-    let(:other_business) { create(:business, trading_name: "other_business") }
+    expect(highlighted_tab).to eq "Your businesses"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: team_business.company_number)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_business.company_number)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: closed_business.company_number)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-    before do
-      user_case = create(:allegation, creator: user)
-      team_case = create(:allegation, creator: other_user_same_team)
-      closed_case = create(:allegation, creator: user, is_closed: true)
-      other_case = create(:allegation)
+    # Add more businesses and reload page
+    create_list(:business, 8)
+    Business.import refresh: true, force: true
 
-      InvestigationBusiness.create!(business_id: user_business.id, investigation_id: user_case.id)
-      InvestigationBusiness.create!(business_id: team_business.id, investigation_id: team_case.id)
-      InvestigationBusiness.create!(business_id: closed_business.id, investigation_id: closed_case.id)
-      InvestigationBusiness.create!(business_id: other_business.id, investigation_id: other_case.id)
-
-      Investigation.import refresh: true, force: true
-      Business.import refresh: true, force: true
-    end
-
-    context "when the user is on the your businesses page" do
-      before do
-        click_on "Your businesses"
-      end
-
-      it "shows businesses that are associated with businesses that are owned by the user and open" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: team_business.company_number)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_business.company_number)
-      end
-
-      it "does not show closed businesses" do
-        expect(page).not_to have_selector("td.govuk-table__cell", text: closed_business.company_number)
-      end
-
-      context "when less than 12 businesses" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-    end
-
-    context "when more than 11 businesses" do
-      before do
-        11.times do
-          create(:allegation, :with_business, creator: user)
-          Investigation.import refresh: true, force: true
-          Business.import refresh: true, force: true
-        end
-        visit your_businesses_path
-      end
-
-      it "does show the sort filter drop down with 'newly added' sorting option selected" do
-        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-      end
-    end
-
-    context "when the user is on the team businesses page" do
-      it "shows businesses that are owned by the users team" do
-        click_on "All businesses"
-        click_on "Team businesses"
-        expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_business.company_number)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_business.company_number)
-      end
-
-      it "does not show closed businesses" do
-        expect(page).not_to have_selector("td.govuk-table__cell", text: closed_business.company_number)
-      end
-
-      context "when less than 12 businesses" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 businesses" do
-        before do
-          10.times do
-            create(:allegation, :with_business, creator: user)
-            Investigation.import refresh: true, force: true
-            Business.import refresh: true, force: true
-          end
-          visit "/businesses/team-businesses"
-        end
-
-        it "does show the sort filter drop down with 'newly added' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-        end
-      end
-    end
-
-    context "when the user is on the all businesses page" do
-      before do
-        click_on "All businesses"
-      end
-
-      it "shows all businesses" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_business.company_number)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_business.company_number)
-        expect(page).to have_selector("td.govuk-table__cell", text: other_business.company_number)
-        expect(page).to have_selector("td.govuk-table__cell", text: closed_business.company_number)
-      end
-
-      it "highlights the all businesses tab" do
-        expect(highlighted_tab).to eq "All businesses - Search"
-      end
-
-      it "shows closed businesses" do
-        expect(page).to have_selector("td.govuk-table__cell", text: closed_business.company_number)
-      end
-
-      context "when less than 12 businesses" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 businesses" do
-        before do
-          9.times do
-            create(:allegation, :with_business, creator: user)
-            Investigation.import refresh: true, force: true
-            Business.import refresh: true, force: true
-          end
-          visit "/businesses/all-businesses"
-        end
-
-        it "does show the sort filter drop down with 'recent businesses' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-        end
-      end
-    end
+    visit "/businesses"
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added") # sort filter drop down
   end
 
   def highlighted_tab

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -4,180 +4,69 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
   let(:team) { create :team }
   let(:user) { create :user, :activated, has_viewed_introduction: true, team: }
 
-  before do
+  let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
+
+  scenario "No cases" do
     sign_in user
+
+    click_on "Your cases"
+
+    expect(highlighted_tab).to eq "Your cases"
+    expect(page).to have_content "You have no open cases. You can find all other cases in the all cases search page."
+
+    click_on "Team cases"
+
+    expect(highlighted_tab).to eq "Team cases"
+    expect(page).to have_content "The team has no open cases. You can find all other cases in the all cases search page."
   end
 
-  context "when there are no cases" do
-    context "when the user is on the your cases page" do
-      before do
-        click_on "Your cases"
-      end
+  scenario "Browsing cases" do
+    user_case = create(:allegation, creator: user)
+    other_case = create(:allegation)
+    team_case = create(:allegation, creator: other_user_same_team)
+    Investigation.import refresh: true, force: true
 
-      it "explains that the user has no cases" do
-        expect(page).to have_content "You have no open cases. You can find all other cases in the all cases search page."
-      end
+    sign_in user
 
-      it "highlights the your cases tab" do
-        expect(highlighted_tab).to eq "Your cases"
-      end
-    end
+    click_on "All cases"
 
-    context "when the user is on the team cases page" do
-      before do
-        click_on "All cases"
-        click_on "Team cases"
-      end
+    expect(highlighted_tab).to eq "All cases – Search"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
+    expect(page).to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
+    expect(page).not_to have_css("form dl.opss-dl-select dd")  # sort filter drop down
 
-      it "explains that the team has no cases" do
-        visit "/cases"
-        click_on "Team cases"
-        expect(page).to have_content "The team has no open cases. You can find all other cases in the all cases search page."
-      end
+    click_on "Your cases"
 
-      it "highlights the team cases tab" do
-        expect(highlighted_tab).to eq "Team cases"
-      end
-    end
-  end
+    expect(highlighted_tab).to eq "Your cases"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
+    expect(page).not_to have_css("form dl.opss-dl-select dd")  # sort filter drop down
 
-  context "when there are cases" do
-    let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
-    let!(:user_case) { create(:allegation, creator: user) }
-    let!(:other_case) { create(:allegation) }
-    let!(:team_case) { create(:allegation, creator: other_user_same_team) }
+    click_on "Team cases"
 
-    before do
-      Investigation.import refresh: true, force: true
-    end
+    expect(highlighted_tab).to eq "Team cases"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
+    expect(page).not_to have_css("form dl.opss-dl-select dd")  # sort filter drop down
 
-    context "when the user is on the your cases page" do
-      before do
-        click_on "Your cases"
-      end
+    # Add more cases and reload page
+    create_list(:allegation, 11, creator: user)
+    Investigation.import refresh: true, force: true
+    visit "/cases/your-cases"
 
-      it "shows cases that are owned by the user" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
-      end
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases") # sort filter drop down
 
-      context "when less than 12 cases" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
+    # does not change table headers when user changes the filter options
+    expect(page).to have_css("th#updated")
+    expect(page).not_to have_css("th#created")
 
-      context "when more than 11 cases" do
-        before do
-          create_list(:allegation, 11, creator: user)
-          Investigation.import refresh: true, force: true
-          visit "/cases/your-cases"
-        end
+    within("form dl.govuk-list.opss-dl-select") { click_on "Oldest cases" }
 
-        it "does show the sort filter drop down with 'newest cases' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases")
-        end
-
-        it "does not change table headers when user changes the filter options" do
-          expect(page).to have_css("th#updated")
-          expect(page).not_to have_css("th#created")
-
-          within "form dl.govuk-list.opss-dl-select" do
-            click_on "Oldest cases"
-          end
-
-          expect(page).to have_css("th#updated")
-          expect(page).not_to have_css("#thcreated")
-        end
-      end
-    end
-
-    context "when the user is on the team cases page" do
-      it "shows cases that are owned by the users team" do
-        click_on "All cases"
-        click_on "Team cases"
-        expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
-      end
-
-      context "when less than 12 cases" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 cases" do
-        before do
-          create_list(:allegation, 11, creator: other_user_same_team)
-          Investigation.import refresh: true, force: true
-          visit "/cases/team-cases"
-        end
-
-        it "does show the sort filter drop down with 'newest cases' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases")
-        end
-
-        it "does not change table headers when user changes the filter options" do
-          expect(page).to have_css("th#updated")
-          expect(page).not_to have_css("th#created")
-
-          within "form dl.govuk-list.opss-dl-select" do
-            click_on "Oldest cases"
-          end
-
-          expect(page).to have_css("th#updated")
-          expect(page).not_to have_css("th#created")
-        end
-      end
-    end
-
-    context "when the user is on the all cases page" do
-      before do
-        click_on "All cases"
-      end
-
-      it "shows all cases" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
-        expect(page).to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
-      end
-
-      it "highlights the all cases tab" do
-        expect(highlighted_tab).to eq "All cases – Search"
-      end
-
-      context "when less than 12 cases" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 cases" do
-        before do
-          create_list(:allegation, 11)
-          Investigation.import refresh: true, force: true
-          visit "/cases/all-cases"
-        end
-
-        it "does show the sort filter drop down with 'recent cases' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Recent updates")
-        end
-
-        it "changes table headers when user changes the filter options" do
-          expect(page).to have_css("th#updated")
-          expect(page).not_to have_css("th#created")
-
-          within "form dl.govuk-list.opss-dl-select" do
-            click_on "Oldest cases"
-          end
-
-          expect(page).to have_css("th#created")
-          expect(page).not_to have_css("th#updated")
-        end
-      end
-    end
+    expect(page).to have_css("th#updated")
+    expect(page).not_to have_css("#thcreated")
   end
 
   def highlighted_tab

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -70,10 +70,8 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
   context "when there are multiple pages of cases" do
     before do
-      20.times do
-        create(:allegation, creator: user, risk_level: Investigation.risk_levels[:serious])
-        Investigation.import refresh: :wait_for
-      end
+      20.times { create(:allegation, creator: user, risk_level: Investigation.risk_levels[:serious]) }
+      Investigation.import refresh: :wait_for
     end
 
     it "maintains the filters when clicking on additional pages" do

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -4,172 +4,74 @@ RSpec.feature "Searching products", :with_opensearch, :with_stubbed_mailer, type
   let(:team) { create :team }
   let(:user) { create :user, :activated, has_viewed_introduction: true, team: }
 
-  before do
+  let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
+  let!(:user_product) { create(:product) }
+  let!(:other_product) { create(:product) }
+  let!(:team_product) { create(:product) }
+  let!(:closed_product) { create(:product) }
+
+  def create_four_products!
+    create(:allegation, creator: user, products: [user_product])
+    create(:allegation, products: [other_product])
+    create(:allegation, creator: other_user_same_team, products: [team_product])
+    create(:allegation, creator: user, products: [closed_product], is_closed: true)
+    Investigation.import refresh: true, force: true
+    Product.import refresh: true, force: true
+  end
+
+  scenario "No products" do
     sign_in user
     visit "/products"
+
+    click_on "Your products"
+
+    expect(highlighted_tab).to eq "Your products"
+    expect(page).to have_content "There are 0 products linked to open cases where you are the case owner."
+
+    click_on "Team products"
+
+    expect(highlighted_tab).to eq "Team products"
+    expect(page).to have_content "There are 0 products linked to open cases where the #{team.name} team is the case owner."
   end
 
-  context "when there are no products" do
-    context "when the user is on the your products page" do
-      before do
-        click_on "Your products"
-      end
+  scenario "Browsing products" do
+    create_four_products!
 
-      it "explains that the user has no products" do
-        expect(page).to have_content "There are 0 products linked to open cases where you are the case owner."
-      end
+    sign_in user
+    visit "/products"
 
-      it "highlights the your products tab" do
-        expect(highlighted_tab).to eq "Your products"
-      end
-    end
+    expect(highlighted_tab).to eq "All products - Search"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
+    expect(page).to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
+    expect(page).to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-    context "when the user is on the team products page" do
-      before do
-        click_on "All products"
-        click_on "Team products"
-      end
+    click_on "Your products"
 
-      it "explains that the team has no products" do
-        visit "/products"
-        click_on "Team products"
-        expect(page).to have_content "There are 0 products linked to open cases where the #{team.name} team is the case owner."
-      end
+    expect(highlighted_tab).to eq "Your products"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-      it "highlights the team products tab" do
-        expect(highlighted_tab).to eq "Team products"
-      end
-    end
-  end
+    click_on "Team products"
 
-  context "when there are products" do
-    let(:other_user_same_team) { create :user, :activated, has_viewed_introduction: true, team: }
-    let!(:user_product) { create(:product) }
-    let!(:other_product) { create(:product) }
-    let!(:team_product) { create(:product) }
-    let!(:closed_product) { create(:product) }
+    expect(highlighted_tab).to eq "Team products"
+    expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
+    expect(page).to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
+    expect(page).not_to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
+    expect(page).not_to have_css("form dl.opss-dl-select dd") # sort filter drop down
 
-    before do
-      create(:allegation, creator: user, products: [user_product])
-      create(:allegation, products: [other_product])
-      create(:allegation, creator: other_user_same_team, products: [team_product])
-      create(:allegation, creator: user, products: [closed_product], is_closed: true)
-      Investigation.import refresh: true, force: true
-      Product.import refresh: true, force: true
-    end
+    # Add more products and reload page
+    10.times { create(:allegation, creator: other_user_same_team, products: [create(:product)]) }
+    Product.import refresh: true, force: true
 
-    context "when the user is on the your products page" do
-      before do
-        click_on "Your products"
-      end
+    visit "/products"
 
-      it "shows products that are associated with cases that are owned by the user and open" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
-      end
-
-      it "does not show closed cases" do
-        expect(page).not_to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
-      end
-
-      context "when less than 12 products" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-    end
-
-    context "when more than 11 products" do
-      before do
-        11.times do
-          create(:allegation, creator: user, products: [create(:product)])
-          Investigation.import refresh: true, force: true
-          Product.import refresh: true, force: true
-        end
-        visit "/products/your-products"
-      end
-
-      it "does show the sort filter drop down with 'newest cases' sorting option selected" do
-        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-      end
-    end
-
-    context "when the user is on the team cases page" do
-      it "shows cases that are owned by the users team" do
-        click_on "All products"
-        click_on "Team products"
-        expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
-        expect(page).not_to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
-      end
-
-      it "does not show closed cases" do
-        expect(page).not_to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
-      end
-
-      context "when less than 12 cases" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 cases" do
-        before do
-          10.times do
-            create(:allegation, creator: other_user_same_team, products: [create(:product)])
-            Investigation.import refresh: true, force: true
-            Product.import refresh: true, force: true
-          end
-          visit "/products/team-products"
-        end
-
-        it "does show the sort filter drop down with 'newest cases' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-        end
-      end
-    end
-
-    context "when the user is on the all products page" do
-      before do
-        click_on "All products"
-      end
-
-      it "shows all cases" do
-        expect(page).to have_selector("td.govuk-table__cell", text: user_product.psd_ref)
-        expect(page).to have_selector("td.govuk-table__cell", text: other_product.psd_ref)
-        expect(page).to have_selector("td.govuk-table__cell", text: team_product.psd_ref)
-      end
-
-      it "highlights the all products tab" do
-        expect(highlighted_tab).to eq "All products - Search"
-      end
-
-      it "shows closed cases" do
-        expect(page).to have_selector("td.govuk-table__cell", text: closed_product.psd_ref)
-      end
-
-      context "when less than 12 products" do
-        it "does not show the sort filter drop down" do
-          expect(page).not_to have_css("form dl.opss-dl-select dd")
-        end
-      end
-
-      context "when more than 11 products" do
-        before do
-          9.times do
-            create(:allegation, products: [create(:product)])
-            Investigation.import refresh: true, force: true
-            Product.import refresh: true, force: true
-          end
-          visit "/products/all-products"
-        end
-
-        it "does show the sort filter drop down with 'recent products' sorting option selected" do
-          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added")
-        end
-      end
-    end
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newly added") # sort filter drop down
   end
 
   def highlighted_tab


### PR DESCRIPTION
This is a developer quality of life improvement to some of the feature specs which require Opensearch.

This tackles all of the top 10 slowest running specs (all times taken from my 16in Macbook Pro Intel i9 2.4GHz w/ 64GB machine):

```
Top 10 slowest examples (406.72 seconds, 18.3% of total time):
  Searching businesses when there are businesses when the user is on the all businesses page when more than 11 businesses does show the sort filter drop down with 'recent businesses' sorting option selected
    58.95 seconds ./spec/features/businesses_navigation_spec.rb:175
  Searching businesses when there are businesses when the user is on the team businesses page when more than 11 businesses does show the sort filter drop down with 'newly added' sorting option selected
    58.94 seconds ./spec/features/businesses_navigation_spec.rb:133
  Searching businesses when there are businesses when more than 11 businesses does show the sort filter drop down with 'newly added' sorting option selected
    58.22 seconds ./spec/features/businesses_navigation_spec.rb:99
  Searching products when there are products when the user is on the all products page when more than 11 products does show the sort filter drop down with 'recent products' sorting option selected
    55.59 seconds ./spec/features/products_navigation_spec.rb:168
  Searching products when there are products when the user is on the team cases page when more than 11 cases does show the sort filter drop down with 'newest cases' sorting option selected
    55.21 seconds ./spec/features/products_navigation_spec.rb:127
  Searching products when there are products when more than 11 products does show the sort filter drop down with 'newest cases' sorting option selected
    54.96 seconds ./spec/features/products_navigation_spec.rb:93
  Case filtering when there are multiple pages of cases maintains the filters when clicking on additional pages
    19.14 seconds ./spec/features/filter_investigations_spec.rb:79
  Searching cases when there are cases when the user is on the all cases page when more than 11 cases changes table headers when user changes the filter options
    16.39 seconds ./spec/features/cases_navigation_spec.rb:168
  Searching businesses when there are businesses when the user is on the all businesses page highlights the all businesses tab
    15.25 seconds ./spec/features/businesses_navigation_spec.rb:151
  Searching products when there are products when the user is on the all products page when less than 12 products does not show the sort filter drop down
    14.08 seconds ./spec/features/products_navigation_spec.rb:153
```
```
rspec spec/features/businesses_navigation_spec.rb
BEFORE: Finished in 3 minutes 51.1 seconds (files took 14.93 seconds to load)
AFTER: Finished in 11.97 seconds (files took 10.47 seconds to load)

rspec spec/features/products_navigation_spec.rb
BEFORE: Finished in 5 minutes 35 seconds (files took 10.59 seconds to load)
AFTER: Finished in 15.43 seconds (files took 11.2 seconds to load)

rspec spec/features/cases_navigation_spec.rb
BEFORE: Finished in 2 minutes 24.5 seconds (files took 10.8 seconds to load)
AFTER: Finished in 13.34 seconds (files took 12.25 seconds to load)

rspec spec/features/filter_investigations_spec.rb
BEFORE: Finished in 5 minutes 43 seconds (files took 12.35 seconds to load)
AFTER: Finished in 4 minutes 27.6 seconds (files took 10.35 seconds to load)
```

**Total savings approx with this change: 12 minutes 46 seconds.**

There are more improvements that can be made to `filter_investigations_spec.rb` which is currently taking over 5 minutes, but this requires significant refactoring to this file and will be subject to a follow-up pull request.

The savings are mostly derived from fixing:

* Opensearch `import` methods being called on each iteration of a loop when creating records, rather than once, plus additional redundant calls in `before` blocks
* Redundant clicks on pages in examples and `before` blocks calling search results and page renders which are not used
* Unnecessarily duplicated specs in different context blocks
* Assertions being split into multiple example blocks causing the spec setup to be run on each example. Lumping them together into a single `scenario` with a series of steps eliminates this inefficiency.