### PR TITLE
Remove other options

### DIFF
--- a/config/constants/hazard_constants.yml
+++ b/config/constants/hazard_constants.yml
@@ -22,4 +22,3 @@ hazard_type:
   - Security
   - Strangulation
   - Suffocation
-  - Other

--- a/config/constants/product_constants.yml
+++ b/config/constants/product_constants.yml
@@ -37,4 +37,3 @@ product_category:
   - Stationery
   - Toys
   - Waste
-  - Other


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/PST1/boards/53?selectedIssue=PST1-1331

## Description
This change removes the "Other" option from the hazard type and product category drop-downs

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
