### PR TITLE
Create case from product record

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -30,6 +30,7 @@ class Investigations::TsInvestigationsController < ApplicationController
       @case_name_form = CaseNameForm.new
     when :case_created
       @investigation = session[:investigation]
+      @product = Product.find(session[:product_id])
       @investigation.build_owner_collaborations_from(current_user)
       CreateCase.call(investigation: session[:investigation], user: current_user, product: Product.find(session[:product_id]))
       clear_session

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -31,7 +31,7 @@ class Investigations::TsInvestigationsController < ApplicationController
     when :case_created
       @investigation = session[:investigation]
       @investigation.build_owner_collaborations_from(current_user)
-      CreateCase.call(investigation: session[:investigation], user: current_user)
+      CreateCase.call(investigation: session[:investigation], user: current_user, product: Product.find(session[:product_id]))
       clear_session
     end
 
@@ -40,6 +40,7 @@ class Investigations::TsInvestigationsController < ApplicationController
 
   def new
     clear_session
+    session[:product_id] = params[:product_id]
     redirect_to wizard_path(steps.first)
   end
 
@@ -90,6 +91,7 @@ private
   def clear_session
     session.delete :form_answers
     session.delete :investigation
+    session.delete :product_id
   end
 
   def redirect_to_first_step_if_wizard_not_started
@@ -99,7 +101,7 @@ private
   def reason_for_creating_params
     return {} unless params[:investigation]
 
-    params.require(:investigation).permit(:case_is_safe)
+    params.require(:investigation).permit(:case_is_safe, :product_id)
   end
 
   def reason_for_concern_params

--- a/app/forms/reason_for_creating_form.rb
+++ b/app/forms/reason_for_creating_form.rb
@@ -4,6 +4,7 @@ class ReasonForCreatingForm
   include ActiveModel::Serialization
 
   attribute :case_is_safe, :string
+  attribute :product_id, :integer
 
   validates :case_is_safe, inclusion: { in: %w[yes no] }
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -97,7 +97,7 @@ module InvestigationsHelper
   end
 
   def product_overview_rows(product)
-    product_record_owner_value = product.owning_team_id ? Team.find_by(owning_team_id: product.owning_team_id).name : nil
+    product_record_owner_value = product.owning_team_id ? Team.find_by(id: product.owning_team_id).name : nil
     [
       {
         key: { text: "Last updated" },

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -97,6 +97,7 @@ module InvestigationsHelper
   end
 
   def product_overview_rows(product)
+    product_record_owner_value = product.owning_team_id ? Team.find_by(owning_team_id: product.owning_team_id).name : nil
     [
       {
         key: { text: "Last updated" },
@@ -108,7 +109,7 @@ module InvestigationsHelper
       },
       {
         key: { text: "Product record owner" },
-        value: { text: "" }
+        value: { text: product_record_owner_value }
       }
     ]
   end

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -5,6 +5,7 @@ class AddProductToCase
   delegate :investigation,
            :user,
            :product,
+           :skip_email,
            to: :context
 
   def call
@@ -22,7 +23,7 @@ class AddProductToCase
 
     context.activity = create_audit_activity_for_product_added
 
-    send_notification_email
+    send_notification_email unless skip_email
   end
 
 private

--- a/app/services/create_case.rb
+++ b/app/services/create_case.rb
@@ -6,7 +6,7 @@ class CreateCase
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
-    context.fail!(error: "Product must be supplied for non opss users") if (!user.is_opss? && !product.is_a?(Product))
+    context.fail!(error: "Product must be supplied for non opss users") if !user.is_opss? && !product.is_a?(Product)
     team = user.team
 
     investigation.creator_user = user
@@ -25,7 +25,7 @@ class CreateCase
 
       investigation.save!
 
-      AddProductToCase.call!(investigation: investigation, product: product, user: user, skip_email: true) if product
+      AddProductToCase.call!(investigation:, product:, user:, skip_email: true) if product
 
       create_audit_activity_for_case_added
     end

--- a/app/services/create_case.rb
+++ b/app/services/create_case.rb
@@ -25,19 +25,9 @@ class CreateCase
 
       investigation.save!
 
-      if !user.is_opss?
-        InvestigationProduct.create(investigation_id: investigation.id, product_id: product.id)
-      end
+      AddProductToCase.call!(investigation: investigation, product: product, user: user, skip_email: true) if product
 
-      product.update!(owning_team_id: user.team.id) if (product && product.owning_team_id.nil?)
-      
       create_audit_activity_for_case_added
-
-      # When a case is created we don't want to send notification emails as in
-      # the AddProductToCase service
-      investigation.products.each do |product|
-        create_audit_activity_for_product_added(product)
-      end
     end
 
     send_confirmation_email
@@ -59,15 +49,6 @@ private
       title: nil,
       body: nil,
       metadata:
-    )
-  end
-
-  def create_audit_activity_for_product_added(product)
-    AuditActivity::Product::Add.create!(
-      added_by_user: user,
-      investigation:,
-      title: product.name,
-      product:
     )
   end
 

--- a/app/views/investigations/ts_investigations/case_created.html.erb
+++ b/app/views/investigations/ts_investigations/case_created.html.erb
@@ -13,11 +13,10 @@
   <h2 class="govuk-heading-m">What happens next</h2>
 
   <p class="govuk-body">
-    A basic case record has been created. You can now add more information to the case whenever you want to. For example, you can:
+    The case has been created and includes the product record <%= @product.psd_ref %>. You can now add more information to the case whenever you want to. For example, you can:
   </p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>add a product</li>
     <li>add a business</li>
     <li>add case images</li>
     <li>add documents</li>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -20,6 +20,10 @@
         <%= "Updated: " + @product.updated_at.to_s(:govuk) %>
       <% end %>
     </p>
+
+    <% unless current_user.is_opss? %>
+      <%= link_to "Create a new case for this product", new_investigation_ts_investigation_path(product_id: @product.id) %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third govuk-!-margin-top-7">

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_opensearch, :with_stubbed_m
   let(:organisation)  { create :organisation }
   let(:user)          { create(:user, organisation:).decorate }
   let(:team)          { create(:team) }
-  let(:creator)       { create(:user, organisation:, team:) }
+  let(:creator)       { create(:user, :opss_user, organisation:, team:) }
   let(:products)      { [] }
   let(:risk_level)    { :serious }
   let(:coronavirus_related) { false }

--- a/spec/factories/investigations.rb
+++ b/spec/factories/investigations.rb
@@ -110,7 +110,11 @@ FactoryBot.define do
     # We need to do this before rather than after create because database
     # constraints on pretty_id need to be satisfied
     before(:create) do |investigation, options|
-      CreateCase.call(investigation:, user: options.creator)
+      if options.creator.is_opss?
+        CreateCase.call(investigation:, user: options.creator)
+      else
+        CreateCase.call(investigation:, user: options.creator, product: create(:product))
+      end
     end
 
     after(:create) do |investigation, evaluator|

--- a/spec/factories/investigations.rb
+++ b/spec/factories/investigations.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     non_compliant_reason  {}
 
     transient do
-      creator { create(:user, :activated) }
+      creator { create(:user, :activated, :opss_user) }
       read_only_teams { [] }
       edit_access_teams { [] }
     end
@@ -109,6 +109,7 @@ FactoryBot.define do
 
     # We need to do this before rather than after create because database
     # constraints on pretty_id need to be satisfied
+    # Cases created by non OPSS users must have a product assigned to them.
     before(:create) do |investigation, options|
       if options.creator.is_opss?
         CreateCase.call(investigation:, user: options.creator)

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_opensearch, :w
   let(:risk_assessment_file) { Rails.root.join "test/fixtures/files/new_risk_assessment.txt" }
   let(:team) { create(:team, name: "MyCouncil Trading Standards") }
 
-  let(:user) { create(:user, :activated, has_viewed_introduction: true, team:, name: "Jo Bloggs") }
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, team:, name: "Jo Bloggs") }
 
   let(:product1) { create(:product_washing_machine, name: "MyBrand washing machine model X") }
   let(:product2) { create(:product_washing_machine, name: "MyBrand washing machine model Y") }

--- a/spec/features/add_product_to_case_spec.rb
+++ b/spec/features/add_product_to_case_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Adding a product to a case", :with_stubbed_mailer, :with_stubbed_opensearch do
-  let(:user)          { create(:user, :activated) }
+  let(:user)          { create(:user, :opss_user, :activated) }
   let(:investigation) { create(:enquiry, creator: user) }
   let(:other_user)    { create(:user, :activated) }
   let(:right_product) { create(:product) }

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true) }
   let(:product) { create(:product_washing_machine, name: "MyBrand washing machine") }
   let(:investigation) { create(:allegation, products: [product], creator: user) }
   let(:date) { Date.parse("1 Jan 2020") }

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Case actions", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
-  let(:user) { create :user, :activated, has_viewed_introduction: true }
+  let(:user) { create :user, :opss_user, :activated, has_viewed_introduction: true }
   let(:investigation_1) { create :allegation, creator: user }
   let(:washing_machine) { create :product_washing_machine }
   let(:investigation_2) { create :allegation, products: [washing_machine], creator: user }

--- a/spec/features/case_specific_information_spec.rb
+++ b/spec/features/case_specific_information_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Case specific information spec", :with_stubbed_opensearch, :with_stubbed_mailer do
   let(:team) { create :team }
   let(:other_team) { create :team }
-  let(:user) { create :user, :activated, has_viewed_introduction: true, team: }
+  let(:user) { create :user, :opss_user, :activated, has_viewed_introduction: true, team: }
   let(:team_mate) { create :user, :activated, has_viewed_introduction: true, team: }
   let(:other_user) { create :user, :activated, has_viewed_introduction: true, team: other_team }
   let(:investigation) { create :allegation, creator: user }

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :feature do
   let(:team) { create :team }
-  let(:user) { create :user, :activated, has_viewed_introduction: true, team: }
+  let(:user) { create :user, :opss_user, :activated, has_viewed_introduction: true, team: }
 
   before do
     sign_in user

--- a/spec/features/create_case_as_ts_user_spec.rb
+++ b/spec/features/create_case_as_ts_user_spec.rb
@@ -12,11 +12,14 @@ RSpec.feature "Creating a case as a TS user", :with_stubbed_opensearch, :with_st
   let(:non_compliant_reason) { "does not comply with laws" }
   let(:reference_number) { "12345" }
   let(:case_name) { "Red hot case" }
+  let(:product) { create(:product) }
 
   scenario "Opening a new case (with validation error)" do
     sign_in(user)
 
-    click_link "Create a case"
+    visit "/products/#{product.id}"
+
+    click_link "Create a new case for this product"
 
     expect(page).to have_css("h1", text: "Why are you creating a case?")
 
@@ -98,6 +101,9 @@ RSpec.feature "Creating a case as a TS user", :with_stubbed_opensearch, :with_st
 
     expect(page).to have_current_path("/cases/#{Investigation.last.pretty_id}")
     expect_summary_page_to_contain_correct_data
+
+    click_link "Products (1)"
+    expect(page.find("dt", text: "PSD ref")).to have_sibling("dd", text: product.psd_ref)
   end
 
   context "when a case is safe and compliant" do

--- a/spec/features/remove_product_from_a_case_spec.rb
+++ b/spec/features/remove_product_from_a_case_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Remove product from investigation", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
-  let(:user)           { create(:user, :activated) }
+  let(:user)           { create(:user, :opss_user, :activated) }
   let(:investigation)  { create(:enquiry, :with_products, creator: user) }
   let(:removal_reason) { "I made a mistake" }
   let(:product)        { investigation.products.first }

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
   let!(:organisation) { create(:organisation) }
   let!(:team) { create(:team, organisation:) }
   let!(:other_team) { create(:team, organisation:) }
-  let!(:user) { create(:user, :activated, organisation:, team:, has_viewed_introduction: true) }
-  let!(:other_user_other_team) { create(:user, :activated, name: "other user same team", organisation:, team: other_team) }
+  let!(:user) { create(:user, :activated, :opss_user, organisation:, team:, has_viewed_introduction: true) }
+  let!(:other_user_other_team) { create(:user, :activated, :opss_user, name: "other user same team", organisation:, team: other_team) }
   let!(:investigation) { create(:allegation, creator: user).decorate }
   let!(:other_team_investigation) { create(:allegation, creator: other_user_other_team, is_private: true).decorate }
   let(:params) { { case_type: "all", sort_by: "recent", created_by: "all", case_status: "open", teams_with_access: "all" } }

--- a/spec/services/add_product_to_case_spec.rb
+++ b/spec/services/add_product_to_case_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AddProductToCase, :with_stubbed_opensearch, :with_test_queue_adapter do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :opss_user) }
   let(:investigation) { create(:allegation, creator: user) }
   let(:product) { create(:product) }
 

--- a/spec/services/create_case_spec.rb
+++ b/spec/services/create_case_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
   let(:investigation) { build(:enquiry, creator: user) }
   let(:user) { create(:user) }
+  let(:product) { create(:product) }
+  let(:other_team) { create(:team) }
 
   describe ".call" do
     context "with no parameters" do
@@ -14,7 +16,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
     end
 
     context "with no investigation parameter" do
-      let(:result) { described_class.call(user:) }
+      let(:result) { described_class.call(user:, product:) }
 
       it "returns a failure" do
         expect(result).to be_failure
@@ -22,15 +24,36 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
     end
 
     context "with no user parameter" do
-      let(:result) { described_class.call(investigation:) }
+      let(:result) { described_class.call(investigation:, product:) }
 
       it "returns a failure" do
         expect(result).to be_failure
       end
     end
 
+    context "when user is opss" do
+      context "with no product parameter" do
+        let(:result) { described_class.call(investigation:, user:) }
+
+        it "does not return a failure" do
+          allow(user).to receive(:is_opss?) { true }
+          expect(result).to be_success
+        end
+      end
+    end
+
+    context "when user is not opss" do
+      context "with no product parameter" do
+        let(:result) { described_class.call(investigation:, user:) }
+
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+    end
+
     context "with required parameters" do
-      let(:result) { described_class.call(investigation:, user:) }
+      let(:result) { described_class.call(investigation:, user:, product:) }
 
       it "returns success" do
         expect(result).to be_success
@@ -68,7 +91,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
       context "with previous investigations" do
         let(:investigations) { build_list(:enquiry, 3, creator: user) }
 
-        before { investigations.each { |i| described_class.call(investigation: i, user:) } }
+        before { investigations.each { |i| described_class.call(investigation: i, user:, product:) } }
 
         it "generates a successive pretty_id", :aggregate_failures do
           expect(Investigation.pluck(:pretty_id).map { |id| id.split("-").last })
@@ -88,15 +111,14 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
 
       it "creates an audit activity for case created", :aggregate_failures do
         result
-        activity = investigation.reload.activities.first
+        activity = investigation.reload.activities.last
         expect(activity).to be_a(AuditActivity::Investigation::AddEnquiry)
         expect(activity.added_by_user).to eq(user)
         expect(activity.metadata).to eq(AuditActivity::Investigation::AddEnquiry.build_metadata(investigation).deep_stringify_keys)
       end
 
       context "when there are products added to the case" do
-        let(:investigation) { build(:allegation, products: [product], creator: user) }
-        let(:product) { create(:product_washing_machine) }
+        let(:investigation) { build(:allegation, creator: user) }
 
         it "creates an audit activity for product added", :aggregate_failures do
           result
@@ -116,6 +138,21 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
           "test enquiry title",
           "enquiry"
         )
+      end
+
+      context "when the product is previously unowned" do
+        it "product becomes owned by the team of the user creating the investigation" do
+          result
+          expect(product.reload.owning_team_id).to eq user.team.id
+        end
+      end
+
+      context "when the product is already owned" do
+        it "the product remains owned by the previous owner" do
+          product.update!(owning_team_id: other_team.id)
+          result
+          expect(product.owning_team_id).to eq other_team.id
+        end
       end
     end
   end

--- a/spec/services/create_case_spec.rb
+++ b/spec/services/create_case_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
-  let(:investigation) { build(:enquiry, creator: user) }
+  let(:investigation) { build(:enquiry) }
   let(:user) { create(:user) }
   let(:product) { create(:product) }
   let(:other_team) { create(:team) }
@@ -89,7 +89,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
       end
 
       context "with previous investigations" do
-        let(:investigations) { build_list(:enquiry, 3, creator: user) }
+        let(:investigations) { build_list(:enquiry, 3) }
 
         before { investigations.each { |i| described_class.call(investigation: i, user:, product:) } }
 
@@ -111,7 +111,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
 
       it "creates an audit activity for case created", :aggregate_failures do
         result
-        activity = investigation.reload.activities.last
+        activity = investigation.reload.activities.first
         expect(activity).to be_a(AuditActivity::Investigation::AddEnquiry)
         expect(activity.added_by_user).to eq(user)
         expect(activity.metadata).to eq(AuditActivity::Investigation::AddEnquiry.build_metadata(investigation).deep_stringify_keys)
@@ -122,7 +122,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
 
         it "creates an audit activity for product added", :aggregate_failures do
           result
-          activity = investigation.reload.activities.first
+          activity = investigation.reload.activities.last
           expect(activity).to be_a(AuditActivity::Product::Add)
           expect(activity.added_by_user).to eq(user)
           expect(activity.product).to eq(product)

--- a/spec/services/create_case_spec.rb
+++ b/spec/services/create_case_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CreateCase, :with_stubbed_opensearch, :with_test_queue_adapter do
         let(:result) { described_class.call(investigation:, user:) }
 
         it "does not return a failure" do
-          allow(user).to receive(:is_opss?) { true }
+          allow(user).to receive(:is_opss?).and_return(true)
           expect(result).to be_success
         end
       end

--- a/spec/services/remove_product_from_case_spec.rb
+++ b/spec/services/remove_product_from_case_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RemoveProductFromCase, :with_test_queue_adapter do
   let(:investigation) { create(:allegation, products: [product], creator:) }
   let(:product)       { create(:product_washing_machine) }
   let(:reason)        { Faker::Hipster.sentence }
-  let(:user)          { create(:user) }
+  let(:user)          { create(:user, :opss_user) }
   let(:creator)       { user }
   let(:owner)         { user }
 

--- a/spec/support/shared_contexts/add_corrective_action_context.rb
+++ b/spec/support/shared_contexts/add_corrective_action_context.rb
@@ -1,5 +1,5 @@
 RSpec.shared_context "with add corrective action setup" do
-  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true) }
   let(:product) { create(:product_washing_machine, name: "MyBrand Washing Machine") }
   let(:products) { [product] }
   let(:investigation) { create(:allegation, :with_business, products:, creator: user, read_only_teams: read_only_team) }


### PR DESCRIPTION
https://trello.com/c/9hL8XPMo/1559-create-a-case-directly-from-the-product-record-cap022

## Description
This ticket forces TS users to open cases from a product. This means that a case opened by a TS user must always have a product associated with it which has caused quite a few tests to need to be changed. For this reason I have made some changes to the investigation factory, defaulting the case creator to be an OPSS user so as to not force us to create products for every investigation by default.


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
