### PR TITLE
Use same database statement timeout configuration on workers as on web processes

### DIFF
--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -45,6 +45,7 @@ applications:
     - type: worker
       env:
         RAILS_MAX_THREADS: ((worker-max-threads))
+        STATEMENT_TIMEOUT: 60s
       command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 1

--- a/manifest.yml
+++ b/manifest.yml
@@ -42,6 +42,7 @@ applications:
     - type: worker
       env:
         RAILS_MAX_THREADS: ((worker-max-threads))
+        STATEMENT_TIMEOUT: 60s
       command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: ((worker-instances))


### PR DESCRIPTION
This fixes various database statement timeout errors seeon only on Sidekiq jobs.

This appears to be because the worker processes were not configured with the same longer statement timeout as the web processes, thereby defaulting to 500ms as per https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/master/config/database.yml#L19

This change replicates the statement timeout configuration used on the web processes to the workers as well.