### PR TITLE
New search filter

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -147,6 +147,6 @@ private
   end
 
   def count_to_display
-    params[:hazard_type].blank? && params[:q].blank? ? Product.count : @results.total_count
+    params[:hazard_type].blank? && params[:q].blank? && params[:retired_status] == "active"  ? Product.not_retired.count : @results.total_count
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -147,6 +147,6 @@ private
   end
 
   def count_to_display
-    params[:hazard_type].blank? && params[:q].blank? && params[:retired_status] == "active"  ? Product.not_retired.count : @results.total_count
+    params[:hazard_type].blank? && params[:q].blank? && [nil, "active"].include?(params[:retired_status]) ? Product.not_retired.count : @results.total_count
   end
 end

--- a/app/helpers/product_search_helper.rb
+++ b/app/helpers/product_search_helper.rb
@@ -4,7 +4,8 @@ module ProductSearchHelper
   def filter_params(user)
     must_match_filters = [
       get_hazard_filter,
-      get_status_filter
+      get_status_filter,
+      get_retired_filter
     ].compact
 
     should_match_filters = [
@@ -23,6 +24,18 @@ module ProductSearchHelper
   def get_status_filter
     if @search.case_status == "open_only"
       { term: { "investigations.is_closed" => "false" } }
+    end
+  end
+
+  def get_retired_filter
+    return if @search.retired_status == "all"
+
+    if @search.retired_status == "active" || @search.retired_status.blank?
+      return { term: { "is_retired" => false } }
+    end
+
+    if @search.retired_status == "retired"
+      { term: { "is_retired" => true } }
     end
   end
 end

--- a/app/helpers/product_search_helper.rb
+++ b/app/helpers/product_search_helper.rb
@@ -31,11 +31,11 @@ module ProductSearchHelper
     return if @search.retired_status == "all"
 
     if @search.retired_status == "active" || @search.retired_status.blank?
-      return { term: { "is_retired" => false } }
+      return { term: { "retired?" => false } }
     end
 
     if @search.retired_status == "retired"
-      { term: { "is_retired" => true } }
+      { term: { "retired?" => true } }
     end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -13,7 +13,7 @@ module SearchHelper
   end
 
   def query_params
-    params.permit(:q, :sort_by, :sort_dir, :direction, :hazard_type, :page_name)
+    params.permit(:q, :sort_by, :sort_dir, :direction, :hazard_type, :retired_status, :page_name)
   end
 
   def sorting_params

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -22,6 +22,7 @@ class SearchParams
   attribute :teams_with_access_other_id
   attribute :hazard_type
   attribute :page_name
+  attribute :retired_status
 
   def selected_sort_by
     if sort_by.blank?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -45,7 +45,7 @@ class Product < ApplicationRecord
           methods: :owner_id
         }
       },
-      methods: %i[tiebreaker_id name_for_sorting psd_ref is_retired]
+      methods: %i[tiebreaker_id name_for_sorting psd_ref retired?]
     )
   end
 
@@ -129,9 +129,5 @@ class Product < ApplicationRecord
 
   def unique_investigation_products
     investigation_products.group_by(&:investigation_id).values.map(&:first)
-  end
-
-  def is_retired
-    retired_at ? true : false
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -45,7 +45,7 @@ class Product < ApplicationRecord
           methods: :owner_id
         }
       },
-      methods: %i[tiebreaker_id name_for_sorting psd_ref]
+      methods: %i[tiebreaker_id name_for_sorting psd_ref is_retired]
     )
   end
 
@@ -71,6 +71,8 @@ class Product < ApplicationRecord
                        :brand, :category, :country_of_origin, :created_at, :description,
                        :has_markings, :markings, :name, :product_code, :retired_at,
                        :subcategory, :updated_at, :webpage, :when_placed_on_market, :owning_team_id
+
+  scope :not_retired, -> { where(retired_at: nil) }
 
   def self.retire_stale_products!
     Product.not_retired.where("created_at < ?", 18.months.ago).select(&:stale?).each do |stale_product|
@@ -127,5 +129,9 @@ class Product < ApplicationRecord
 
   def unique_investigation_products
     investigation_products.group_by(&:investigation_id).values.map(&:first)
+  end
+
+  def is_retired
+    retired_at ? true : false
   end
 end

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -19,4 +19,8 @@ class ProductPolicy < ApplicationPolicy
   def can_spawn_case?
     record.not_retired?
   end
+
+  def can_view_retired_products?
+    user.is_opss?
+  end
 end

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -17,7 +17,7 @@
       attributes: { "data-opss-clear-on-reset" => "element" }
     ) %>
 
-    <% if current_user.is_opss? %>
+    <% if policy(Product).can_view_retired_products? %>
       <%= govukRadios(
       form: form,
       key: :retired_status,

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -17,6 +17,43 @@
       attributes: { "data-opss-clear-on-reset" => "element" }
     ) %>
 
+    <% if current_user.is_opss? %>
+      <%= govukRadios(
+      form: form,
+      key: :retired_status,
+      formGroup: {
+        classes: "opss-form-group opss-form-group--sm-labels"
+      },
+      classes: "govuk-radios govuk-radios--small",
+      fieldset: {
+        legend: {
+          text: "Product record status",
+          is_page_heading: false,
+          classes: "govuk-fieldset__legend--s govuk-!-font-weight-regular"
+        }
+      },
+      attributes: { "data-opss-reset-to-default" => "element" },
+      items: [
+      {
+        id: "active",
+        text: "Active",
+        value: "active",
+        checked: true
+      },
+      {
+        id: "retired",
+        text: "Retired",
+        value: "retired"
+      },
+      {
+        id: "all",
+        text: "All",
+        value: "all"
+      }
+      ]
+      ) %>
+    <% end %>
+
     <div class="govuk-button-group">
       <%= form.button "Apply", name: nil, type: "submit", class: "govuk-button" %>
       <%= form.button "Reset", name: nil, type: "reset", class: "govuk-button opss-button-link govuk-!-font-size-16 opss-nojs-hide", data: { "opss-clear-on-reset" => "trigger" } %>

--- a/app/views/products/_search_statement.html.erb
+++ b/app/views/products/_search_statement.html.erb
@@ -1,5 +1,6 @@
 <p class="govuk-body">
-  <% if keywords.blank? && filter.blank? %>
+  <% filters_are_blank = filter[:hazard_type].blank? && filter[:retired_status].blank? %>
+  <% if keywords.blank? && filters_are_blank %>
     There are currently <%= pluralize count, "product" %>.
   <% else %>
     <% if keywords.present? || filter.present? %>
@@ -7,8 +8,8 @@
       <% if keywords.present? %>
         matching keyword(s) <span class="govuk-!-font-weight-bold"><%= sanitize keywords %></span>,
       <% end %>
-      <% if filter.present? %>
-        using the current filter,
+      <% unless filters_are_blank %>
+        using the current filters,
       <% end %>
       <%= count == 1 ? "was" : "were" %> found.
     <% end %>

--- a/app/views/products/_table_row.html.erb
+++ b/app/views/products/_table_row.html.erb
@@ -1,10 +1,11 @@
-<tbody class="govuk-table__body">
+<% tbody_classes = class_names('govuk-table__body', "opss-grey-record" => product.is_retired) %>
+<tbody class="<%= tbody_classes %>">
   <tr class="govuk-table__row">
       <th class="govuk-visually-hidden">
           Product
       </th>
       <th id="item-<%= index %>" colspan="4" scope="colgroup" class="govuk-table__header">
-        <%= link_to product.name, product, class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to product.name, product, class: "govuk-link govuk-link--no-visited-state" %><%= '<span class="govuk-!-font-size-14 govuk-!-font-weight-regular opss-no-wrap">(Retired product record)</span>'.html_safe if product.is_retired %>
       </th>
   </tr>
   <tr class="govuk-table__row">

--- a/app/views/products/_table_row.html.erb
+++ b/app/views/products/_table_row.html.erb
@@ -1,4 +1,4 @@
-<% tbody_classes = class_names('govuk-table__body', "opss-grey-record" => product.is_retired) %>
+<% tbody_classes = class_names('govuk-table__body', "opss-grey-record" => product.retired?) %>
 <tbody class="<%= tbody_classes %>">
   <tr class="govuk-table__row">
       <th class="govuk-visually-hidden">
@@ -6,7 +6,7 @@
       </th>
       <th id="item-<%= index %>" colspan="4" scope="colgroup" class="govuk-table__header">
         <%= link_to product.name, product, class: "govuk-link govuk-link--no-visited-state" %>
-        <% if product.is_retired %>
+        <% if product.retired? %>
           <span class="govuk-!-font-size-14 govuk-!-font-weight-regular opss-no-wrap">(Retired product record)</span>
         <% end %>
       </th>

--- a/app/views/products/_table_row.html.erb
+++ b/app/views/products/_table_row.html.erb
@@ -5,7 +5,10 @@
           Product
       </th>
       <th id="item-<%= index %>" colspan="4" scope="colgroup" class="govuk-table__header">
-        <%= link_to product.name, product, class: "govuk-link govuk-link--no-visited-state" %><%= '<span class="govuk-!-font-size-14 govuk-!-font-weight-regular opss-no-wrap">(Retired product record)</span>'.html_safe if product.is_retired %>
+        <%= link_to product.name, product, class: "govuk-link govuk-link--no-visited-state" %>
+        <% if product.is_retired %>
+          <span class="govuk-!-font-size-14 govuk-!-font-weight-regular opss-no-wrap">(Retired product record)</span>
+        <% end %>
       </th>
   </tr>
   <tr class="govuk-table__row">

--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -10,6 +10,9 @@
       </p>
       <p class="govuk-body-s govuk-!-margin-bottom-1">
         You can filter the results by hazard type.
+        <% if current_user.is_opss? %>
+          As an OPSS user you can also include 'retired' product records in your search. (These are records which are no longer active and are now considered less relevant).
+        <% end %>
       </p>
       <p class="govuk-body-s govuk-visually-hidden">
         Search results appear within the following <code>form</code> and within the <code>role = region</code>.

--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -10,7 +10,7 @@
       </p>
       <p class="govuk-body-s govuk-!-margin-bottom-1">
         You can filter the results by hazard type.
-        <% if current_user.is_opss? %>
+        <% if policy(Product).can_view_retired_products? %>
           As an OPSS user you can also include 'retired' product records in your search. (These are records which are no longer active and are now considered less relevant).
         <% end %>
       </p>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <%= render "search_statement", count: @count, keywords: params[:q], filter: params[:hazard_type] %>
+            <%= render "search_statement", count: @count, keywords: params[:q], filter: { hazard_type: params[:hazard_type], retired_status: params[:retired_status] } %>
           </div>
         </div>
       <% elsif (@results.total_count && @results.total_count > 11) %>

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).not_to have_content(fire_product_2.name)
       expect(page).not_to have_content(chemical_product.name)
       expect(page).not_to have_content(drowning_product.name)
-      expect(page).to have_content(retired_drowning_product.name)
+      expect(page).to have_content(retired_drowning_product.name + "(Retired product record)")
       expect(page).to have_content("1 product using the current filters, was found.")
     end
 
@@ -156,7 +156,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).to have_content(fire_product_2.name)
       expect(page).to have_content(chemical_product.name)
       expect(page).to have_content(drowning_product.name)
-      expect(page).to have_content(retired_drowning_product.name)
+      expect(page).to have_content(retired_drowning_product.name + "(Retired product record)")
       expect(page).to have_content("5 products using the current filters, were found.")
     end
   end

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let!(:fire_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation]) }
   let!(:chemical_product) { create(:product, name: "Some lab stuff", investigations: [chemical_investigation]) }
   let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
-  let!(:retired_drowning_product) { create(:product, name: "Dangerous retired life vest", investigations: [drowning_investigation], retired_at: Time.now) }
+  let!(:retired_drowning_product) { create(:product, name: "Dangerous retired life vest", investigations: [drowning_investigation], retired_at: Time.zone.now) }
 
   before do
     Investigation.import scope: "not_deleted", refresh: :wait_for
@@ -25,6 +25,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       sign_in(user)
       visit products_path
     end
+
     scenario "no filters applied shows all non-retired products" do
       expect(page).to have_content(fire_product_1.name)
       expect(page).to have_content(fire_product_2.name)
@@ -144,7 +145,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).not_to have_content(fire_product_2.name)
       expect(page).not_to have_content(chemical_product.name)
       expect(page).not_to have_content(drowning_product.name)
-      expect(page).to have_content(retired_drowning_product.name + "(Retired product record)")
+      expect(page).to have_content("#{retired_drowning_product.name}(Retired product record)")
       expect(page).to have_content("1 product using the current filters, was found.")
     end
 
@@ -156,7 +157,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).to have_content(fire_product_2.name)
       expect(page).to have_content(chemical_product.name)
       expect(page).to have_content(drowning_product.name)
-      expect(page).to have_content(retired_drowning_product.name + "(Retired product record)")
+      expect(page).to have_content("#{retired_drowning_product.name}(Retired product record)")
       expect(page).to have_content("5 products using the current filters, were found.")
     end
   end

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type: :feature do
   let(:organisation)          { create(:organisation) }
   let(:user)                  { create(:user, :activated, organisation:, has_viewed_introduction: true) }
+  let(:opss_user)             { create(:user, :opss_user, :activated, organisation:, has_viewed_introduction: true) }
 
   let!(:chemical_investigation)              { create(:allegation, hazard_type: "Chemical") }
   let!(:fire_investigation)                  { create(:allegation, hazard_type: "Fire") }
@@ -12,90 +13,151 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let!(:fire_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation]) }
   let!(:chemical_product) { create(:product, name: "Some lab stuff", investigations: [chemical_investigation]) }
   let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
+  let!(:retired_drowning_product) { create(:product, name: "Dangerous retired life vest", investigations: [drowning_investigation], retired_at: Time.now) }
 
   before do
     Investigation.import scope: "not_deleted", refresh: :wait_for
     Product.import refresh: :wait_for
-    sign_in(user)
-    visit products_path
   end
 
-  scenario "no filters applied shows all products" do
-    expect(page).to have_content(fire_product_1.name)
-    expect(page).to have_content(fire_product_2.name)
-    expect(page).to have_content(chemical_product.name)
-    expect(page).to have_content(drowning_product.name)
-    expect(page).to have_content("There are currently 4 products.")
-  end
-
-  context "when there are multiple pages of products" do
+  context "when user is non OPSS" do
     before do
-      17.times { Product.create(name: "TestProduct") }
-      Product.import refresh: :wait_for
+      sign_in(user)
+      visit products_path
+    end
+    scenario "no filters applied shows all non-retired products" do
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).to have_content(chemical_product.name)
+      expect(page).to have_content(drowning_product.name)
+      expect(page).to have_content("There are currently 4 products.")
+    end
+
+    context "when there are multiple pages of products" do
+      before do
+        17.times { Product.create(name: "TestProduct") }
+        Product.import refresh: :wait_for
+        visit products_path
+      end
+
+      it "shows total number of products regardless of how many are on the current page" do
+        expect(page).to have_content("There are currently #{Product.not_retired.count} products.")
+      end
+    end
+
+    scenario "filtering by hazard type" do
+      select "Fire", from: "Hazard type"
+      click_button "Apply"
+
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).not_to have_content(chemical_product.name)
+      expect(page).not_to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).to have_content("2 products using the current filters, were found.")
+    end
+
+    scenario "filtering by hazard type and a keyword" do
+      select "Fire", from: "Hazard type"
+      fill_in "Search", with: "Fire"
+      click_button "Apply"
+
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).not_to have_content(chemical_product.name)
+      expect(page).not_to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).to have_content("2 products matching keyword(s) Fire, using the current filters, were found.")
+    end
+
+    scenario "filtering by a keyword" do
+      fill_in "Search", with: "Dangerous"
+      click_button "Apply"
+
+      expect(page).to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).not_to have_content(fire_product_1.name)
+      expect(page).not_to have_content(fire_product_2.name)
+      expect(page).not_to have_content(chemical_product.name)
+      expect(page).to have_content("1 product matching keyword(s) Dangerous, was found.")
+    end
+
+    scenario "filtering by a keyword with whitespaces" do
+      fill_in "Search", with: "   Dangerous    "
+      click_button "Apply"
+
+      expect(page).to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).not_to have_content(fire_product_1.name)
+      expect(page).not_to have_content(fire_product_2.name)
+      expect(page).not_to have_content(chemical_product.name)
+      expect(page).to have_content("1 product matching keyword(s) Dangerous, was found.")
+    end
+
+    scenario "filtering by an ID" do
+      fill_in "Search", with: chemical_product.id
+      click_button "Apply"
+
+      expect(page).to have_content(chemical_product.name)
+    end
+
+    scenario "filtering by a PSD ref" do
+      fill_in "Search", with: chemical_product.psd_ref
+      click_button "Apply"
+
+      expect(page).to have_content(chemical_product.name)
+    end
+  end
+
+  context "when user is OPSS" do
+    before do
+      sign_in(opss_user)
       visit products_path
     end
 
-    it "shows total number of products regardless of how many are on the current page" do
-      expect(page).to have_content("There are currently #{Product.count} products.")
+    scenario "no filters applied shows all non-retired products" do
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).to have_content(chemical_product.name)
+      expect(page).to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).to have_content("There are currently 4 products.")
     end
-  end
 
-  scenario "filtering by hazard type" do
-    select "Fire", from: "Hazard type"
-    click_button "Apply"
+    scenario "filtering by active products" do
+      within_fieldset("Product record status") { choose "Active" }
+      click_button "Apply"
 
-    expect(page).to have_content(fire_product_1.name)
-    expect(page).to have_content(fire_product_2.name)
-    expect(page).not_to have_content(chemical_product.name)
-    expect(page).not_to have_content(drowning_product.name)
-    expect(page).to have_content("2 products using the current filter, were found.")
-  end
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).to have_content(chemical_product.name)
+      expect(page).to have_content(drowning_product.name)
+      expect(page).not_to have_content(retired_drowning_product.name)
+      expect(page).to have_content("4 products using the current filters, were found.")
+    end
 
-  scenario "filtering by hazard type and a keyword" do
-    select "Fire", from: "Hazard type"
-    fill_in "Search", with: "Fire"
-    click_button "Apply"
+    scenario "filtering by retired products" do
+      within_fieldset("Product record status") { choose "Retired" }
+      click_button "Apply"
 
-    expect(page).to have_content(fire_product_1.name)
-    expect(page).to have_content(fire_product_2.name)
-    expect(page).not_to have_content(chemical_product.name)
-    expect(page).not_to have_content(drowning_product.name)
-    expect(page).to have_content("2 products matching keyword(s) Fire, using the current filter, were found.")
-  end
+      expect(page).not_to have_content(fire_product_1.name)
+      expect(page).not_to have_content(fire_product_2.name)
+      expect(page).not_to have_content(chemical_product.name)
+      expect(page).not_to have_content(drowning_product.name)
+      expect(page).to have_content(retired_drowning_product.name)
+      expect(page).to have_content("1 product using the current filters, was found.")
+    end
 
-  scenario "filtering by a keyword" do
-    fill_in "Search", with: "Dangerous"
-    click_button "Apply"
+    scenario "filtering by both retired and active products" do
+      within_fieldset("Product record status") { choose "All" }
+      click_button "Apply"
 
-    expect(page).to have_content(drowning_product.name)
-    expect(page).not_to have_content(fire_product_1.name)
-    expect(page).not_to have_content(fire_product_2.name)
-    expect(page).not_to have_content(chemical_product.name)
-    expect(page).to have_content("1 product matching keyword(s) Dangerous, was found.")
-  end
-
-  scenario "filtering by a keyword with whitespaces" do
-    fill_in "Search", with: "   Dangerous    "
-    click_button "Apply"
-
-    expect(page).to have_content(drowning_product.name)
-    expect(page).not_to have_content(fire_product_1.name)
-    expect(page).not_to have_content(fire_product_2.name)
-    expect(page).not_to have_content(chemical_product.name)
-    expect(page).to have_content("1 product matching keyword(s) Dangerous, was found.")
-  end
-
-  scenario "filtering by an ID" do
-    fill_in "Search", with: chemical_product.id
-    click_button "Apply"
-
-    expect(page).to have_content(chemical_product.name)
-  end
-
-  scenario "filtering by a PSD ref" do
-    fill_in "Search", with: chemical_product.psd_ref
-    click_button "Apply"
-
-    expect(page).to have_content(chemical_product.name)
+      expect(page).to have_content(fire_product_1.name)
+      expect(page).to have_content(fire_product_2.name)
+      expect(page).to have_content(chemical_product.name)
+      expect(page).to have_content(drowning_product.name)
+      expect(page).to have_content(retired_drowning_product.name)
+      expect(page).to have_content("5 products using the current filters, were found.")
+    end
   end
 end

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -145,7 +145,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).not_to have_content(fire_product_2.name)
       expect(page).not_to have_content(chemical_product.name)
       expect(page).not_to have_content(drowning_product.name)
-      expect(page).to have_content("#{retired_drowning_product.name}(Retired product record)")
+      expect(page).to have_content("#{retired_drowning_product.name} (Retired product record)")
       expect(page).to have_content("1 product using the current filters, was found.")
     end
 
@@ -157,7 +157,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).to have_content(fire_product_2.name)
       expect(page).to have_content(chemical_product.name)
       expect(page).to have_content(drowning_product.name)
-      expect(page).to have_content("#{retired_drowning_product.name}(Retired product record)")
+      expect(page).to have_content("#{retired_drowning_product.name} (Retired product record)")
       expect(page).to have_content("5 products using the current filters, were found.")
     end
   end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
 
     context "when over 10k cases exist" do
       before do
-        not_retired_products_double = double("not_retired_products")
+        not_retired_products_double = instance_double("not_retired_products")
         allow(Product).to receive(:not_retired).and_return(not_retired_products_double)
         allow(not_retired_products_double).to receive(:count).and_return(10_001)
       end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -84,7 +84,9 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
 
     context "when over 10k cases exist" do
       before do
-        allow(Product).to receive(:count).and_return(10_001)
+        not_retired_products_double = double("not_retired_products")
+        allow(Product).to receive(:not_retired).and_return(not_retired_products_double)
+        allow(not_retired_products_double).to receive(:count).and_return(10_001)
       end
 
       it "shows total number of cases" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1168

## Description
This change allows opss users to filter by retired or active products. It does not allow non opss users to use this filter and instead only shows them active products.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
