### PR TITLE
Improve smoke test reliability

### DIFF
--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -44,10 +44,10 @@ RSpec.feature "Search smoke test" do
       sleep attempts * 10
     end
 
-    expect(@session).to have_current_path("/cases/your-cases")
+    expect(@session).to have_current_path("/")
 
-    @session.click_link "Cases", wait: 60
-    @session.click_link "All cases"
+    @session.click_link "All cases", wait: 60
+
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(3)")
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(13)")
   end

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -33,6 +33,8 @@ RSpec.feature "Search smoke test" do
 
     attempts = 0
     loop do
+      puts "Attempting 2FA (#{attempts + 1})..."
+
       code = get_code
       break unless code && @session.has_current_path?(/\/two-factor/) && attempts < 4
 
@@ -42,7 +44,9 @@ RSpec.feature "Search smoke test" do
       sleep attempts * 10
     end
 
-    @session.click_link "Cases"
+    expect(@session).to have_current_path("/cases/your-cases")
+
+    @session.click_link "Cases", wait: 60
     @session.click_link "All cases"
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(3)")
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(13)")


### PR DESCRIPTION
The smoke test after deployment has become unreliable as the "Cases" homepage sometimes takes too long to respond after a fresh deployment. This PR adds some debug logging around 2FA to the smoke test to allow us to diagnose any issues around the number of 2FA attempts, and increases the maximum wait time for the cases page to 60 seconds.
