### PR TITLE
Fix invalid DOM IDs on sub-nav links

### DIFF
--- a/app/views/investigations/_sub_nav.html.erb
+++ b/app/views/investigations/_sub_nav.html.erb
@@ -9,7 +9,7 @@
   <ul class="govuk-list opss-left-nav">
     <% items.each do |item| %>
       <li class="<%= class_names("opss-left-nav__active" => item[:active]) %>">
-        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active]), id: "#{item[:text]}_id") do %>
+        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active]), id: "#{item[:text].underscore}_id") do %>
           <%= item[:html] || item[:text] + item[:count].to_s %>
         <% end %>
         <% if item[:active] && item[:sub_items] %>

--- a/app/views/investigations/_sub_nav.html.erb
+++ b/app/views/investigations/_sub_nav.html.erb
@@ -9,7 +9,7 @@
   <ul class="govuk-list opss-left-nav">
     <% items.each do |item| %>
       <li class="<%= class_names("opss-left-nav__active" => item[:active]) %>">
-        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active]), id: "#{item[:text].underscore}_id") do %>
+        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active]), id: "#{item[:text].parameterize(separator: "_")}_id") do %>
           <%= item[:html] || item[:text] + item[:count].to_s %>
         <% end %>
         <% if item[:active] && item[:sub_items] %>

--- a/app/views/investigations/_sub_nav.html.erb
+++ b/app/views/investigations/_sub_nav.html.erb
@@ -9,7 +9,7 @@
   <ul class="govuk-list opss-left-nav">
     <% items.each do |item| %>
       <li class="<%= class_names("opss-left-nav__active" => item[:active]) %>">
-        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active]), id: "#{item[:text].parameterize(separator: "_")}_id") do %>
+        <%= link_to(item[:href], class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if item[:active])) do %>
           <%= item[:html] || item[:text] + item[:count].to_s %>
         <% end %>
         <% if item[:active] && item[:sub_items] %>


### PR DESCRIPTION
https://trello.com/c/IR7vDyBV/1635-html-id-bug

## Description

Removes DOM IDs from the links on the case navigation menu. Some of the generated IDs were not valid HTML as they had spaces in them, and these IDs were never actually used.