### PR TITLE
Upgrade govuk-design-system-rails to 0.9.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "validate_email", "~> 0.1"
 gem "webpacker", "~> 5.4"
 gem "wicked", "~> 2.0"
 
-gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.4", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.5", require: "govuk_design_system"
 
 gem "bootsnap"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails
-  revision: 9f34e5e5050f6fb1308c6289addcabf68102fc77
-  tag: 0.9.4
+  revision: 5490201a035cb66ce6cf92109a00036151f8415b
+  tag: 0.9.5
   specs:
-    govuk-design-system-rails (0.9.4)
+    govuk-design-system-rails (0.9.5)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Upgrades `govuk-design-system-rails` to `0.9.5` to fix the input styling bug described at: https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails/pull/58