### PR TITLE
Retired product page

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -29,7 +29,7 @@ class ProductsController < ApplicationController
       render_404_page and return unless @product
     else
       # Anyone can view timestamped products, but only certain people can view live [retired] products
-      return render "/products/retired" unless Pundit.policy(current_user, @product).show?
+      return render "/products/retired" unless policy(@product).show?
     end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -29,7 +29,7 @@ class ProductsController < ApplicationController
       render_404_page and return unless @product
     else
       # Anyone can view timestamped products, but only certain people can view live [retired] products
-      authorize @product
+      return render "/products/retired" unless Pundit.policy(current_user, @product).show?
     end
   end
 

--- a/app/views/products/retired.html.erb
+++ b/app/views/products/retired.html.erb
@@ -1,0 +1,35 @@
+<%= page_title "Product record no match" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      The product record does not exist
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-9">
+      A product record matching <span class="govuk-!-font-weight-bold"><abbr>psd</abbr>-<%= @product.id %></span> does not exist or is no longer available.
+    </p>
+
+    <% if @product.investigations %>
+      <p class="govuk-body">
+        These closed cases were originally linked to the product record (and are now linked to their own copy of the original product record).
+      </p>
+
+      <div class="opss-2-col-flow">
+        <ul class="govuk-list govuk-list--bullet">
+          <% @product.investigations.each do |investigation| %>
+            <li>
+              <%= link_to investigation.title, investigation_path(investigation), class: "govuk-link govuk-link--no-visited-state" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <p class="govuk-body">
+      <%= link_to "Search for product records", products_path, class: "govuk-link govuk-link--no-visited-state" %>
+    </p>
+  </div>
+</div>

--- a/spec/features/retired_products_spec.rb
+++ b/spec/features/retired_products_spec.rb
@@ -48,8 +48,17 @@ RSpec.feature "Retired products", :with_opensearch, :with_stubbed_mailer, type: 
       expect(page).to have_summary_item(key: "Record owner", value: owning_team.name)
     end
 
-    scenario "the user can not view a retired product" do
-      expect { visit product_path(retired_product) }.to raise_error(Pundit::NotAuthorizedError)
+    context "when user tries to view a retired product" do
+      before do
+        create(:allegation, products: [retired_product])
+        retired_product.reload.decorate
+      end
+
+      it "shows retired product page and links to the investigations related to the product" do
+        visit product_path(retired_product)
+        expect(page).to have_css("h1", text: "The product record does not exist")
+        expect(page).to have_link(retired_product.investigations.first.title, href: "/cases/#{retired_product.investigations.first.pretty_id}")
+      end
     end
 
     scenario "the user can not view a retired product's owner" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1169

## Description
This change adds a retired product page to be shown when a none opss user tries to view a retired product.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
