### PR TITLE
Add Complainant_Reference to case export

### DIFF
--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -104,7 +104,8 @@ private
                      Date_Validated
                      Case_Creator_Team
                      Notifying_Country
-                     Reported_as]
+                     Reported_As
+                     Complainant_Reference]
   end
 
   def find_cases(ids)
@@ -144,7 +145,8 @@ private
       investigation.risk_validated_at,
       investigation.creator_user&.team&.name,
       country_from_code(investigation.notifying_country, Country.notifying_countries),
-      investigation.reported_reason
+      investigation.reported_reason,
+      investigation.complainant_reference
     ]
   end
 
@@ -175,7 +177,8 @@ private
       investigation.risk_validated_at,
       investigation.creator_user&.team&.name,
       country_from_code(investigation.notifying_country, Country.notifying_countries),
-      investigation.reported_reason
+      investigation.reported_reason,
+      "Restricted"
     ]
   end
 end

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -133,9 +133,13 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
       expect(sheet.cell(2, 25)).to eq "England"
       expect(sheet.cell(3, 25)).to eq "England"
 
-      expect(sheet.cell(1, 26)).to eq "Reported_as"
+      expect(sheet.cell(1, 26)).to eq "Reported_As"
       expect(sheet.cell(2, 26)).to eq investigation.reported_reason
       expect(sheet.cell(3, 26)).to eq other_team_investigation.reported_reason
+
+      expect(sheet.cell(1, 27)).to eq "Complainant_Reference"
+      expect(sheet.cell(2, 27)).to eq investigation.complainant_reference
+      expect(sheet.cell(3, 27)).to eq other_team_investigation.complainant_reference
     end
     # rubocop:enable RSpec/MultipleExpectations
     # rubocop:enable RSpec/ExampleLength

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 27)).to eq "Complainant_Reference"
       expect(sheet.cell(2, 27)).to eq investigation.complainant_reference
-      expect(sheet.cell(3, 27)).to eq other_team_investigation.complainant_reference
+      expect(sheet.cell(3, 27)).to eq "Restricted"
     end
     # rubocop:enable RSpec/MultipleExpectations
     # rubocop:enable RSpec/ExampleLength

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -217,8 +217,20 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         get generate_case_exports_path
 
         aggregate_failures do
-          expect(exported_data.cell(1, 26)).to eq "Reported_as"
+          expect(exported_data.cell(1, 26)).to eq "Reported_As"
           expect(exported_data.cell(2, 26)).to eq "unsafe"
+        end
+      end
+
+      it "exports complainant_reference" do
+        create(:allegation, complainant_reference: "testing")
+        Investigation.import refresh: true, force: true
+
+        get generate_case_exports_path
+
+        aggregate_failures do
+          expect(exported_data.cell(1, 27)).to eq "Complainant_Reference"
+          expect(exported_data.cell(2, 27)).to eq "testing"
         end
       end
 
@@ -310,7 +322,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         end
 
         context "when user is not on the team that owns the case" do
-          it "does not show description, title and user owner name" do
+          it "does not show description, title, user owner name, or complainant reference" do
             other_team = create(:team)
             other_user = create(:user, team: other_team)
             create(:allegation, creator: other_user, is_private: true)
@@ -328,6 +340,9 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
               expect(exported_data.cell(1, 11)).to eq "Case_Owner_User"
               expect(exported_data.cell(2, 11)).to eq "Restricted"
+
+              expect(exported_data.cell(1, 27)).to eq "Complainant_Reference"
+              expect(exported_data.cell(2, 27)).to eq "Restricted"
             end
           end
         end


### PR DESCRIPTION
https://trello.com/c/B21OZf08/1658-include-trading-standards-reference-in-the-cases-export

## Description

Adds the following existing field (Complainant Reference) to the Case Export.

![image](https://user-images.githubusercontent.com/85587097/201706010-a13a90b8-aeb9-4c07-993a-20fde43208bc.png)

- Adds a new column to case export Excel sheets "Complainant_Reference"
- This will display as "Restricted" for restricted cases
- Will be null/blank if not set
- Changes the casing of "Reported_as" to be "Reported_As" in order to be consistent with the casing of other fields