### PR TITLE
Allow editing of units affected data

### DIFF
--- a/app/controllers/investigation_products/number_of_affected_units_controller.rb
+++ b/app/controllers/investigation_products/number_of_affected_units_controller.rb
@@ -21,12 +21,10 @@ module InvestigationProducts
       redirect_to investigation_path(@investigation_product.investigation), flash: result.changed ? { success: "The case information was updated" } : nil
     end
 
+  private
+
     def number_of_affected_units_params
       params.require(:number_of_affected_units_form).permit(:affected_units_status, :exact_units, :approx_units)
-    end
-
-    def investigation_product_has_no_changes?
-      @investigation_product.affected_units_status == @number_of_affected_units_form.affected_units_status && @investigation_product.number_of_affected_units == @number_of_affected_units_form.number_of_affected_units
     end
   end
 end

--- a/app/controllers/investigation_products/number_of_affected_units_controller.rb
+++ b/app/controllers/investigation_products/number_of_affected_units_controller.rb
@@ -1,0 +1,32 @@
+module InvestigationProducts
+  class NumberOfAffectedUnitsController < ApplicationController
+    def edit
+      @investigation_product = InvestigationProduct.find(params[:investigation_product_id])
+      authorize @investigation_product.investigation, :update?
+      @number_of_affected_units_form = NumberOfAffectedUnitsForm.from(@investigation_product)
+    end
+
+    def update
+      @investigation_product = InvestigationProduct.find(params[:investigation_product_id])
+      authorize @investigation_product.investigation, :update?
+
+      @number_of_affected_units_form = NumberOfAffectedUnitsForm.new(number_of_affected_units_params)
+      return render(:edit) if @number_of_affected_units_form.invalid?
+
+      result = ChangeNumberOfAffectedUnits.call!(number_of_affected_units: @number_of_affected_units_form.number_of_affected_units,
+                                                 affected_units_status: @number_of_affected_units_form.affected_units_status,
+                                                 investigation_product: @investigation_product,
+                                                 user: current_user)
+
+      redirect_to investigation_path(@investigation_product.investigation), flash: result.changed ? { success: "The case information was updated" } : nil
+    end
+
+    def number_of_affected_units_params
+      params.require(:number_of_affected_units_form).permit(:affected_units_status, :exact_units, :approx_units)
+    end
+
+    def investigation_product_has_no_changes?
+      @investigation_product.affected_units_status == @number_of_affected_units_form.affected_units_status && @investigation_product.number_of_affected_units == @number_of_affected_units_form.number_of_affected_units
+    end
+  end
+end

--- a/app/decorators/audit_activity/investigation/update_case_specific_product_information_decorator.rb
+++ b/app/decorators/audit_activity/investigation/update_case_specific_product_information_decorator.rb
@@ -12,4 +12,12 @@ class AuditActivity::Investigation::UpdateCaseSpecificProductInformationDecorato
   def title(_viewer)
     "Case specific product information updated"
   end
+
+  def new_number_of_affected_units
+    metadata.dig("updates", "number_of_affected_units", 1)
+  end
+
+  def new_affected_units_status
+    metadata.dig("updates", "affected_units_status", 1)
+  end
 end

--- a/app/forms/number_of_affected_units_form.rb
+++ b/app/forms/number_of_affected_units_form.rb
@@ -1,0 +1,35 @@
+class NumberOfAffectedUnitsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :exact_units
+  attribute :approx_units
+  attribute :affected_units_status
+  attribute :number_of_affected_units
+
+  validates :affected_units_status, inclusion: {  in: InvestigationProduct.affected_units_statuses.keys }
+  validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
+  validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
+
+  def self.from(investigation_product)
+    new(investigation_product.serializable_hash.slice("number_of_affected_units", "affected_units_status")).tap do |investigation_product_form|
+      if investigation_product.affected_units_status == InvestigationProduct.affected_units_statuses["approx"]
+        investigation_product_form.approx_units = investigation_product.number_of_affected_units
+      elsif investigation_product.affected_units_status == InvestigationProduct.affected_units_statuses["exact"]
+        investigation_product_form.exact_units = investigation_product.number_of_affected_units
+      end
+    end
+  end
+
+  def number_of_affected_units
+    return if affected_units_status.blank?
+
+    case affected_units_status
+    when "exact"
+      exact_units
+    when "approx"
+      approx_units
+    end
+  end
+end

--- a/app/forms/number_of_affected_units_form.rb
+++ b/app/forms/number_of_affected_units_form.rb
@@ -8,9 +8,9 @@ class NumberOfAffectedUnitsForm
   attribute :affected_units_status
   attribute :number_of_affected_units
 
-  validates :affected_units_status, inclusion: {  in: InvestigationProduct.affected_units_statuses.keys }
-  validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
-  validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
+  validates :affected_units_status, inclusion: { in: InvestigationProduct.affected_units_statuses.keys }
+  validates :approx_units, presence: { message: "Enter how many units are affected" }, if: -> { affected_units_status == "approx" }
+  validates :exact_units, presence: { message: "Enter how many units are affected" }, if: -> { affected_units_status == "exact" }
 
   def self.from(investigation_product)
     new(investigation_product.serializable_hash.slice("number_of_affected_units", "affected_units_status")).tap do |investigation_product_form|

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -372,7 +372,7 @@ private
       items: [
         href: edit_investigation_product_number_of_affected_units_path(investigation_product),
         text: "Edit",
-        visuallyHiddenText: "  the units affected for #{investigation_product.product.name}"
+        visuallyHiddenText: " the units affected for #{investigation_product.product.name}"
       ]
     }
   end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -90,7 +90,8 @@ module InvestigationsHelper
       },
       {
         key: { text: "Units affected" },
-        value: units_affected(investigation_product)
+        value: units_affected(investigation_product),
+        actions: number_of_affected_units_actions(investigation_product, user)
       }
     ]
   end
@@ -360,6 +361,18 @@ private
         href: edit_investigation_product_customs_code_path(investigation_product),
         text: "Edit",
         visuallyHiddenText: "  the customs codes for #{investigation_product.product.name}"
+      ]
+    }
+  end
+
+  def number_of_affected_units_actions(investigation_product, user)
+    return {} unless investigation_product && policy(investigation_product.investigation).update?(user:)
+
+    {
+      items: [
+        href: edit_investigation_product_number_of_affected_units_path(investigation_product),
+        text: "Edit",
+        visuallyHiddenText: "  the units affected for #{investigation_product.product.name}"
       ]
     }
   end

--- a/app/models/audit_activity/investigation/update_case_specific_product_information.rb
+++ b/app/models/audit_activity/investigation/update_case_specific_product_information.rb
@@ -1,6 +1,6 @@
 class AuditActivity::Investigation::UpdateCaseSpecificProductInformation < AuditActivity::Investigation::Base
   def self.build_metadata(investigation_product)
-    updated_values = investigation_product.previous_changes.slice(:batch_number, :customs_code)
+    updated_values = investigation_product.previous_changes.slice(:batch_number, :customs_code, :affected_units_status, :number_of_affected_units)
 
     {
       updates: updated_values

--- a/app/services/change_number_of_affected_units.rb
+++ b/app/services/change_number_of_affected_units.rb
@@ -1,0 +1,63 @@
+class ChangeNumberOfAffectedUnits
+  include Interactor
+  include EntitiesToNotify
+
+  delegate :investigation_product, :affected_units_status, :number_of_affected_units, :user, to: :context
+
+  def call
+    context.fail!(error: "No investigation product supplied") unless investigation_product.is_a?(InvestigationProduct)
+    context.fail!(error: "No affected units status supplied") unless affected_units_status.is_a?(String)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+
+    investigation_product.assign_attributes(affected_units_status:, number_of_affected_units:)
+    return if investigation_product.changes.none?
+
+    ActiveRecord::Base.transaction do
+      investigation_product.save!
+      create_audit_activity_for_batch_number_changed
+    end
+
+    context.changed = true
+
+    send_notification_email
+  end
+
+private
+
+  def create_audit_activity_for_batch_number_changed
+    metadata = activity_class.build_metadata(investigation_product)
+
+    activity_class.create!(
+      added_by_user: user,
+      investigation:,
+      title: nil,
+      body: nil,
+      metadata:
+    )
+  end
+
+  def activity_class
+    AuditActivity::Investigation::UpdateCaseSpecificProductInformationDecorator
+  end
+
+  def send_notification_email
+    email_recipients_for_case_owner.each do |recipient|
+      NotifyMailer.investigation_updated(
+        investigation.pretty_id,
+        recipient.name,
+        recipient.email,
+        email_body(recipient),
+        "#{investigation.case_type.upcase_first} units affected updated"
+      ).deliver_later
+    end
+  end
+
+  def investigation
+    investigation_product.investigation
+  end
+
+  def email_body(viewer = nil)
+    user_name = user.decorate.display_name(viewer:)
+    "#{investigation.case_type.upcase_first} units affected was updated by #{user_name}."
+  end
+end

--- a/app/views/investigation_products/number_of_affected_units/edit.html.erb
+++ b/app/views/investigation_products/number_of_affected_units/edit.html.erb
@@ -10,18 +10,26 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @number_of_affected_units_form, url: investigation_product_number_of_affected_units_path, builder: ApplicationFormBuilder, method: :put, html: {novalidate: true}, local: true do |form| %>
     <%= error_summary @number_of_affected_units_form.errors %>
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-      <h1 class="govuk-fieldset__heading">
+
+      <% legend = capture do %>
+        <h1 class="govuk-fieldset__heading">
           Edit how many units are affected
-      </h1>
-    </legend>
+        </h1>
+      <% end %>
+
       <%= govukRadios(
         form: form,
         key: :affected_units_status,
+        fieldset: {
+        legend: {
+            html: legend,
+            classes: "govuk-fieldset__legend--l"
+          },
+        },
         hint: { text: "You can add and edit how many product units are affected for #{@investigation_product.product.name}.", classes: "govuk-!-margin-bottom-5" },
         items: [
-          { text: "Exact number",       value: "exact", conditional: { html: form.govuk_input(:exact_units, label: "How many units are affected?") }, id: "affected_units_status" },
-          { text: "Approximate number", value: "approx", conditional: { html: form.govuk_input(:approx_units, label: "How many units are affected?") } },
+          { text: "Exact number",       value: "exact", conditional: { html: form.govuk_input(:exact_units, label: "How many units are affected?",  classes: "govuk-input--width-10") }, id: "affected_units_status" },
+          { text: "Approximate number", value: "approx", conditional: { html: form.govuk_input(:approx_units, label: "How many units are affected?",  classes: "govuk-input--width-10") } },
           { text: "Unknown",            value: "unknown" },
           { divider: "or" },
           { text: "Not relevant", value: "not_relevant" }

--- a/app/views/investigation_products/number_of_affected_units/edit.html.erb
+++ b/app/views/investigation_products/number_of_affected_units/edit.html.erb
@@ -1,0 +1,37 @@
+<% page_heading = "Edit how many units are affected" %>
+
+<% page_title page_heading, errors: @number_of_affected_units_form.errors.any? %>
+<%= govukBackLink(
+  text: "Back",
+  href: investigation_path(@investigation_product.investigation)
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @number_of_affected_units_form, url: investigation_product_number_of_affected_units_path, builder: ApplicationFormBuilder, method: :put, html: {novalidate: true}, local: true do |form| %>
+    <%= error_summary @number_of_affected_units_form.errors %>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+          Edit how many units are affected
+      </h1>
+    </legend>
+      <%= govukRadios(
+        form: form,
+        key: :affected_units_status,
+        hint: { text: "You can add and edit how many product units are affected for #{@investigation_product.product.name}.", classes: "govuk-!-margin-bottom-5" },
+        items: [
+          { text: "Exact number",       value: "exact", conditional: { html: form.govuk_input(:exact_units, label: "How many units are affected?") }, id: "affected_units_status" },
+          { text: "Approximate number", value: "approx", conditional: { html: form.govuk_input(:approx_units, label: "How many units are affected?") } },
+          { text: "Unknown",            value: "unknown" },
+          { divider: "or" },
+          { text: "Not relevant", value: "not_relevant" }
+        ]
+      ) %>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Save", class: "govuk-button" %>
+        <%= link_to "Cancel", investigation_path(@investigation_product.investigation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/investigations/activities/investigation/_update_case_specific_product_information.html.erb
+++ b/app/views/investigations/activities/investigation/_update_case_specific_product_information.html.erb
@@ -6,3 +6,9 @@
   <% if activity.new_customs_code %>
     <%= "Customs code:" %> <b><%= activity.new_customs_code %></b><br>
   <% end %>
+  <% if activity.new_number_of_affected_units %>
+    <%= "Number of affected units:" %> <b><%= activity.new_number_of_affected_units %></b><br>
+  <% end %>
+  <% if activity.new_affected_units_status %>
+    <%= "Affected units status:" %> <b><%= activity.new_affected_units_status %></b><br>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
   resources :investigation_products, only: %i[], param: :id do
     resource :batch_numbers, only: %i[edit update], path: "edit-batch-numbers", controller: "investigation_products/batch_numbers"
     resource :customs_code, only: %i[edit update], path: "edit-customs-code", controller: "investigation_products/customs_codes"
+    resource :number_of_affected_units, only: %i[edit update], path: "edit-number-of-affected-units", controller: "investigation_products/number_of_affected_units"
   end
 
   resources :products, except: %i[destroy], concerns: %i[document_attachable]

--- a/spec/features/case_specific_information_spec.rb
+++ b/spec/features/case_specific_information_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Case specific information spec", :with_stubbed_opensearch, :with
           click_link "Edit the batch numbers for #{InvestigationProduct.first.product.name}"
         end
 
-        expect_to_be_on_edit_batch_numbers_page(product_id: InvestigationProduct.first.id)
+        expect_to_be_on_edit_batch_numbers_page(investigation_product_id: InvestigationProduct.first.id)
 
         expect(page).to have_field("batch_number", with: InvestigationProduct.first.batch_number)
 
@@ -96,7 +96,7 @@ RSpec.describe "Case specific information spec", :with_stubbed_opensearch, :with
           click_link "Edit the customs codes for #{InvestigationProduct.first.product.name}"
         end
 
-        expect_to_be_on_edit_customs_code_page(product_id: InvestigationProduct.first.id)
+        expect_to_be_on_edit_customs_code_page(investigation_product_id: InvestigationProduct.first.id)
 
         expect(page).to have_field("customs_code", with: InvestigationProduct.first.customs_code)
 
@@ -120,6 +120,40 @@ RSpec.describe "Case specific information spec", :with_stubbed_opensearch, :with
         expect(page).to have_content("Customs code: #{new_customs_code}")
 
         expect(delivered_emails.last.personalization[:subject_text]).to eq "Allegation customs code updated"
+      end
+
+      it "allows editing of units affected" do
+        within("dl#product-0") do
+          click_link "Edit the units affected for #{InvestigationProduct.first.product.name}"
+        end
+
+        expect_to_be_on_edit_units_affected_page(investigation_product_id: InvestigationProduct.first.id)
+
+        expect(page).to have_checked_field("Unknown")
+
+        choose "Exact number"
+
+        fill_in "exact_units", with: "100"
+
+        click_button "Save"
+
+        expect_to_be_on_case_page(case_id: investigation.pretty_id)
+
+        expect(page).to have_content("The case information was updated")
+
+        within("dl#product-0") do
+          expect(page).to have_css("dt.govuk-summary-list__key", text: "Units affected")
+          expect(page).to have_css("dd.govuk-summary-list__value", text: "100 Exact number")
+        end
+
+        click_link "Activity"
+
+        expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
+        expect(page).to have_css("h3", text: "Case specific product information updated")
+        expect(page).to have_content("Affected units status: exact")
+        expect(page).to have_content("Number of affected units: 100")
+
+        expect(delivered_emails.last.personalization[:subject_text]).to eq "Allegation units affected updated"
       end
     end
 

--- a/spec/features/case_specific_information_spec.rb
+++ b/spec/features/case_specific_information_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe "Case specific information spec", :with_stubbed_opensearch, :with
 
         choose "Exact number"
 
+        fill_in "exact_units", with: ""
+
+        click_button "Save"
+
+        errors_list = page.find(".govuk-error-summary__list").all("li")
+        expect(errors_list[0].text).to eq "Enter how many units are affected"
+
+        choose "Exact number"
+
         fill_in "exact_units", with: "100"
 
         click_button "Save"

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -668,13 +668,18 @@ module PageExpectations
     expect(page).to have_current_path("/cases/#{case_id}/summary/edit")
   end
 
-  def expect_to_be_on_edit_batch_numbers_page(product_id:)
-    expect(page).to have_current_path("/investigation_products/#{product_id}/edit-batch-numbers/edit")
+  def expect_to_be_on_edit_batch_numbers_page(investigation_product_id:)
+    expect(page).to have_current_path("/investigation_products/#{investigation_product_id}/edit-batch-numbers/edit")
     expect(page).to have_css("h1", text: "Edit the batch numbers")
   end
 
-  def expect_to_be_on_edit_customs_code_page(product_id:)
-    expect(page).to have_current_path("/investigation_products/#{product_id}/edit-customs-code/edit")
+  def expect_to_be_on_edit_customs_code_page(investigation_product_id:)
+    expect(page).to have_current_path("/investigation_products/#{investigation_product_id}/edit-customs-code/edit")
     expect(page).to have_css("h1", text: "Edit the customs code")
+  end
+
+  def expect_to_be_on_edit_units_affected_page(investigation_product_id:)
+    expect(page).to have_current_path("/investigation_products/#{investigation_product_id}/edit-number-of-affected-units/edit")
+    expect(page).to have_css("h1", text: "Edit how many units are affected")
   end
 end


### PR DESCRIPTION
https://trello.com/c/UfZVqwiE/1519-edit-units-affected-form-page-cap109

## Description
As the final part of the piece allowing users to edit case specific information, this change allows users to change the numbers of, and status of, affected units.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
