### PR TITLE
Case to product page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "validate_email", "~> 0.1"
 gem "webpacker", "~> 5.4"
 gem "wicked", "~> 2.0"
 
-gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.5", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails", tag: "0.9.6", require: "govuk_design_system"
 
 gem "bootsnap"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/OfficeForProductSafetyAndStandards/govuk-design-system-rails
-  revision: 5490201a035cb66ce6cf92109a00036151f8415b
-  tag: 0.9.5
+  revision: 78d74f03891347f69ec7bde3bd5d01c90b0d2f21
+  tag: 0.9.6
   specs:
-    govuk-design-system-rails (0.9.5)
+    govuk-design-system-rails (0.9.6)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/create_a_case_page_controller.rb
+++ b/app/controllers/create_a_case_page_controller.rb
@@ -1,0 +1,2 @@
+class CreateACasePageController < ApplicationController
+end

--- a/app/views/create_a_case_page/index.html.erb
+++ b/app/views/create_a_case_page/index.html.erb
@@ -1,0 +1,55 @@
+<%= page_title "Create a case" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+
+          <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
+              Create a case
+          </h1>
+
+          <% inset_html = capture do %>
+              <p class="govuk-body-l govuk-!-margin-bottom-4">
+                  Creating a case starts from a product record page.
+              </p>
+
+              <p class="govuk-body">
+                  Find a product and create the case from there.
+              </p>
+
+              <%= govukDetails(summaryText: "How to create a case") do %>
+                <ol class="govuk-list govuk-list--number govuk-list--spaced">
+                  <li>
+                    In the products area <%= link_to "search for your product", products_path, class: "govuk-link govuk-link--no-visited-state" %>
+                  </li>
+                  <li>
+                    Select a product record to view the product record page
+                  </li>
+                  <li>
+                    Select the '<span class="govuk-!-font-weight-bold">Create a new case for this product</span>' option
+                  </li>
+                </ol>
+
+                <p class="govuk-body">
+                  When you have finished creating the case, the product record will automatically be included.
+                </p>
+
+                <p class="govuk-body">
+                  If a suitable product record does not already exist, create a new product record and then create your case from that product record.
+                </p>
+              <% end %>
+          <% end %>
+
+          <%= govukInsetText({
+            html: inset_html,
+            classes: "govuk-!-margin-bottom-7"
+          }) %>
+
+          <%= link_to "Go to the products search page", products_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-24" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/homepage/non_opss.html.erb
+++ b/app/views/homepage/non_opss.html.erb
@@ -9,7 +9,7 @@
     </p>
     <%= govukButton(
       text: t(:create_case),
-      href: new_ts_investigation_path,
+      href: create_a_case_page_index_path,
       classes: "govuk-button--start",
     ) %>
   </div>

--- a/app/views/investigations/_create_a_case_link.html.erb
+++ b/app/views/investigations/_create_a_case_link.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-one-third">
   <div class="opss-text-align-right govuk-!-margin-bottom-8">
     <%= link_to "Create a case",
-      current_user.is_opss? ? new_investigation_path : new_ts_investigation_path,
+      current_user.is_opss? ? new_investigation_path : create_a_case_page_index_path,
       class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset",
       role: "button"
     %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
     get :skip
   end
 
+  resources :create_a_case_page, controller: "create_a_case_page", only: %i[index]
+
   resources :enquiry, controller: "investigations/enquiry", only: %i[show new create update]
   resources :allegation, controller: "investigations/allegation", only: %i[show new create update]
   resources :project, controller: "investigations/project", only: %i[show new create update]

--- a/spec/features/create_case_as_ts_user_spec.rb
+++ b/spec/features/create_case_as_ts_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Creating a case as a TS user", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
+RSpec.feature "Creating a case as a TS user", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
   let(:user) { create(:user, :activated) }
   let(:investigation_with_same_user_title) do
     create(:allegation,
@@ -12,12 +12,20 @@ RSpec.feature "Creating a case as a TS user", :with_stubbed_opensearch, :with_st
   let(:non_compliant_reason) { "does not comply with laws" }
   let(:reference_number) { "12345" }
   let(:case_name) { "Red hot case" }
-  let(:product) { create(:product) }
+  let!(:product) { create(:product) }
+
+  before do
+    Product.import force: true, refresh: :wait_for
+  end
 
   scenario "Opening a new case (with validation error)" do
     sign_in(user)
 
-    visit "/products/#{product.id}"
+    click_link "Create a case"
+
+    click_link "Go to the products search page"
+
+    click_link product.name
 
     click_link "Create a new case for this product"
 
@@ -111,6 +119,12 @@ RSpec.feature "Creating a case as a TS user", :with_stubbed_opensearch, :with_st
       sign_in(user)
 
       click_link "Create a case"
+
+      click_link "Go to the products search page"
+
+      click_link product.name
+
+      click_link "Create a new case for this product"
 
       expect(page).to have_css("h1", text: "Why are you creating a case?")
 


### PR DESCRIPTION
https://trello.com/c/GprlgvMo/1595-create-a-case-link-and-redirect-page

## Description
This PR changes the create a case links for ts users to direct them to a new intermediary page that informs them that they need to create a case from a product record, and links them to the products page.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
