### PR TITLE
Change research workflows

### DIFF
--- a/.github/workflows/deploy-research.yml
+++ b/.github/workflows/deploy-research.yml
@@ -5,11 +5,6 @@ on:
 
 concurrency: research_environment
 
-env:
-  BUNDLE_WITHOUT: development
-  BUNDLE_JOBS: 4
-  BUNDLE_RETRY: 3
-
 jobs:
   deploy:
     name: Deploy the application
@@ -50,32 +45,9 @@ jobs:
           ./deploy.sh
           cf logout
 
-      - name: Set up Ruby
-        if: success()
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Run Smoke Tests
-        if: success()
-        env:
-          SMOKE_USER: ${{secrets.SMOKE_USER}}
-          SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
-          SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
-          SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
-          SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
-          IS_REVIEW_APP: "false"
-          SMOKE_TEST_URL: "https://psd-research.london.cloudapps.digital"
-
-        run: |
-          bundle exec rspec ./smoke_test/cases_page_spec.rb
-
       - name: Alert team via Slack of deployment failure
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.SlackWebhookUrl }}
         run: |
           curl -X POST --data-urlencode "payload={\"channel\": \"#alerts\", \"username\": \"deploybot\", \"text\": \"User Research deploy has failed!\n\nSee $LOG_URL\", \"icon_emoji\": \":fire:\"}" $SLACK_WEBHOOK
-
-  refresh:
-    uses: ./.github/workflows/refresh-research.yml

--- a/.github/workflows/refresh-research.yml
+++ b/.github/workflows/refresh-research.yml
@@ -1,12 +1,6 @@
 name: Refresh User Research Environment
 
 on:
-  workflow_call:
-    inputs:
-      stateFile:
-        required: true
-        default: populated.sql
-        type: string
   workflow_dispatch:
     inputs:
       stateFile:


### PR DESCRIPTION
Changes the workflows relating to the user research environment:

- No longer runs the smoke tests (because the environment will often have no cases/data to test with, and the researcher will be manually verifying the environment as part of the research process)
- No longer triggers an automatic data refresh (because this is not always desirable, for example, when fast-forwarding a deployed branch)