### PR TITLE
Fix environment variables specified in wrong place in app manifests

### DIFF
--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -14,6 +14,8 @@ applications:
     SENTRY_CURRENT_ENV: ((sentry-current-env))
     LOCK_MAXIMUM_ATTEMPTS: 3
     OS_NAMESPACE: ((app-name))
+    STATEMENT_TIMEOUT: 60s
+    RAILS_MAX_THREADS: ((web-max-threads))
   timeout: 180
   services:
     - ((psd-db-name))
@@ -36,17 +38,11 @@ applications:
     - psd-redacted-export-env
   processes:
     - type: web
-      env:
-        RAILS_MAX_THREADS: ((web-max-threads))
-        STATEMENT_TIMEOUT: 60s
       command: export $(./env/get-env-from-vcap.sh) && bin/rake cf:on_first_instance db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
       memory: 2G
     - type: worker
-      env:
-        RAILS_MAX_THREADS: ((worker-max-threads))
-        STATEMENT_TIMEOUT: 60s
-      command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
+      command: export $(./env/get-env-from-vcap.sh) && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 1
       memory: 500M

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,8 @@ applications:
     - route: ((psd-host))
   env:
     PSD_HOST: ((psd-host))
+    STATEMENT_TIMEOUT: 60s
+    RAILS_MAX_THREADS: ((web-max-threads))
   timeout: 180
   services:
     - opss-log-drain
@@ -32,18 +34,12 @@ applications:
     - psd-redacted-export-env
   processes:
     - type: web
-      env:
-        RAILS_MAX_THREADS: ((web-max-threads))
-        STATEMENT_TIMEOUT: 60s
       command: export $(./env/get-env-from-vcap.sh) && bin/rake cf:on_first_instance db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: ((web-instances))
       memory: ((web-memory))
       disk_quota: ((web-disk-quota))
     - type: worker
-      env:
-        RAILS_MAX_THREADS: ((worker-max-threads))
-        STATEMENT_TIMEOUT: 60s
-      command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
+      command: export $(./env/get-env-from-vcap.sh) && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: ((worker-instances))
       memory: ((worker-memory))


### PR DESCRIPTION
The [CloudFoundry app manifest specification](https://v3-apidocs.cloudfoundry.org/version/3.76.0/index.html#the-app-manifest-specification) shows that there is no `env` section for `processes`, and therefore `RAILS_MAX_THREADS` and `STATEMENT_TIMEOUT` were never being set in the applications.

This resulted in occasional database statement timeout errors in the workers.

Note that our deployment configuration [specifies the max threads for the application](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/master/.github/workflows/deploy.yml#L147-L148) but this configuration was never used. It is currently set to `16` threads in production. Deploying this change will therefore change the performance characteristics of the application by *reducing the number of threads* and we should monitor this to ensure there is no degradation in performance.