### PR TITLE
Skip review app deployment for Dependabot PRs

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -9,6 +9,10 @@ jobs:
   reviewapp:
     name: Deploy
     runs-on: ubuntu-latest
+    # Skip if it is a Dependabot created PR.
+    # For security reasons they do not have write permissions to deploy or access to secrets.
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The access token used by Dependabot does not have write access to the repository, and therefore no access to the secrets required to deploy the review apps.

This change will prevent the review app step being run in this event. As before, if a user with write access updates the branch the review app will still deploy as normal. This means we can choose to merge dependency updates without requiring a review app deployment beforehand.