### PR TITLE
Revert "Improve smoke test reliability" and try again

### DIFF
--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -33,8 +33,6 @@ RSpec.feature "Search smoke test" do
 
     attempts = 0
     loop do
-      puts "Attempting 2FA (#{attempts + 1})..."
-
       code = get_code
       break unless code && @session.has_current_path?(/\/two-factor/) && attempts < 4
 
@@ -44,10 +42,8 @@ RSpec.feature "Search smoke test" do
       sleep attempts * 10
     end
 
-    expect(@session).to have_current_path("/")
-
-    @session.click_link "All cases", wait: 60
-
+    @session.click_link "Cases"
+    @session.click_link "All cases"
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(3)")
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(13)")
   end

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -33,6 +33,8 @@ RSpec.feature "Search smoke test" do
 
     attempts = 0
     loop do
+      puts "Attempting 2FA (#{attempts + 1})..."
+
       code = get_code
       break unless code && @session.has_current_path?(/\/two-factor/) && attempts < 4
 
@@ -42,8 +44,9 @@ RSpec.feature "Search smoke test" do
       sleep attempts * 10
     end
 
-    @session.click_link "Cases"
-    @session.click_link "All cases"
+    @session.click_link "Cases", wait: 60
+    @session.click_link "All cases", wait: 60
+
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(3)")
     expect(@session).to have_css("tbody.govuk-table__body:nth-child(13)")
   end


### PR DESCRIPTION
Reverts OfficeForProductSafetyAndStandards/product-safety-database#2089.

The smoke test users in various environments are different types, so it's not possible to determine which path the smoke test will land on.

This PR follows the old logic of clicking Cases > All cases, which is common to both landing pages, and not checking the path explicitly.