### PR TITLE
Use a .profile file to set up the app environment

### DIFF
--- a/.github/workflows/publish-production-redacted-export.yml
+++ b/.github/workflows/publish-production-redacted-export.yml
@@ -124,7 +124,7 @@ jobs:
           cf delete-service $TEMP_DB_SERVICE_NAME -f
 
           echo "Exporting files..."
-          cf run-task $APP_NAME --name 'redacted-export-s3-copy' --command 'export $(./env/get-env-from-vcap.sh) && bin/rails redacted_export:copy_s3_objects' --wait
+          cf run-task $APP_NAME --name 'redacted-export-s3-copy' --command 'bin/rails redacted_export:copy_s3_objects' --wait
 
           cf logout
 

--- a/.github/workflows/publish-staging-redacted-export.yml
+++ b/.github/workflows/publish-staging-redacted-export.yml
@@ -124,7 +124,7 @@ jobs:
           cf delete-service $TEMP_DB_SERVICE_NAME -f
 
           echo "Exporting files..."
-          cf run-task $APP_NAME --name 'redacted-export-s3-copy' --command 'export $(./env/get-env-from-vcap.sh) && bin/rails redacted_export:copy_s3_objects' --wait
+          cf run-task $APP_NAME --name 'redacted-export-s3-copy' --command 'bin/rails redacted_export:copy_s3_objects' --wait
 
           cf logout
 

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -76,7 +76,7 @@ jobs:
         cf auth
         cf target -o 'beis-opss' -s $SPACE
         export APP_NAME=psd-pr-$PR_NUMBER
-        cf run-task $APP_NAME -c "export \$(./env/get-env-from-vcap.sh) && rails opensearch:index" --name add-opensearch-indexes -k 2G
+        cf run-task $APP_NAME -c "bin/rails opensearch:index" --name add-opensearch-indexes -k 2G
         task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks psd-pr-$PR_NUMBER | grep add-opensearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
 
     - name: Update deployment status (success)

--- a/.profile
+++ b/.profile
@@ -1,0 +1,3 @@
+# See: https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile
+#   Extracts and exports Rails config from VCAP_SERVICES
+export $(./env/get-env-from-vcap.sh)

--- a/bin/tll
+++ b/bin/tll
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/tmp/lifecycle/launcher /home/vcap/app "$*" ""

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -169,7 +169,7 @@ You'll need an account for [GOV.UK PaaS](https://admin.london.cloud.service.gov.
 
 We're using [user-provided services](https://docs.cloudfoundry.org/devguide/services/user-provided.html#deliver-service-credentials-to-an-app) to load environment variables into our applications.
 
-Running [get-env-from-vcap.sh](./infrastructure/env/get-env-from-vcap.sh) as part of the application startup will add credentials from any service named `*-env` to the current environment.
+The app's `.profile` [automatically initialises](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile) environment variables using [get-env-from-vcap.sh](./infrastructure/env/get-env-from-vcap.sh) as part of the application startup. This will add credentials from any service named `*-env` to the current environment.
 
 #### Domains
 

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -9,7 +9,7 @@ The `-k 2G` option specifies a disk quota of 2GB, as the default of 1GB is not c
 ## Create a new organisation, team, and team admin user
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && ORG_NAME=<name> ADMIN_EMAIL=<email address> bin/rake organisation:create" --name <task name> -k 2G
+cf run-task psd-web --command "ORG_NAME=<name> ADMIN_EMAIL=<email address> bin/rake organisation:create" --name <task name> -k 2G
 ```
 
 Where `ORG_NAME` is the name of the organisation and team to be created, `ADMIN_EMAIL` is the email address of the new team admin user to be created and `COUNTRY` is the country in which the team is based. ( For countries use the ISO codes found [here] (https://github.com/alphagov/govuk-country-and-territory-autocomplete/blob/master/dist/location-autocomplete-canonical-list.json) or the following: England = "country:GB-ENG", Scotland = "country:GB-SCT", Wales = "country:GB-WLS", Northern Ireland = "country:GB-NIR") They will receive an invitation email to create their account. Task name can be set to anything you like.
@@ -17,13 +17,13 @@ Where `ORG_NAME` is the name of the organisation and team to be created, `ADMIN_
 ## Deleting a User
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && EMAIL=<email address> rake user:delete" --name <task name> -k 2G
+cf run-task psd-web --command "EMAIL=<email address> bin/rake user:delete" --name <task name> -k 2G
 ```
 
 or
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && ID=<user ID> rake user:delete" --name <task name> -k 2G
+cf run-task psd-web --command "ID=<user ID> bin/rake user:delete" --name <task name> -k 2G
 ```
 
 Where `EMAIL` or `ID` is the e-mail address or ID of the user to be deleted. Task name can be set to anything you like.
@@ -31,7 +31,7 @@ Where `EMAIL` or `ID` is the e-mail address or ID of the user to be deleted. Tas
 ## Deleting a Team
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && ID=<id> NEW_TEAM_ID=<id> EMAIL=<email address> rake team:delete" --name <task name> -k 2G
+cf run-task psd-web --command "ID=<id> NEW_TEAM_ID=<id> EMAIL=<email address> bin/rake team:delete" --name <task name> -k 2G
 ```
 
 Case collaborations and users which belong to the team identified by `ID` will be migrated to another team identified by `NEW_TEAM_ID`. The user identified by `EMAIL` will be attributed to the change on all relevant audit activity.
@@ -41,7 +41,7 @@ Case collaborations and users which belong to the team identified by `ID` will b
 Sometimes we need to update the structure of metadata stored against an activity type. We provide a task which can be used instead of ActiveRecord migrations to more safely migrate the data asynchronously to avoid problems with deployment timeouts and multiple versions of the code resulting in errors.
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && CLASS_NAME=<activity class name> rake activities:update_metadata" --name <task name> -k 2G
+cf run-task psd-web --command "CLASS_NAME=<activity class name> bin/rake activities:update_metadata" --name <task name> -k 2G
 ```
 
 To implement a conversion, override the `metadata` getter method on the class being changed to return legacy activity metadata in the new format. This task will invoke the overridden getter method and update each instance with the new structure.
@@ -67,7 +67,7 @@ The way to do this on the deployed service is a little different and it's best d
 Risk Assessment and Test Result user uploads are also exported to S3. These are copied to a separate bucket using an S3 Batch Operation job. This is usually done as part of the [same workflow which exports the database](/.github/workflows/publish-staging-redacted-export.yml), however it can be triggered manually:
 
 ```bash
-cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && bin/rails redacted_export:copy_s3_objects" --name <task name> -k 2G --wait
+cf run-task psd-web --command "bin/rails redacted_export:copy_s3_objects" --name <task name> -k 2G --wait
 cf logs psd-web --recent
 ```
 

--- a/doc/using-cloud-foundry.md
+++ b/doc/using-cloud-foundry.md
@@ -14,8 +14,11 @@ cf login -a api.london.cloud.service.gov.uk -u some@email.com
 
 ```
 cf ssh APP-NAME
+/tmp/lifecycle/launcher /home/vcap/app 'bin/rails c' ''
 
-cd app && export $(./env/get-env-from-vcap.sh) && /tmp/lifecycle/launcher /home/vcap/app 'rails c' ''
+# There is a shorthand alias:
+cd app
+bin/tll bin/rails c
 ```
 
 #### List apps

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -38,11 +38,11 @@ applications:
     - psd-redacted-export-env
   processes:
     - type: web
-      command: export $(./env/get-env-from-vcap.sh) && bin/rake cf:on_first_instance db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+      command: bin/rake cf:on_first_instance db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
       memory: 2G
     - type: worker
-      command: export $(./env/get-env-from-vcap.sh) && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
+      command: RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 1
       memory: 500M

--- a/manifest.yml
+++ b/manifest.yml
@@ -34,12 +34,12 @@ applications:
     - psd-redacted-export-env
   processes:
     - type: web
-      command: export $(./env/get-env-from-vcap.sh) && bin/rake cf:on_first_instance db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+      command: bin/rake cf:on_first_instance db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: ((web-instances))
       memory: ((web-memory))
       disk_quota: ((web-disk-quota))
     - type: worker
-      command: export $(./env/get-env-from-vcap.sh) && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
+      command: RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: ((worker-instances))
       memory: ((worker-memory))


### PR DESCRIPTION
The project had a common initialisation task of destructuting some JSON stored in the `VCAP_SERVICES` environment variable and exporting several other environment variables reflecting Rails' config. This is a common pattern in applications deployed to Cloud Foundary.

This PR uses the [newer method of app initialization, using a `.profile` file](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile).

It also provides a shorthand for running processes within a launched environment:

```sh
cd app
/tmp/lifecycle/launcher /home/vcap/app 'bin/rails c' ''
# becomes...
bin/tll bin/rails c
```

This work was spurred on by https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2650/commits/0ce88a866dd7269dba0fcb9573de0e56db0418fa.