### PR TITLE
Cant close case with no products

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -39,7 +39,7 @@ class BusinessesController < ApplicationController
   def update
     respond_to do |format|
       if @business.save
-        @business.investigations.import
+        @business.investigations.not_deleted.import
         format.html { redirect_to @business, flash: { success: "Business was successfully updated." } }
         format.json { render :show, status: :ok, location: @business }
       else

--- a/app/controllers/investigations/status_controller.rb
+++ b/app/controllers/investigations/status_controller.rb
@@ -13,8 +13,7 @@ module Investigations
     def change_case_status(new_status:, template:, flash:)
       investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
       authorize investigation, :change_owner_or_status?
-
-      return redirect_to cannot_close_investigation_path(investigation) if investigation.products.count.zero? && new_status == "closed"
+      return redirect_to cannot_close_investigation_path(investigation) if policy(investigation).can_be_deleted? && new_status == "closed"
 
       @change_case_status_form = ChangeCaseStatusForm.from(investigation)
       @change_case_status_form.assign_attributes(change_case_status_form_params.merge(new_status:))

--- a/app/controllers/investigations/status_controller.rb
+++ b/app/controllers/investigations/status_controller.rb
@@ -14,6 +14,8 @@ module Investigations
       investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
       authorize investigation, :change_owner_or_status?
 
+      return redirect_to cannot_close_investigation_path(investigation) if investigation.products.count.zero? && new_status == "closed"
+
       @change_case_status_form = ChangeCaseStatusForm.from(investigation)
       @change_case_status_form.assign_attributes(change_case_status_form_params.merge(new_status:))
 

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -76,11 +76,9 @@ class InvestigationsController < ApplicationController
     render "investigations/index.html.erb"
   end
 
-  def cannot_close
-  end
+  def cannot_close; end
 
-  def confirm_deletion
-  end
+  def confirm_deletion; end
 
   def destroy
     authorize @investigation, :update?

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -2,7 +2,7 @@ class InvestigationsController < ApplicationController
   include InvestigationsHelper
 
   before_action :set_search_params, only: %i[index]
-  before_action :set_investigation, only: %i[show created cannot_close confirm_deletion]
+  before_action :set_investigation, only: %i[show created cannot_close confirm_deletion destroy]
   before_action :build_breadcrumbs, only: %i[show]
 
   # GET /cases
@@ -80,6 +80,19 @@ class InvestigationsController < ApplicationController
   end
 
   def confirm_deletion
+  end
+
+  def destroy
+    authorize @investigation, :update?
+
+    @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation, deleting_user: current_user)
+
+    if @delete_investigation_form.valid?
+      @investigation.mark_as_deleted!
+      redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }
+    else
+      redirect_to your_cases_investigations_path, flash: { notice: "The case could not be deleted" }
+    end
   end
 
 private

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -81,7 +81,7 @@ class InvestigationsController < ApplicationController
   def confirm_deletion; end
 
   def destroy
-    authorize @investigation, :update?
+    authorize @investigation, :change_owner_or_status?
 
     @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation, deleting_user: current_user)
 

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -89,7 +89,7 @@ class InvestigationsController < ApplicationController
       DeleteInvestigation.call!(investigation: @investigation, deleted_by: current_user)
       redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }
     else
-      redirect_to your_cases_investigations_path, flash: { notice: "The case could not be deleted" }
+      redirect_to your_cases_investigations_path, flash: { warning: "The case could not be deleted" }
     end
   end
 

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -86,7 +86,7 @@ class InvestigationsController < ApplicationController
     @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation, deleting_user: current_user)
 
     if @delete_investigation_form.valid?
-      @investigation.mark_as_deleted!
+      DeleteInvestigation.call!(investigation: @investigation, deleted_by: current_user)
       redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }
     else
       redirect_to your_cases_investigations_path, flash: { notice: "The case could not be deleted" }

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -2,7 +2,7 @@ class InvestigationsController < ApplicationController
   include InvestigationsHelper
 
   before_action :set_search_params, only: %i[index]
-  before_action :set_investigation, only: %i[show created]
+  before_action :set_investigation, only: %i[show created cannot_close confirm_deletion]
   before_action :build_breadcrumbs, only: %i[show]
 
   # GET /cases
@@ -74,6 +74,12 @@ class InvestigationsController < ApplicationController
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
 
     render "investigations/index.html.erb"
+  end
+
+  def cannot_close
+  end
+
+  def confirm_deletion
   end
 
 private

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -83,7 +83,7 @@ class InvestigationsController < ApplicationController
   def destroy
     authorize @investigation, :change_owner_or_status?
 
-    @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation, deleting_user: current_user)
+    @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation)
 
     if @delete_investigation_form.valid?
       DeleteInvestigation.call!(investigation: @investigation, deleted_by: current_user)
@@ -134,7 +134,7 @@ private
   end
 
   def count_to_display
-    default_params ? Investigation.count : @answer.total_count
+    default_params ? Investigation.not_deleted.count : @answer.total_count
   end
 
   def default_params

--- a/app/forms/delete_investigation_form.rb
+++ b/app/forms/delete_investigation_form.rb
@@ -1,0 +1,11 @@
+class DeleteInvestigationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :deleting_user
+  attribute :investigation
+
+  validates :deleting_user, presence: true
+  validates :investigation, presence: true
+end

--- a/app/forms/delete_investigation_form.rb
+++ b/app/forms/delete_investigation_form.rb
@@ -3,10 +3,8 @@ class DeleteInvestigationForm
   include ActiveModel::Attributes
   include ActiveModel::Serialization
 
-  attribute :deleting_user
   attribute :investigation
 
-  validates :deleting_user, presence: true
   validates :investigation, presence: true
   validate :investigation_has_no_products
 

--- a/app/forms/delete_investigation_form.rb
+++ b/app/forms/delete_investigation_form.rb
@@ -11,6 +11,6 @@ class DeleteInvestigationForm
   validate :investigation_has_no_products
 
   def investigation_has_no_products
-    errors.add(:has_products, "Cannot delete a case with products") unless investigation.products.count.zero?
+    errors.add(:has_products, "Cannot delete a case with products") unless investigation && investigation.products.count.zero?
   end
 end

--- a/app/forms/delete_investigation_form.rb
+++ b/app/forms/delete_investigation_form.rb
@@ -9,6 +9,6 @@ class DeleteInvestigationForm
   validate :investigation_has_no_products
 
   def investigation_has_no_products
-    errors.add(:has_products, "Cannot delete a case with products") unless investigation && investigation.products.count.zero?
+    errors.add(:has_products, "Cannot delete a case with products") unless investigation && investigation.products.none?
   end
 end

--- a/app/forms/delete_investigation_form.rb
+++ b/app/forms/delete_investigation_form.rb
@@ -8,4 +8,9 @@ class DeleteInvestigationForm
 
   validates :deleting_user, presence: true
   validates :investigation, presence: true
+  validate :investigation_has_no_products
+
+  def investigation_has_no_products
+    errors.add(:has_products, "Cannot delete a case with products") unless investigation.products.count.zero?
+  end
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -2,7 +2,7 @@ module InvestigationsHelper
   include InvestigationSearchHelper
 
   def search_for_investigations(page_size = Investigation.count, user = current_user)
-    result = Investigation.full_search(search_query(user))
+    result = Investigation.not_deleted.full_search(search_query(user))
     result.page(page_number).per(page_size)
   end
 

--- a/app/models/concerns/investigation_opensearch.rb
+++ b/app/models/concerns/investigation_opensearch.rb
@@ -13,6 +13,7 @@ module InvestigationOpensearch
         indexes :owner_id, type: :keyword
         indexes :creator_id, type: :keyword
         indexes :hazard_type, type: :keyword
+        indexes :deleted_at, type: :keyword
         indexes :teams_with_access, type: :nested do
           indexes :id, type: :keyword
         end

--- a/app/models/concerns/investigation_opensearch.rb
+++ b/app/models/concerns/investigation_opensearch.rb
@@ -13,7 +13,6 @@ module InvestigationOpensearch
         indexes :owner_id, type: :keyword
         indexes :creator_id, type: :keyword
         indexes :hazard_type, type: :keyword
-        indexes :deleted_at, type: :keyword
         indexes :teams_with_access, type: :nested do
           indexes :id, type: :keyword
         end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -81,14 +81,13 @@ class Investigation < ApplicationRecord
   has_many :incidents
   has_many :unexpected_events
 
-  default_scope { where(deleted_at: nil) }
   scope :not_private, -> { where(is_private: false) }
 
   redacted_export_with :id, :complainant_reference, :coronavirus_related, :created_at, :custom_risk_level,
                        :date_closed, :date_received, :description, :hazard_description, :hazard_type,
                        :is_closed, :is_private, :non_compliant_reason, :notifying_country, :pretty_id,
                        :product_category, :received_type, :reported_reason, :risk_level, :risk_validated_at,
-                       :risk_validated_by, :type, :updated_at, :user_title
+                       :risk_validated_by, :type, :updated_at, :user_title, :deleted_at, :deleted_by
 
   # All sub-classes share this policy class
   def self.policy_class

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -2,6 +2,7 @@ class Investigation < ApplicationRecord
   include Documentable
   include SanitizationHelper
   include InvestigationOpensearch
+  include Deletable
 
   attr_accessor :visibility_rationale, :owner_rationale
 
@@ -80,6 +81,7 @@ class Investigation < ApplicationRecord
   has_many :incidents
   has_many :unexpected_events
 
+  default_scope { where(deleted_at: nil) }
   scope :not_private, -> { where(is_private: false) }
 
   redacted_export_with :id, :complainant_reference, :coronavirus_related, :created_at, :custom_risk_level,

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -67,4 +67,8 @@ class InvestigationPolicy < ApplicationPolicy
 
     show?
   end
+
+  def can_be_deleted?
+    record.products.none?
+  end
 end

--- a/app/services/create_case.rb
+++ b/app/services/create_case.rb
@@ -67,7 +67,7 @@ private
   end
 
   def latest_case_number_this_month
-    case_number = Investigation.unscope(:where).select(:pretty_id)
+    case_number = Investigation.select(:pretty_id)
       .where("created_at < ? AND created_at > ?", date, date.beginning_of_month)
       .order(:id).last&.pretty_id
 

--- a/app/services/create_case.rb
+++ b/app/services/create_case.rb
@@ -67,7 +67,7 @@ private
   end
 
   def latest_case_number_this_month
-    case_number = Investigation.select(:pretty_id)
+    case_number = Investigation.unscope(:where).select(:pretty_id)
       .where("created_at < ? AND created_at > ?", date, date.beginning_of_month)
       .order(:id).last&.pretty_id
 

--- a/app/services/delete_investigation.rb
+++ b/app/services/delete_investigation.rb
@@ -6,7 +6,7 @@ class DeleteInvestigation
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No deleted_by supplied") unless deleted_by.is_a?(User)
-    context.fail!(error: "Cannot delete investigation with products") unless investigation.products.count.zero?
+    context.fail!(error: "Cannot delete investigation with products") unless Pundit.policy(deleted_by, investigation).can_be_deleted?
 
     ActiveRecord::Base.transaction do
       investigation.mark_as_deleted!

--- a/app/services/delete_investigation.rb
+++ b/app/services/delete_investigation.rb
@@ -1,0 +1,16 @@
+class DeleteInvestigation
+  include Interactor
+
+  delegate :investigation, :deleted_by, to: :context
+
+  def call
+    context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+
+    ActiveRecord::Base.transaction do
+      investigation.mark_as_deleted!
+      investigation.update!(deleted_by: deleted_by.id)
+
+      investigation.reload.__elasticsearch__.delete_document
+    end
+  end
+end

--- a/app/services/delete_investigation.rb
+++ b/app/services/delete_investigation.rb
@@ -11,7 +11,7 @@ class DeleteInvestigation
       investigation.mark_as_deleted!
       investigation.update!(deleted_by: deleted_by.id)
 
-      investigation.reload.__elasticsearch__.delete_document
+      investigation.__elasticsearch__.delete_document
     end
   end
 end

--- a/app/services/delete_investigation.rb
+++ b/app/services/delete_investigation.rb
@@ -5,6 +5,7 @@ class DeleteInvestigation
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+    context.fail!(error: "No deleted_by supplied") unless deleted_by.is_a?(User)
     context.fail!(error: "Cannot delete investigation with products") unless investigation.products.count.zero?
 
     ActiveRecord::Base.transaction do

--- a/app/services/delete_investigation.rb
+++ b/app/services/delete_investigation.rb
@@ -5,6 +5,7 @@ class DeleteInvestigation
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+    context.fail!(error: "Cannot delete investigation with products") unless investigation.products.count.zero?
 
     ActiveRecord::Base.transaction do
       investigation.mark_as_deleted!

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -9,6 +9,7 @@ class RemoveProductFromCase
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
     context.fail!(error: "Cannot remove a product from a previously closed case") if investigation_product.investigation_closed_at
+
     InvestigationProduct.transaction do
       product.reload
       investigation.products.delete product

--- a/app/services/update_product.rb
+++ b/app/services/update_product.rb
@@ -14,7 +14,7 @@ class UpdateProduct
 
       product.update!(product_params)
 
-      product.investigations.import
+      product.investigations.not_deleted.import
     end
   end
 end

--- a/app/views/investigations/cannot_close.html.erb
+++ b/app/views/investigations/cannot_close.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+            A product has not been added to this case
+          </h1>
+
+          <% inset_html = capture do %>
+            <p class="govuk-body">
+              A case cannot be closed if it does not include a product.
+            </p>
+          <% end %>
+
+          <%= govukInsetText({
+            html: inset_html,
+          }) %>
+
+          <p class="govuk-body">
+            Either add an active product record to the case or delete the case.
+          </p>
+
+          <div class="govuk-button-group">
+            <%= link_to "Delete the case", confirm_deletion_investigation_path(@investigation), class: "govuk-button govuk-link--no-underline" %>
+            <%= link_to "Go back to the case page", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/investigations/cannot_close.html.erb
+++ b/app/views/investigations/cannot_close.html.erb
@@ -1,3 +1,8 @@
+<% page_heading = "Case cannot be closed" %>
+
+<%= page_title page_heading %>
+
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
@@ -21,7 +26,7 @@
             Either add an active product record to the case or delete the case.
           </p>
 
-          <div class="govuk-button-group">
+          <div class="govuk-button-group govuk-!-margin-top-8">
             <%= link_to "Delete the case", confirm_deletion_investigation_path(@investigation), class: "govuk-button govuk-link--no-underline" %>
             <%= link_to "Go back to the case page", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -10,7 +10,7 @@
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
           <div class="govuk-button-group">
-            <%= link_to "Delete the case", investigation_path(@investigation), class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= link_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
             <%= link_to "Go back to the case page", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+            Delete the case
+          </h1>
+
+          <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
+
+          <div class="govuk-button-group">
+            <%= link_to "Delete the case", investigation_path(@investigation), class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= link_to "Go back to the case page", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -1,3 +1,7 @@
+<% page_heading = "Delete the case" %>
+
+<%= page_title page_heading %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
@@ -9,9 +13,9 @@
 
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
-          <div class="govuk-button-group">
+          <div class="govuk-button-group govuk-!-margin-top-8">
             <%= link_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
-            <%= link_to "Go back to the case page", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+            <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,11 +95,13 @@ Rails.application.routes.draw do
 
   resources :investigations,
             path: "cases",
-            only: %i[show new index],
+            only: %i[show new index destroy],
             param: :pretty_id,
             concerns: %i[document_attachable] do
     member do
       get :created
+      get :cannot_close
+      get :confirm_deletion
     end
 
     resource :status, only: %i[], controller: "investigations/status" do

--- a/db/migrate/20200615121613_move_owners_to_collaboration.rb
+++ b/db/migrate/20200615121613_move_owners_to_collaboration.rb
@@ -1,7 +1,7 @@
 class MoveOwnersToCollaboration < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
-      Investigation.all.each do |i|
+      Investigation.unscoped.all.each do |i|
         owner = i[:owner_type].constantize.find(i[:owner_id])
         i.owner = owner
         i.save!

--- a/db/migrate/20200615121613_move_owners_to_collaboration.rb
+++ b/db/migrate/20200615121613_move_owners_to_collaboration.rb
@@ -1,7 +1,7 @@
 class MoveOwnersToCollaboration < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
-      Investigation.unscoped.all.each do |i|
+      Investigation.all.each do |i|
         owner = i[:owner_type].constantize.find(i[:owner_id])
         i.owner = owner
         i.save!

--- a/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
+++ b/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
@@ -1,7 +1,10 @@
 class AddDeletedAtAndDeletedByToInvestigations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
   def change
     # rubocop:disable Rails/BulkChangeTable
     add_column :investigations, :deleted_at, :datetime
+    add_index :investigations, :deleted_at, algorithm: :concurrently
     add_column :investigations, :deleted_by, :string
     # rubocop:enable Rails/BulkChangeTable
   end

--- a/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
+++ b/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
@@ -2,10 +2,8 @@ class AddDeletedAtAndDeletedByToInvestigations < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def change
-    # rubocop:disable Rails/BulkChangeTable
     add_column :investigations, :deleted_at, :datetime
     add_index :investigations, :deleted_at, algorithm: :concurrently
     add_column :investigations, :deleted_by, :string
-    # rubocop:enable Rails/BulkChangeTable
   end
 end

--- a/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
+++ b/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
@@ -1,6 +1,8 @@
 class AddDeletedAtAndDeletedByToInvestigations < ActiveRecord::Migration[6.1]
   def change
+    # rubocop:disable Rails/BulkChangeTable
     add_column :investigations, :deleted_at, :datetime
     add_column :investigations, :deleted_by, :string
+    # rubocop:enable Rails/BulkChangeTable
   end
 end

--- a/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
+++ b/db/migrate/20221130153756_add_deleted_at_and_deleted_by_to_investigations.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtAndDeletedByToInvestigations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :investigations, :deleted_at, :datetime
+    add_column :investigations, :deleted_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_08_123932) do
+ActiveRecord::Schema.define(version: 2022_11_30_153756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -222,6 +222,8 @@ ActiveRecord::Schema.define(version: 2022_11_08_123932) do
     t.string "custom_risk_level"
     t.datetime "date_closed"
     t.date "date_received"
+    t.datetime "deleted_at"
+    t.string "deleted_by"
     t.text "description"
     t.text "hazard_description"
     t.string "hazard_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,6 +242,7 @@ ActiveRecord::Schema.define(version: 2022_11_30_153756) do
     t.datetime "updated_at", null: false
     t.string "user_title"
     t.index ["custom_risk_level"], name: "index_investigations_on_custom_risk_level"
+    t.index ["deleted_at"], name: "index_investigations_on_deleted_at"
     t.index ["pretty_id"], name: "index_investigations_on_pretty_id", unique: true
     t.index ["updated_at"], name: "index_investigations_on_updated_at"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -704,7 +704,7 @@ if run_seeds
   end
 
   Investigation.__elasticsearch__.create_index! force: true
-  Investigation.import
+  Investigation.import scope: 'not_deleted'
 
   Product.__elasticsearch__.create_index! force: true
   Product.import

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -704,7 +704,7 @@ if run_seeds
   end
 
   Investigation.__elasticsearch__.create_index! force: true
-  Investigation.import scope: 'not_deleted'
+  Investigation.import scope: "not_deleted"
 
   Product.__elasticsearch__.create_index! force: true
   Product.import

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -1,7 +1,8 @@
 namespace :opensearch do
   desc "re-index opensearch model"
   task index: :environment do
-    [Investigation, Product, Business].each do |model|
+    Investigation.__elasticsearch__.import scope: "not_deleted", force: true, refresh: :wait
+    [Product, Business].each do |model|
       model.__elasticsearch__.import force: true, refresh: :wait
     end
   end

--- a/spec/features/businesses_navigation_spec.rb
+++ b/spec/features/businesses_navigation_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Searching businesses", :with_opensearch, :with_stubbed_mailer, ty
     InvestigationBusiness.create!(business_id: closed_business.id, investigation_id: closed_case.id)
     InvestigationBusiness.create!(business_id: other_business.id, investigation_id: other_case.id)
 
-    Investigation.import scope: 'not_deleted', refresh: true, force: true
+    Investigation.import scope: "not_deleted", refresh: true, force: true
     Business.import refresh: true, force: true
   end
 

--- a/spec/features/businesses_navigation_spec.rb
+++ b/spec/features/businesses_navigation_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Searching businesses", :with_opensearch, :with_stubbed_mailer, ty
     InvestigationBusiness.create!(business_id: closed_business.id, investigation_id: closed_case.id)
     InvestigationBusiness.create!(business_id: other_business.id, investigation_id: other_case.id)
 
-    Investigation.import refresh: true, force: true
+    Investigation.import scope: 'not_deleted', refresh: true, force: true
     Business.import refresh: true, force: true
   end
 

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
     let!(:team_case) { create(:allegation, creator: other_user_same_team) }
 
     before do
-      Investigation.import scope: 'not_deleted', refresh: true, force: true
+      Investigation.import scope: "not_deleted", refresh: true, force: true
     end
 
     context "when the user is on the your cases page" do
@@ -83,7 +83,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11, creator: user)
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
           visit "/cases/your-cases"
         end
 
@@ -135,7 +135,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11, creator: other_user_same_team)
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
           visit "/cases/team-cases"
         end
 
@@ -181,7 +181,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11)
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
           visit "/cases/all-cases"
         end
 

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
     let!(:team_case) { create(:allegation, creator: other_user_same_team) }
 
     before do
-      Investigation.import refresh: true, force: true
+      Investigation.import scope: 'not_deleted', refresh: true, force: true
     end
 
     context "when the user is on the your cases page" do
@@ -83,7 +83,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11, creator: user)
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
           visit "/cases/your-cases"
         end
 
@@ -135,7 +135,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11, creator: other_user_same_team)
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
           visit "/cases/team-cases"
         end
 
@@ -181,7 +181,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       context "when more than 11 cases" do
         before do
           create_list(:allegation, 11)
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
           visit "/cases/all-cases"
         end
 

--- a/spec/features/change_case_status_spec.rb
+++ b/spec/features/change_case_status_spec.rb
@@ -163,5 +163,4 @@ RSpec.feature "Changing the status of a case", :with_opensearch, :with_stubbed_m
       end
     end
   end
-
 end

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer
 
   context "when case does not have products associated with it" do
     let!(:investigation) { create(:allegation, creator: user, is_closed: false) }
+
     it "allows user to delete case" do
       sign_in user
       visit "/cases/#{investigation.pretty_id}"

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer, type: :feature do
+RSpec.describe "Deleting a case", :with_opensearch, :with_stubbed_mailer, type: :feature do
   let(:user) { create(:user, :activated, :opss_user, name: "Jane Jones") }
 
   context "when case has products associated with it" do
@@ -31,6 +31,13 @@ RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer
 
     it "does not allow user to close case, redirects to a delete case page" do
       sign_in user
+      Investigation.__elasticsearch__.import refresh: :wait_for
+
+      visit "/cases"
+
+      expect(page).to have_content "1 case using the current filters, was found."
+      expect(page).to have_content investigation.pretty_id
+
       visit "/cases/#{investigation.pretty_id}"
 
       click_link "Close case"
@@ -45,6 +52,12 @@ RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer
 
       expect(page).to have_current_path("/cases/your-cases")
       expect_confirmation_banner("The case was deleted")
+
+      Investigation.__elasticsearch__.import refresh: :wait_for
+
+      visit "/cases"
+
+      expect(page).to have_content "0 cases using the current filters, were found."
     end
   end
 end

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -4,22 +4,22 @@ RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer
   let(:user) { create(:user, :activated, :opss_user, name: "Jane Jones") }
 
   context "when case has products associated with it" do
-    let!(:investigation) { create(:allegation, creator: user, is_closed: false) }
+    let!(:investigation) { create(:allegation, :with_products, creator: user, is_closed: false) }
 
-    it "does not allow user to delete case" do
+    it "allows user to close the case" do
       sign_in user
       visit "/cases/#{investigation.pretty_id}"
 
       click_link "Close case"
 
-      expect_to_be_on_cannot_close_case_page(case_id: investigation.pretty_id)
+      expect_to_be_on_close_case_page(case_id: investigation.pretty_id)
     end
   end
 
   context "when case does not have products associated with it" do
     let!(:investigation) { create(:allegation, creator: user, is_closed: false) }
 
-    it "allows user to delete case" do
+    it "does not allow user to close case, redirects to a delete case page" do
       sign_in user
       visit "/cases/#{investigation.pretty_id}"
 

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer
 
       expect_to_be_on_close_case_page(case_id: investigation.pretty_id)
     end
+
+    it "does not allow user to delete the case" do
+      sign_in user
+      visit "cases/#{investigation.pretty_id}/confirm_deletion"
+
+      click_link "Delete the case"
+
+      expect(page).to have_current_path("/cases/your-cases")
+      expect(page).to have_css(".govuk-notification-banner", text: "The case could not be deleted")
+    end
   end
 
   context "when case does not have products associated with it" do

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Deleting a case", :with_stubbed_opensearch, :with_stubbed_mailer, type: :feature do
+  let(:user) { create(:user, :activated, :opss_user, name: "Jane Jones") }
+
+  context "when case has products associated with it" do
+    let!(:investigation) { create(:allegation, creator: user, is_closed: false) }
+
+    it "does not allow user to delete case" do
+      sign_in user
+      visit "/cases/#{investigation.pretty_id}"
+
+      click_link "Close case"
+
+      expect_to_be_on_cannot_close_case_page(case_id: investigation.pretty_id)
+    end
+  end
+
+  context "when case does not have products associated with it" do
+    let!(:investigation) { create(:allegation, creator: user, is_closed: false) }
+    it "allows user to delete case" do
+      sign_in user
+      visit "/cases/#{investigation.pretty_id}"
+
+      click_link "Close case"
+
+      expect_to_be_on_cannot_close_case_page(case_id: investigation.pretty_id)
+
+      click_link "Delete the case"
+
+      expect_to_be_on_confirm_case_deletion_page(case_id: investigation.pretty_id)
+
+      click_link "Delete the case"
+
+      expect(page).to have_current_path("/cases/your-cases")
+      expect_confirmation_banner("The case was deleted")
+    end
+  end
+end

--- a/spec/features/export_businesses_spec.rb
+++ b/spec/features/export_businesses_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Business export", :with_opensearch, :with_stubbed_antivirus, :wit
   before do
     create(:business, trading_name: "ABC")
     create(:business, trading_name: "XYZ")
-    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
+    Investigation.import scope: "not_deleted", force: true, refresh: :wait_for
     Business.import force: true, refresh: :wait_for
 
     sign_in(user)

--- a/spec/features/export_businesses_spec.rb
+++ b/spec/features/export_businesses_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Business export", :with_opensearch, :with_stubbed_antivirus, :wit
   before do
     create(:business, trading_name: "ABC")
     create(:business, trading_name: "XYZ")
-    Investigation.import force: true, refresh: :wait_for
+    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
     Business.import force: true, refresh: :wait_for
 
     sign_in(user)

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Case export", :with_opensearch, :with_stubbed_antivirus, :with_st
   let!(:allegation_closed) { create(:allegation, :closed, creator: user) }
 
   before do
-    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
+    Investigation.import scope: "not_deleted", force: true, refresh: :wait_for
 
     sign_in(user)
     visit investigations_path

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Case export", :with_opensearch, :with_stubbed_antivirus, :with_st
   let!(:allegation_closed) { create(:allegation, :closed, creator: user) }
 
   before do
-    Investigation.import force: true, refresh: :wait_for
+    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
 
     sign_in(user)
     visit investigations_path

--- a/spec/features/export_products_spec.rb
+++ b/spec/features/export_products_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Product export", :with_opensearch, :with_stubbed_antivirus, :with
 
   before do
     Product.import force: true, refresh: :wait_for
-    Investigation.import force: true, refresh: :wait_for
+    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
 
     sign_in(user)
   end

--- a/spec/features/export_products_spec.rb
+++ b/spec/features/export_products_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Product export", :with_opensearch, :with_stubbed_antivirus, :with
 
   before do
     Product.import force: true, refresh: :wait_for
-    Investigation.import scope: 'not_deleted', force: true, refresh: :wait_for
+    Investigation.import scope: "not_deleted", force: true, refresh: :wait_for
 
     sign_in(user)
   end

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   let(:other_user_other_team) { create(:user, :activated, name: "other user other team", organisation:, team: other_team) }
 
   let!(:investigation)                       { create(:allegation, creator: user, hazard_type: "Fire") }
+  let!(:deleted_investigation)               { create(:allegation, creator: user, hazard_type: "Fire", deleted_at: Time.now) }
   let!(:other_user_investigation)            { create(:allegation, creator: other_user_same_team, hazard_type: "Fire") }
   let!(:other_user_other_team_investigation) { create(:allegation, creator: other_user_other_team) }
   let!(:other_team_investigation)            { create(:allegation, creator: yet_another_user_same_team, hazard_type: "Fire") }
@@ -37,19 +38,20 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   before do
     create(:allegation, creator: user, risk_level: Investigation.risk_levels[:high], coronavirus_related: true)
     other_team_investigation.touch # Tests sort order
-    Investigation.import refresh: :wait_for
+    Investigation.import scope: 'not_deleted', refresh: :wait_for, force: true
     sign_in(user)
     visit all_cases_investigations_path
   end
 
-  scenario "no filters applied shows all open cases" do
+  scenario "no filters applied shows all open cases but does not show closed or deleted cases" do
     expect(page).to have_listed_case(investigation.pretty_id)
     expect(page).to have_listed_case(other_user_investigation.pretty_id)
     expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
     expect(page).to have_listed_case(other_team_investigation.pretty_id)
 
+    expect(page).not_to have_listed_case(deleted_investigation.pretty_id)
     expect(page).not_to have_listed_case(closed_investigation.pretty_id)
-    number_of_open_cases = Investigation.where(is_closed: false).count
+    number_of_open_cases = Investigation.not_deleted.where(is_closed: false).count
     expect(page).to have_content("#{number_of_open_cases} cases using the current filters, were found.")
 
     expect(find("details#filter-details")["open"]).to eq(nil)
@@ -71,7 +73,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   context "when there are multiple pages of cases" do
     before do
       20.times { create(:allegation, creator: user, risk_level: Investigation.risk_levels[:serious]) }
-      Investigation.import refresh: :wait_for
+      Investigation.import scope: 'not_deleted', refresh: :wait_for, force: true
     end
 
     it "maintains the filters when clicking on additional pages" do
@@ -315,7 +317,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
         expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
         expect(page).not_to have_listed_case(another_team_investigation.pretty_id)
 
-        number_of_total_cases = Investigation.where(hazard_type: "Fire").count
+        number_of_total_cases = Investigation.not_deleted.where(hazard_type: "Fire").count
         expect(page).to have_content("#{number_of_total_cases} cases using the current filters, were found.")
       end
     end
@@ -433,7 +435,8 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
         expect(page).to have_listed_case(investigation.pretty_id)
         expect(page).to have_listed_case(closed_investigation.pretty_id)
-        number_of_total_cases = Investigation.count
+        expect(page).not_to have_listed_case(deleted_investigation.pretty_id)
+        number_of_total_cases = Investigation.not_deleted.count
         expect(page).to have_content("#{number_of_total_cases} cases using the current filters, were found.")
 
         expect(find("details#filter-details")["open"]).to eq(nil)

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   let(:other_user_other_team) { create(:user, :activated, name: "other user other team", organisation:, team: other_team) }
 
   let!(:investigation)                       { create(:allegation, creator: user, hazard_type: "Fire") }
-  let!(:deleted_investigation)               { create(:allegation, creator: user, hazard_type: "Fire", deleted_at: Time.now) }
+  let!(:deleted_investigation)               { create(:allegation, creator: user, hazard_type: "Fire", deleted_at: Time.zone.now) }
   let!(:other_user_investigation)            { create(:allegation, creator: other_user_same_team, hazard_type: "Fire") }
   let!(:other_user_other_team_investigation) { create(:allegation, creator: other_user_other_team) }
   let!(:other_team_investigation)            { create(:allegation, creator: yet_another_user_same_team, hazard_type: "Fire") }
@@ -38,7 +38,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   before do
     create(:allegation, creator: user, risk_level: Investigation.risk_levels[:high], coronavirus_related: true)
     other_team_investigation.touch # Tests sort order
-    Investigation.import scope: 'not_deleted', refresh: :wait_for, force: true
+    Investigation.import scope: "not_deleted", refresh: :wait_for, force: true
     sign_in(user)
     visit all_cases_investigations_path
   end
@@ -73,7 +73,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   context "when there are multiple pages of cases" do
     before do
       20.times { create(:allegation, creator: user, risk_level: Investigation.risk_levels[:serious]) }
-      Investigation.import scope: 'not_deleted', refresh: :wait_for, force: true
+      Investigation.import scope: "not_deleted", refresh: :wait_for, force: true
     end
 
     it "maintains the filters when clicking on additional pages" do

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -479,7 +479,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
   end
 
   describe "Sorting" do
-    let(:default_filtered_cases) { Investigation.where(is_closed: false) }
+    let(:default_filtered_cases) { Investigation.not_deleted.where(is_closed: false) }
     let(:cases) { default_filtered_cases.order(updated_at: :desc) }
 
     def select_sorting_option(option)

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
 
   before do
-    Investigation.import scope: 'not_deleted', refresh: :wait_for
+    Investigation.import scope: "not_deleted", refresh: :wait_for
     Product.import refresh: :wait_for
     sign_in(user)
     visit products_path

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
 
   before do
-    Investigation.import refresh: :wait_for
+    Investigation.import scope: 'not_deleted', refresh: :wait_for
     Product.import refresh: :wait_for
     sign_in(user)
     visit products_path

--- a/spec/features/investigations_spec.rb
+++ b/spec/features/investigations_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Investigation listing", :with_opensearch, :with_stubbed_mailer, t
 
   scenario "lists cases correctly sorted" do
     # it is necessary to re-import and wait for the indexing to be done.
-    Investigation.import refresh: :wait_for
+    Investigation.import scope: 'not_deleted', refresh: :wait_for
 
     sign_in(user)
     visit investigations_path

--- a/spec/features/investigations_spec.rb
+++ b/spec/features/investigations_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Investigation listing", :with_opensearch, :with_stubbed_mailer, t
 
   scenario "lists cases correctly sorted" do
     # it is necessary to re-import and wait for the indexing to be done.
-    Investigation.import scope: 'not_deleted', refresh: :wait_for
+    Investigation.import scope: "not_deleted", refresh: :wait_for
 
     sign_in(user)
     visit investigations_path

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Searching products", :with_opensearch, :with_stubbed_mailer, type
     create(:allegation, products: [other_product])
     create(:allegation, creator: other_user_same_team, products: [team_product])
     create(:allegation, creator: user, products: [closed_product], is_closed: true)
-    Investigation.import refresh: true, force: true
+    Investigation.import scope: 'not_deleted', refresh: true, force: true
     Product.import refresh: true, force: true
   end
 

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Searching products", :with_opensearch, :with_stubbed_mailer, type
     create(:allegation, products: [other_product])
     create(:allegation, creator: other_user_same_team, products: [team_product])
     create(:allegation, creator: user, products: [closed_product], is_closed: true)
-    Investigation.import scope: 'not_deleted', refresh: true, force: true
+    Investigation.import scope: "not_deleted", refresh: true, force: true
     Product.import refresh: true, force: true
   end
 

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
            product_code: "W2020-10/1")
   end
   let!(:investigation) { create(:allegation, products: [product], user_title: nil) }
-  let!(:deleted_investigation) { create(:allegation, products: [product], user_title: "DeletedCase", deleted_at: Time.now) }
+  let!(:deleted_investigation) { create(:allegation, products: [product], user_title: "DeletedCase", deleted_at: Time.zone.now) }
 
   let(:mobile_phone) do
     create(:product,

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -256,10 +256,14 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       end
 
       context "when over 10k cases exist" do
+        # rubocop:disable RSpec/VerifiedDoubles
         before do
-          allow(Investigation).to receive(:count).and_return(10_001)
+          spy = spy("not_deleted")
+          allow(Investigation).to receive(:not_deleted).and_return(spy)
+          allow(spy).to receive(:count).and_return(10_001)
           sign_in(user)
         end
+        # rubocop:enable RSpec/VerifiedDoubles
 
         it "shows total number of cases" do
           visit "/cases"

--- a/spec/features/sort_businesses_spec.rb
+++ b/spec/features/sort_businesses_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Business sorting", :with_opensearch, :with_stubbed_mailer, type: 
   # rubocop:enable RSpec/LetSetup
 
   before do
-    Investigation.import scope: 'not_deleted', refresh: :wait_for
+    Investigation.import scope: "not_deleted", refresh: :wait_for
     Business.import refresh: :wait_for
     sign_in(user)
     visit businesses_path

--- a/spec/features/sort_businesses_spec.rb
+++ b/spec/features/sort_businesses_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Business sorting", :with_opensearch, :with_stubbed_mailer, type: 
   # rubocop:enable RSpec/LetSetup
 
   before do
-    Investigation.import refresh: :wait_for
+    Investigation.import scope: 'not_deleted', refresh: :wait_for
     Business.import refresh: :wait_for
     sign_in(user)
     visit businesses_path

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
   # rubocop:enable RSpec/LetSetup
 
   before do
-    Investigation.import scope: 'not_deleted', refresh: :wait_for
+    Investigation.import scope: "not_deleted", refresh: :wait_for
     Product.import refresh: :wait_for
     sign_in(user)
     visit products_path

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
   # rubocop:enable RSpec/LetSetup
 
   before do
-    Investigation.import refresh: :wait_for
+    Investigation.import scope: 'not_deleted', refresh: :wait_for
     Product.import refresh: :wait_for
     sign_in(user)
     visit products_path

--- a/spec/forms/delete_investigation_form_spec.rb
+++ b/spec/forms/delete_investigation_form_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe DeleteInvestigationForm, :with_stubbed_opensearch, :with_stubbed_mailer do
+  subject(:form) { described_class.new(investigation:, deleting_user:) }
+
+  let(:deleting_user) { create(:user) }
+  let(:investigation) { create(:allegation) }
+
+  describe "validations" do
+    context "with valid params" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "with no investigation" do
+      let(:investigation) { nil }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with no deleteing_user" do
+      let(:deleting_user) { nil }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+
+    context "with investigation that has associated products" do
+      let(:investigation) { create(:allegation, :with_products) }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/forms/delete_investigation_form_spec.rb
+++ b/spec/forms/delete_investigation_form_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
 RSpec.describe DeleteInvestigationForm, :with_stubbed_opensearch, :with_stubbed_mailer do
-  subject(:form) { described_class.new(investigation:, deleting_user:) }
+  subject(:form) { described_class.new(investigation:) }
 
-  let(:deleting_user) { create(:user) }
   let(:investigation) { create(:allegation) }
 
   describe "validations" do
@@ -15,14 +14,6 @@ RSpec.describe DeleteInvestigationForm, :with_stubbed_opensearch, :with_stubbed_
 
     context "with no investigation" do
       let(:investigation) { nil }
-
-      it "is not valid" do
-        expect(form).not_to be_valid
-      end
-    end
-
-    context "with no deleteing_user" do
-      let(:deleting_user) { nil }
 
       it "is not valid" do
         expect(form).not_to be_valid

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
   let(:params) { { case_type: "all", sort_by: "recent", created_by: "all", case_status: "open", teams_with_access: "all" } }
   let(:case_export) { described_class.create!(user:, params:) }
 
-  before { Investigation.__elasticsearch__.import force: true, refresh: :wait }
+  before { Investigation.__elasticsearch__.import scope: "not_deleted", force: true, refresh: :wait }
 
   describe "#export!" do
     let(:result) { case_export.export! }

--- a/spec/policies/investigation_policy_spec.rb
+++ b/spec/policies/investigation_policy_spec.rb
@@ -176,4 +176,20 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
       end
     end
   end
+
+  describe "#can_be_deleted?" do
+    context "when investigation has products" do
+      let(:investigation) { create(:allegation, :with_products, is_private: false) }
+
+      it "returns false" do
+        expect(policy.can_be_deleted?).to be false
+      end
+    end
+
+    context "when investigation does not have products" do
+      it "returns true" do
+        expect(policy.can_be_deleted?).to be true
+      end
+    end
+  end
 end

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "treats formulas as text" do
         create(:allegation, description: "=A1")
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path, params: { q: "A1" }
 
@@ -80,7 +80,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports coronavirus flag" do
         create(:allegation, coronavirus_related: true)
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -97,7 +97,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         product_category = Faker::Hipster.unique.word
         category = Faker::Hipster.unique.word
         create(:allegation, product_category:, products: [create(:product, category:)])
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -118,7 +118,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           risk_level: (Investigation.risk_levels.values - %w[other]).sample
         )
 
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -139,7 +139,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
         ChangeCaseOwner.call!(investigation: case_with_team_owner, user:, owner: team)
 
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -160,7 +160,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports risk_assessments count" do
         create(:risk_assessment)
 
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -173,7 +173,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports created_at and updated_at" do
         investigation = create(:allegation)
 
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -188,7 +188,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports risk_validated_at" do
         investigation = create(:allegation, risk_validated_at: Date.current)
 
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -200,7 +200,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports notifying_country" do
         create(:allegation)
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -212,7 +212,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports reported_as" do
         create(:allegation, reported_reason: "unsafe")
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -224,7 +224,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports complainant_reference" do
         create(:allegation, complainant_reference: "testing")
-        Investigation.import refresh: true, force: true
+        Investigation.import scope: 'not_deleted', refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -240,7 +240,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           allegation = create(:allegation, creator: creator_user)
           allow(allegation).to receive(:creator_user).and_return(nil)
 
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -257,7 +257,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           creator_user = create(:user, team:)
           create(:allegation, creator: creator_user)
 
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -272,7 +272,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         it "date_closed column is empty" do
           create(:allegation)
 
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -288,7 +288,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           closed_at_date = Date.new(2021, 1, 1)
           create(:allegation, is_closed: true, date_closed: closed_at_date)
 
-          Investigation.import refresh: true, force: true
+          Investigation.import scope: 'not_deleted', refresh: true, force: true
 
           get generate_case_exports_path, params: { case_status: "closed", format: :xlsx }
 
@@ -304,7 +304,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           it "shows description, title and user owner name" do
             investigation = create(:allegation, creator: user, is_private: true)
 
-            Investigation.import refresh: true, force: true
+            Investigation.import scope: 'not_deleted', refresh: true, force: true
 
             get generate_case_exports_path
 
@@ -327,7 +327,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             other_user = create(:user, team: other_team)
             create(:allegation, creator: other_user, is_private: true)
 
-            Investigation.import refresh: true, force: true
+            Investigation.import scope: 'not_deleted', refresh: true, force: true
 
             get generate_case_exports_path
 

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "treats formulas as text" do
         create(:allegation, description: "=A1")
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path, params: { q: "A1" }
 
@@ -80,7 +80,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports coronavirus flag" do
         create(:allegation, coronavirus_related: true)
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -97,7 +97,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         product_category = Faker::Hipster.unique.word
         category = Faker::Hipster.unique.word
         create(:allegation, product_category:, products: [create(:product, category:)])
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -118,7 +118,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           risk_level: (Investigation.risk_levels.values - %w[other]).sample
         )
 
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -139,7 +139,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
         ChangeCaseOwner.call!(investigation: case_with_team_owner, user:, owner: team)
 
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -160,7 +160,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports risk_assessments count" do
         create(:risk_assessment)
 
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -173,7 +173,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports created_at and updated_at" do
         investigation = create(:allegation)
 
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -188,7 +188,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
       it "exports risk_validated_at" do
         investigation = create(:allegation, risk_validated_at: Date.current)
 
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -200,7 +200,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports notifying_country" do
         create(:allegation)
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -212,7 +212,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports reported_as" do
         create(:allegation, reported_reason: "unsafe")
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -224,7 +224,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
 
       it "exports complainant_reference" do
         create(:allegation, complainant_reference: "testing")
-        Investigation.import scope: 'not_deleted', refresh: true, force: true
+        Investigation.import scope: "not_deleted", refresh: true, force: true
 
         get generate_case_exports_path
 
@@ -240,7 +240,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           allegation = create(:allegation, creator: creator_user)
           allow(allegation).to receive(:creator_user).and_return(nil)
 
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -257,7 +257,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           creator_user = create(:user, team:)
           create(:allegation, creator: creator_user)
 
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -272,7 +272,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         it "date_closed column is empty" do
           create(:allegation)
 
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
 
           get generate_case_exports_path
 
@@ -288,7 +288,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           closed_at_date = Date.new(2021, 1, 1)
           create(:allegation, is_closed: true, date_closed: closed_at_date)
 
-          Investigation.import scope: 'not_deleted', refresh: true, force: true
+          Investigation.import scope: "not_deleted", refresh: true, force: true
 
           get generate_case_exports_path, params: { case_status: "closed", format: :xlsx }
 
@@ -304,7 +304,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           it "shows description, title and user owner name" do
             investigation = create(:allegation, creator: user, is_private: true)
 
-            Investigation.import scope: 'not_deleted', refresh: true, force: true
+            Investigation.import scope: "not_deleted", refresh: true, force: true
 
             get generate_case_exports_path
 
@@ -327,7 +327,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             other_user = create(:user, team: other_team)
             create(:allegation, creator: other_user, is_private: true)
 
-            Investigation.import scope: 'not_deleted', refresh: true, force: true
+            Investigation.import scope: "not_deleted", refresh: true, force: true
 
             get generate_case_exports_path
 

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Health Check", :with_opensearch, :with_stubbed_mailer, :with_2fa
 
     before do
       create(:allegation)
-      Investigation.import scope: 'not_deleted', refresh: true, force: true
+      Investigation.import scope: "not_deleted", refresh: true, force: true
       allow(Sidekiq::Queue).to receive(:new).with("psd").and_return(sidekiq_queue)
     end
 

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Health Check", :with_opensearch, :with_stubbed_mailer, :with_2fa
 
     before do
       create(:allegation)
-      Investigation.import refresh: true, force: true
+      Investigation.import scope: 'not_deleted', refresh: true, force: true
       allow(Sidekiq::Queue).to receive(:new).with("psd").and_return(sidekiq_queue)
     end
 

--- a/spec/services/change_case_owner_spec.rb
+++ b/spec/services/change_case_owner_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe ChangeCaseOwner, :with_test_queue_adapter do
       it "indexes correctly the new owner" do
         result
         search = Investigation.__elasticsearch__.search(query: { bool: { must: { term: { owner_id: new_owner.id } } } })
-        Investigation.__elasticsearch__.import refresh: :wait_for
+        Investigation.__elasticsearch__.import scope: "not_deleted", refresh: :wait_for
 
         expect(search.results.first.owner_id).to eq(new_owner.id)
       end

--- a/spec/services/delete_investigation_spec.rb
+++ b/spec/services/delete_investigation_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe DeleteInvestigation, :with_stubbed_mailer, :with_stubbed_opensearch do
+  describe ".call" do
+    context "with no parameters" do
+      subject(:delete_call) { described_class.call }
+
+      it "returns a failure" do
+        expect(delete_call).to be_failure
+      end
+
+      it "provides an error message" do
+        expect(delete_call.error).to eq "No investigation supplied"
+      end
+    end
+
+    context "when given an investigation that has products" do
+      subject(:delete_call) { described_class.call(investigation:, deleted_by:) }
+
+      let(:deleted_by) { create(:user) }
+      let(:investigation) { create(:allegation, :with_products) }
+
+      it "returns a failure" do
+        expect(delete_call).to be_failure
+      end
+
+      it "provides an error message" do
+        expect(delete_call.error).to eq "Cannot delete investigation with products"
+      end
+    end
+
+    context "when given an investigation without products" do
+      subject(:delete_call) { described_class.call(investigation:, deleted_by:) }
+
+      let(:deleted_by)        { create(:user) }
+      let!(:investigation) { create(:allegation) }
+
+      it "succeeds" do
+        expect(delete_call).to be_a_success
+      end
+
+      it "sets the investigation deleted timestamp" do
+        freeze_time do
+          expect {
+            delete_call
+            investigation.reload
+          }.to change(investigation, :deleted_at).from(nil).to(Time.zone.now)
+        end
+      end
+
+      it "changes investigation deleted_by" do
+        expect {
+          delete_call
+          investigation.reload
+        }.to change(investigation, :deleted_by).from(nil).to(deleted_by.id)
+      end
+
+      it "does not send notifications to the user or the team" do
+        expect { delete_call }.not_to change(delivered_emails, :count)
+      end
+    end
+  end
+end

--- a/spec/services/opensearch_query_spec.rb
+++ b/spec/services/opensearch_query_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpensearchQuery, :with_opensearch, :with_stubbed_mailer do
   let(:sorting_params) { {} }
 
   def perform_search
-    Investigation.full_search(os_query)
+    Investigation.not_deleted.full_search(os_query)
   end
 
   # TODO: these specs are a port of the deprecated (and flaky) Minitest tests.

--- a/spec/services/update_product_spec.rb
+++ b/spec/services/update_product_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe UpdateProduct, :with_opensearch, :with_stubbed_mailer do
         result
         expect(product.__elasticsearch__).to have_received(:update_document)
       end
+
       # rubocop:disable RSpec/VerifiedDoubles
       it "reindexes the product's investigations" do
         not_deleted = spy("investigations")

--- a/spec/services/update_product_spec.rb
+++ b/spec/services/update_product_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe UpdateProduct, :with_opensearch, :with_stubbed_mailer do
         result
         expect(product.__elasticsearch__).to have_received(:update_document)
       end
-
+      # rubocop:disable RSpec/VerifiedDoubles
       it "reindexes the product's investigations" do
-        not_deleted = spy('investigations')
+        not_deleted = spy("investigations")
         allow(product.investigations).to receive(:not_deleted) { not_deleted }
         result
         expect(not_deleted).to have_received(:import)
       end
-
+      # rubocop:enable RSpec/VerifiedDoubles
 
       it "sets the updating team as the product owner" do
         result

--- a/spec/services/update_product_spec.rb
+++ b/spec/services/update_product_spec.rb
@@ -47,9 +47,12 @@ RSpec.describe UpdateProduct, :with_opensearch, :with_stubbed_mailer do
       end
 
       it "reindexes the product's investigations" do
+        not_deleted = spy('investigations')
+        allow(product.investigations).to receive(:not_deleted) { not_deleted }
         result
-        expect(product.investigations).to have_received(:import)
+        expect(not_deleted).to have_received(:import)
       end
+
 
       it "sets the updating team as the product owner" do
         result

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -9,6 +9,10 @@ def expect_confirmation_banner(msg)
   expect(page).to have_css(".govuk-notification-banner--success", text: msg)
 end
 
+def expect_warning_banner(msg)
+  expect(page).to have_css(".govuk-notification-banner", text: msg)
+end
+
 def expect_page_to_have_h1(header)
   expect(page).to have_css("h1", text: header)
 end

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -211,6 +211,16 @@ module PageExpectations
     expect(page).to have_h1("Why are you closing the case?")
   end
 
+  def expect_to_be_on_cannot_close_case_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/cannot_close")
+    expect(page).to have_h1("A product has not been added to this case")
+  end
+
+  def expect_to_be_on_confirm_case_deletion_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/confirm_deletion")
+    expect(page).to have_h1("Delete the case")
+  end
+
   def expect_to_be_on_reopen_case_page(case_id:)
     expect(page).to have_current_path("/cases/#{case_id}/status/reopen")
     expect(page).to have_h1("Why are you re-opening the case?")

--- a/spec/support/opensearch.rb
+++ b/spec/support/opensearch.rb
@@ -18,7 +18,7 @@ RSpec.shared_context "with Opensearch", shared_context: :metadata do
   def create_opensearch_indices!
     opensearch_models.each do |model|
       if model == Investigation
-          model.__elasticsearch__.import scope: "not_deleted", force: true, refresh: :wait
+        model.__elasticsearch__.import scope: "not_deleted", force: true, refresh: :wait
       else
         model.__elasticsearch__.import force: true, refresh: :wait
       end

--- a/spec/support/opensearch.rb
+++ b/spec/support/opensearch.rb
@@ -17,7 +17,11 @@ RSpec.shared_context "with Opensearch", shared_context: :metadata do
 
   def create_opensearch_indices!
     opensearch_models.each do |model|
-      model.__elasticsearch__.import force: true, refresh: :wait
+      if model == Investigation
+          model.__elasticsearch__.import scope: "not_deleted", force: true, refresh: :wait
+      else
+        model.__elasticsearch__.import force: true, refresh: :wait
+      end
     end
   end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/PST1/boards/53?selectedIssue=PST1-329

## Description
This changes do not allow users to close a case without any products, instead the user can delete the case.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
