### PR TITLE
Turn off IRB (rails console) autocomplete

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+IRB.conf[:USE_AUTOCOMPLETE] = false


### PR DESCRIPTION
The IRB autocomplete feature from Ruby 3.1 is extremely slow and causes issues when pasting code or when working over a remote connection.

This PR turns it off by default.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/85587097/205691454-f76ddd62-e800-4b91-96bc-7d9dbbfe80e0.png">