### PR TITLE
Product pages changes

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -148,6 +148,6 @@ private
   end
 
   def count_to_display
-    params[:hazard_type].blank? && params[:q].blank? && [nil, "active"].include?(params[:retired_status]) ? Product.not_retired.count : @results.total_count
+    params[:category].blank? && params[:q].blank? && [nil, "active"].include?(params[:retired_status]) ? Product.not_retired.count : @results.total_count
   end
 end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -31,7 +31,7 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Webpage" }, value: { html: webpage_html } },
       { key: { text: "Market date" }, value: { text: when_placed_on_market_value }, secondary_text: { text: "Placed on the market" } },
       { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
-      { key: { text: "Counterfeit" }, value: counterfeit_value },
+      { key: { text: "Counterfeit" }, value: counterfeit_row_value },
       { key: { text: "Product marking" }, value: { text: markings } },
       { key: { text: "Other product identifiers" }, value: { text: product_code } },
     ]
@@ -100,7 +100,7 @@ class ProductDecorator < ApplicationDecorator
     object.investigations.map(&:pretty_id)
   end
 
-  def counterfeit_value
+  def counterfeit_row_value
     if product.counterfeit?
       return { html: "<span class='opss-tag opss-tag--risk2 opss-tag--lrg'>Yes</span>".html_safe, secondary_text: { text: "This is a product record for a counterfeit product" } }
     end
@@ -110,6 +110,12 @@ class ProductDecorator < ApplicationDecorator
     end
 
     { text: I18n.t(object.authenticity || :missing, scope: Product.model_name.i18n_key) }
+  end
+
+  def counterfeit_value
+    return "Unsure" if product.unsure?
+
+    product.counterfeit? ? "<span class='opss-tag opss-tag--risk2 opss-tag--lrg'>Yes</span>".html_safe : "No"
   end
 
   def activity_view_link(timestamp)

--- a/app/helpers/product_search_helper.rb
+++ b/app/helpers/product_search_helper.rb
@@ -3,7 +3,7 @@ module ProductSearchHelper
 
   def filter_params(user)
     must_match_filters = [
-      get_hazard_filter,
+      get_category_filter,
       get_status_filter,
       get_retired_filter
     ].compact
@@ -15,9 +15,9 @@ module ProductSearchHelper
     { must: must_match_filters, should: should_match_filters }
   end
 
-  def get_hazard_filter
-    if params[:hazard_type].present?
-      { match: { "investigations.hazard_type" => @search.hazard_type } }
+  def get_category_filter
+    if params[:category].present?
+      { match: { "category" => @search.category } }
     end
   end
 

--- a/app/helpers/product_search_helper.rb
+++ b/app/helpers/product_search_helper.rb
@@ -17,7 +17,7 @@ module ProductSearchHelper
 
   def get_category_filter
     if params[:category].present?
-      { match: { "category" => @search.category } }
+      { match_phrase: { "category" => @search.category } }
     end
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -33,7 +33,7 @@ module ProductsHelper
   end
 
   def product_export_params
-    params.permit(:q, :hazard_type)
+    params.permit(:q, :category)
   end
 
   def sorting_params

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -13,7 +13,7 @@ module SearchHelper
   end
 
   def query_params
-    params.permit(:q, :sort_by, :sort_dir, :direction, :hazard_type, :retired_status, :page_name)
+    params.permit(:q, :sort_by, :sort_dir, :direction, :category, :retired_status, :page_name)
   end
 
   def sorting_params

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -21,6 +21,7 @@ class SearchParams
   attribute :teams_with_access, default: "all"
   attribute :teams_with_access_other_id
   attribute :hazard_type
+  attribute :category
   attribute :page_name
   attribute :retired_status
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -41,7 +41,7 @@ class Product < ApplicationRecord
     as_json(
       include: {
         investigations: {
-          only: %i[hazard_type is_closed],
+          only: %i[category is_closed],
           methods: :owner_id
         }
       },

--- a/app/models/product_export.rb
+++ b/app/models/product_export.rb
@@ -90,10 +90,6 @@ private
                      updated_at
                      webpage
                      when_placed_on_market
-                     reported_reason
-                     hazard_type
-                     non_compliant_reason
-                     risk_level
                      owning_team]
 
     @product_info_sheet = sheet
@@ -157,10 +153,6 @@ private
       product.updated_at,
       product.webpage,
       product.when_placed_on_market,
-      product.investigations.first.try(:reported_reason),
-      product.investigations.first.try(:hazard_type),
-      product.investigations.first.try(:non_compliant_reason),
-      product.investigations.first.try(:risk_level),
       product.owning_team.try(:name)
     ]
   end

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -22,6 +22,8 @@ class AddProductToCase
 
     change_product_owner_if_unowned
 
+    product.__elasticsearch__.update_document
+
     context.activity = create_audit_activity_for_product_added
 
     send_notification_email unless skip_email

--- a/app/services/change_case_status.rb
+++ b/app/services/change_case_status.rb
@@ -24,8 +24,13 @@ class ChangeCaseStatus
       create_audit_activity_for_case_status_changed
     end
 
-    investigation.products.each { |product| product.__elasticsearch__.update_document }
-    investigation.businesses.each { |business| business.__elasticsearch__.update_document }
+    investigation.products.each do |product|
+      Product.find(product.id).__elasticsearch__.update_document
+    end
+
+    investigation.businesses.each do |business|
+      Business.find(business.id).__elasticsearch__.update_document
+    end
 
     send_notification_email
   end

--- a/app/services/change_case_status.rb
+++ b/app/services/change_case_status.rb
@@ -28,7 +28,7 @@ class ChangeCaseStatus
       product.reload.__elasticsearch__.update_document
     end
 
-    investigation.reload.businesses.each do |business|
+    investigation.businesses.each do |business|
       business.reload.__elasticsearch__.update_document
     end
 

--- a/app/services/change_case_status.rb
+++ b/app/services/change_case_status.rb
@@ -24,12 +24,12 @@ class ChangeCaseStatus
       create_audit_activity_for_case_status_changed
     end
 
-    investigation.products.each do |product|
-      Product.find(product.id).__elasticsearch__.update_document
+    investigation.reload.products.each do |product|
+      product.reload.__elasticsearch__.update_document
     end
 
-    investigation.businesses.each do |business|
-      Business.find(business.id).__elasticsearch__.update_document
+    investigation.reload.businesses.each do |business|
+      business.reload.__elasticsearch__.update_document
     end
 
     send_notification_email

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -8,10 +8,10 @@
     <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
     <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
     <%= govukSelect(
-      key: "hazard_type",
+      key: "category",
       form: form,
-      items: [{ text: "All", value: "", attributes: { class: "govuk-!-font-size-16" }}] + hazard_types.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
-      label: { text: "Hazard type" },
+      items: [{ text: "All", value: "", attributes: { class: "govuk-!-font-size-16" }}] + product_categories.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
+      label: { text: "Category" },
       formGroup: { classes: "govuk-!-margin-right-1" },
       is_autocomplete: false,
       attributes: { "data-opss-clear-on-reset" => "element" }

--- a/app/views/products/_search_statement.html.erb
+++ b/app/views/products/_search_statement.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  <% filters_are_blank = filter[:hazard_type].blank? && filter[:retired_status].blank? %>
+  <% filters_are_blank = filter[:category].blank? && filter[:retired_status].blank? %>
   <% if keywords.blank? && filters_are_blank %>
     There are currently <%= pluralize count, "product" %>.
   <% else %>

--- a/app/views/products/_table.html.erb
+++ b/app/views/products/_table.html.erb
@@ -6,9 +6,9 @@
       <tr class="govuk-table__row">
           <th class="govuk-visually-hidden">&nbsp;</th>
           <th id="psdref" scope="col" class="govuk-table__header"><%= psd_abbr title: false %> ref</th>
-          <th id="prodtype" scope="col" class="govuk-table__header">Product type</th>
-          <th id="haztype" scope="col" class="govuk-table__header">Hazard type</th>
           <th id="cat" scope="col" class="govuk-table__header">Category</th>
+          <th id="prodtype" scope="col" class="govuk-table__header">Product type</th>
+          <th id="haztype" scope="col" class="govuk-table__header">Counterfeit</th>
       </tr>
   </thead>
 
@@ -21,9 +21,9 @@
       <tr class="govuk-table__row">
           <th class="govuk-visually-hidden">&nbsp;</th>
           <th scope="col" class="govuk-table__header"><%= psd_abbr title: false %> ref</th>
-          <th scope="col" class="govuk-table__header">Type</th>
-          <th scope="col" class="govuk-table__header">Hazard type</th>
           <th scope="col" class="govuk-table__header">Category</th>
+          <th scope="col" class="govuk-table__header">Product type</th>
+          <th scope="col" class="govuk-table__header">Counterfeit</th>
       </tr>
     </tfoot>
   <% end %>

--- a/app/views/products/_table_row.html.erb
+++ b/app/views/products/_table_row.html.erb
@@ -24,12 +24,8 @@
       <td headers="prodtype item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
         <%= product.subcategory %>
       </td>
-      <td headers="haztype item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
-        <% if product.counterfeit? %>
-          <span class="opss-tag opss-tag--risk2 opss-tag--lrg">Yes</span>
-        <% else %>
-          No
-        <% end %>
+      <td headers="counterfeit item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
+        <%= product.counterfeit_value %>
       </td>
   </tr>
 </tbody>

--- a/app/views/products/_table_row.html.erb
+++ b/app/views/products/_table_row.html.erb
@@ -18,14 +18,18 @@
       <td headers="psdref item-<%= index %> meta-<%= index %>" class="govuk-table__cell opss-no-wrap">
         <%= product.psd_ref %>
       </td>
+      <td headers="cat item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
+        <%= product.category %>
+      </td>
       <td headers="prodtype item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
         <%= product.subcategory %>
       </td>
       <td headers="haztype item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
-        <%= product.investigations.first.try(:hazard_type) %>
-      </td>
-      <td headers="cat item-<%= index %> meta-<%= index %>" class="govuk-table__cell">
-        <%= product.category %>
+        <% if product.counterfeit? %>
+          <span class="opss-tag opss-tag--risk2 opss-tag--lrg">Yes</span>
+        <% else %>
+          No
+        <% end %>
       </td>
   </tr>
 </tbody>

--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -9,7 +9,7 @@
         <span id="search-hint">You can search for one or more products by using the keywords that describe them or use a single <%= psd_abbr title: false %> reference number to find a specific product record.</span> You can also sort the ordering of the search results.
       </p>
       <p class="govuk-body-s govuk-!-margin-bottom-1">
-        You can filter the results by hazard type.
+        You can filter the results by product category.
         <% if policy(Product).can_view_retired_products? %>
           As an OPSS user you can also include 'retired' product records in your search. (These are records which are no longer active and are now considered less relevant).
         <% end %>

--- a/app/views/products/heading/_team_products.html.erb
+++ b/app/views/products/heading/_team_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Team products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} product records included in open cases where the #{current_user.team.name} team is the case owner." %>
+      <%= "There are #{count} product records linked to open cases where the #{current_user.team.name} team is the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/products/heading/_team_products.html.erb
+++ b/app/views/products/heading/_team_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Team products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} products linked to open cases where the #{current_user.team.name} team is the case owner." %>
+      <%= "There are #{count} product records included in open cases where the #{current_user.team.name} team is the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/products/heading/_your_products.html.erb
+++ b/app/views/products/heading/_your_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Your products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} products linked to open cases where you are the case owner." %>
+      <%= "There are #{count} product records included in cases where you are the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/products/heading/_your_products.html.erb
+++ b/app/views/products/heading/_your_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Your products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} product records included in cases where you are the case owner." %>
+      <%= "There are #{count} product records linked to open cases where you are the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <%= render "search_statement", count: @count, keywords: params[:q], filter: { hazard_type: params[:hazard_type], retired_status: params[:retired_status] } %>
+            <%= render "search_statement", count: @count, keywords: params[:q], filter: { category: params[:category], retired_status: params[:retired_status] } %>
           </div>
         </div>
       <% elsif (@results.total_count && @results.total_count > 11) %>

--- a/spec/features/export_products_spec.rb
+++ b/spec/features/export_products_spec.rb
@@ -11,11 +11,9 @@ RSpec.feature "Product export", :with_opensearch, :with_stubbed_antivirus, :with
     end
   end
 
-  let!(:product_1) { create(:product, name: "ABC") }
-  let!(:product_2) { create(:product, name: "XYZ") }
-  let!(:hazardous_product) { create(:product, name: "STU") }
-  let!(:investigation) { create(:allegation, :reported_unsafe, :with_products, products: [hazardous_product]) }
-  let(:hazard_type) { investigation.hazard_type }
+  let!(:product_1) { create(:product, name: "ABC", category: "Lifts") }
+  let!(:product_2) { create(:product, name: "XYZ", category: "Hand sanitiser") }
+  let!(:hazardous_product) { create(:product, name: "STU", category: "Waste") }
 
   before do
     Product.import force: true, refresh: :wait_for
@@ -61,10 +59,10 @@ RSpec.feature "Product export", :with_opensearch, :with_stubbed_antivirus, :with
     expect(spreadsheet.cell(2, 13)).to eq(product_2.name)
   end
 
-  scenario "with hazard type filter" do
+  scenario "with category filter" do
     visit products_path
 
-    select hazard_type, from: "Hazard type"
+    select hazardous_product.category, from: "Category"
     click_button "Submit search"
 
     expect(page).not_to have_text product_1.name

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let!(:fire_investigation)                  { create(:allegation, hazard_type: "Fire") }
   let!(:drowning_investigation)              { create(:allegation, hazard_type: "Drowning") }
 
-  let!(:lift_product_1)   { create(:product, name: "Elevator", investigations: [fire_investigation], category: "Lifts") }
-  let!(:lift_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation], category: "Lifts") }
+  let!(:lift_product_1)   { create(:product, name: "Elevator", investigations: [fire_investigation], category: "Clothing, textiles and fashion items") }
+  let!(:lift_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation], category: "Clothing, textiles and fashion items") }
   let!(:furniture_product) { create(:product, name: "Hot product1", investigations: [chemical_investigation], category: "Furniture") }
-  let!(:sanitiser_product) { create(:product, name: "SoapForHandz", investigations: [drowning_investigation], category: "Hand sanitiser") }
+  let!(:sanitiser_product) { create(:product, name: "SoapForHandz", investigations: [drowning_investigation], category: "Communication and media equipment") }
   let!(:retired_sanitiser_product) { create(:product, name: "Dangerous retired life vest", investigations: [drowning_investigation], retired_at: Time.zone.now, category: "Hand sanitiser") }
 
   before do
@@ -47,7 +47,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
     end
 
     scenario "filtering by category" do
-      select "Lifts", from: "Category"
+      select "Clothing, textiles and fashion items", from: "Category"
       click_button "Apply"
 
       expect(page).to have_content(lift_product_1.name)
@@ -59,7 +59,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
     end
 
     scenario "filtering by category and a keyword" do
-      select "Lifts", from: "Category"
+      select "Clothing, textiles and fashion items", from: "Category"
       fill_in "Search", with: "Elevator"
       click_button "Apply"
 

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -26,12 +26,12 @@ RSpec.feature "Searching products", :with_opensearch, :with_stubbed_mailer, type
     click_on "Your products"
 
     expect(highlighted_tab).to eq "Your products"
-    expect(page).to have_content "There are 0 product records included in cases where you are the case owner."
+    expect(page).to have_content "There are 0 product records linked to open cases where you are the case owner."
 
     click_on "Team products"
 
     expect(highlighted_tab).to eq "Team products"
-    expect(page).to have_content "There are 0 product records included in open cases where the #{team.name} team is the case owner."
+    expect(page).to have_content "There are 0 product records linked to open cases where the #{team.name} team is the case owner."
   end
 
   scenario "Browsing products" do

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -26,12 +26,12 @@ RSpec.feature "Searching products", :with_opensearch, :with_stubbed_mailer, type
     click_on "Your products"
 
     expect(highlighted_tab).to eq "Your products"
-    expect(page).to have_content "There are 0 products linked to open cases where you are the case owner."
+    expect(page).to have_content "There are 0 product records included in cases where you are the case owner."
 
     click_on "Team products"
 
     expect(highlighted_tab).to eq "Team products"
-    expect(page).to have_content "There are 0 products linked to open cases where the #{team.name} team is the case owner."
+    expect(page).to have_content "There are 0 product records included in open cases where the #{team.name} team is the case owner."
   end
 
   scenario "Browsing products" do

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: :feature do
   let(:user)             { create :user, :activated, has_viewed_introduction: true }
-  let!(:iphone)          { create(:product_iphone,          created_at: 1.day.ago) }
-  let!(:iphone_3g)       { create(:product_iphone_3g,       created_at: 2.days.ago) }
-  let!(:washing_machine) { create(:product_washing_machine, created_at: 3.days.ago) }
+  let!(:iphone)          { create(:product_iphone,          created_at: 1.day.ago, authenticity: "counterfeit") }
+  let!(:iphone_3g)       { create(:product_iphone_3g,       created_at: 2.days.ago, authenticity: "genuine") }
+  let!(:washing_machine) { create(:product_washing_machine, created_at: 3.days.ago, authenticity: "unsure") }
   let!(:investigation)    { create(:allegation, products: [iphone], hazard_type: "Cuts") }
 
   context "with less than 12 products" do
@@ -41,7 +41,7 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
       expect(psd_ref.text).to eq iphone.psd_ref
       expect(subcategory.text).to eq iphone.subcategory
       expect(category.text).to eq iphone.category
-      expect(hazard_type.text).to eq investigation.hazard_type
+      expect_correct_counterfeit_values
 
       within "#item-1" do
         expect(page).to have_link(iphone_3g.name, href: product_path(iphone_3g))
@@ -103,12 +103,18 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
       find('[headers="prodtype item-0 meta-0"]')
     end
 
-    def hazard_type
-      find('[headers="haztype item-0 meta-0"]')
+    def counterfeit(product_index)
+      find("[headers='counterfeit item-#{product_index} meta-#{product_index}']")
     end
 
     def category
-      find('[headers="cat item-0 meta-0"]')
+      find("[headers='cat item-0 meta-0']")
+    end
+
+    def expect_correct_counterfeit_values
+      expect(counterfeit(0).text).to eq "Yes"
+      expect(counterfeit(1).text).to eq "No"
+      expect(counterfeit(2).text).to eq "Unsure"
     end
   end
 end

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
   let(:organisation)          { create(:organisation) }
   let(:user)                  { create(:user, :activated, organisation:, has_viewed_introduction: true) }
 
+  # rubocop:disable RSpec/LetSetup
   let!(:fire_product_1)   { create(:product, name: "Hot product", category: "Lifts") }
   let!(:fire_product_2)   { create(:product, name: "Xtra hot product", category: "Lifts") }
   let!(:fire_product_3)   { create(:product, name: "Very very hot product", category: "Lifts") }
@@ -20,6 +21,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
   let!(:drowning_product) { create(:product, name: "Dangerous life vest") }
   let!(:another_drowning_product) { create(:product, name: "Another dangerous life vest") }
   let!(:zebra_product) { create(:product, name: "Zebra print jacket") }
+  # rubocop:enable RSpec/LetSetup
 
   before do
     Investigation.import scope: "not_deleted", refresh: :wait_for

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -4,27 +4,22 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
   let(:organisation)          { create(:organisation) }
   let(:user)                  { create(:user, :activated, organisation:, has_viewed_introduction: true) }
 
-  let!(:chemical_investigation)              { create(:allegation, hazard_type: "Chemical") }
-  let!(:fire_investigation)                  { create(:allegation, hazard_type: "Fire") }
-  let!(:drowning_investigation)              { create(:allegation, hazard_type: "Drowning") }
-  # rubocop:disable RSpec/LetSetup
-  let!(:fire_product_1)   { create(:product, name: "Hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_2)   { create(:product, name: "Xtra hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_3)   { create(:product, name: "Very very hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_4)   { create(:product, name: "Super hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_5)   { create(:product, name: "Extra hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_6)   { create(:product, name: "Firey hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_7)   { create(:product, name: "Mega hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_8)   { create(:product, name: "Crazy hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_9)   { create(:product, name: "Spicy hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_10)   { create(:product, name: "Ultra hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_11)   { create(:product, name: "Intense hot product", investigations: [fire_investigation]) }
-  let!(:fire_product_12)   { create(:product, name: "Smoking hot product", investigations: [fire_investigation]) }
-  let!(:chemical_product) { create(:product, name: "Some lab stuff", investigations: [chemical_investigation]) }
-  let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
-  let!(:another_drowning_product) { create(:product, name: "Another dangerous life vest", investigations: [drowning_investigation]) }
-  let!(:zebra_product) { create(:product, name: "Zebra print jacket", investigations: [drowning_investigation]) }
-  # rubocop:enable RSpec/LetSetup
+  let!(:fire_product_1)   { create(:product, name: "Hot product", category: "Lifts") }
+  let!(:fire_product_2)   { create(:product, name: "Xtra hot product", category: "Lifts") }
+  let!(:fire_product_3)   { create(:product, name: "Very very hot product", category: "Lifts") }
+  let!(:fire_product_4)   { create(:product, name: "Super hot product", category: "Lifts") }
+  let!(:fire_product_5)   { create(:product, name: "Extra hot product", category: "Lifts") }
+  let!(:fire_product_6)   { create(:product, name: "Firey hot product", category: "Lifts") }
+  let!(:fire_product_7)   { create(:product, name: "Mega hot product", category: "Lifts") }
+  let!(:fire_product_8)   { create(:product, name: "Crazy hot product", category: "Lifts") }
+  let!(:fire_product_9)   { create(:product, name: "Spicy hot product", category: "Lifts") }
+  let!(:fire_product_10)   { create(:product, name: "Ultra hot product", category: "Lifts") }
+  let!(:fire_product_11)   { create(:product, name: "Intense hot product", category: "Lifts") }
+  let!(:fire_product_12)   { create(:product, name: "Smoking hot product", category: "Lifts") }
+  let!(:chemical_product) { create(:product, name: "Some lab stuff") }
+  let!(:drowning_product) { create(:product, name: "Dangerous life vest") }
+  let!(:another_drowning_product) { create(:product, name: "Another dangerous life vest") }
+  let!(:zebra_product) { create(:product, name: "Zebra print jacket") }
 
   before do
     Investigation.import scope: "not_deleted", refresh: :wait_for
@@ -70,12 +65,12 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
     expect(page).to have_css("#item-3", text: fire_product_10.name)
   end
 
-  scenario "selected sort order is persisted when filtering by hazard type" do
+  scenario "selected sort order is persisted when filtering by category" do
     within "form dl.govuk-list.opss-dl-select" do
       click_on "Name A–Z"
     end
 
-    select "Fire", from: "Hazard type"
+    select "Lifts", from: "Category"
     click_button "Apply"
 
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
@@ -88,7 +83,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
 
     expect(page).to have_css("form dl.govuk-list.opss-dl-select dd", text: "Active: Relevance")
 
-    select "Fire", from: "Hazard type"
+    select "Lifts", from: "Category"
     click_button "Apply"
 
     expect(page).to have_current_path(/sort_by=relevant/, ignore_query: false)

--- a/spec/models/product_export_spec.rb
+++ b/spec/models/product_export_spec.rb
@@ -112,22 +112,6 @@ RSpec.describe ProductExport, :with_opensearch, :with_stubbed_notify, :with_stub
       expect(product_sheet.cell(2, 18)).to eq product.when_placed_on_market
       expect(product_sheet.cell(3, 18)).to eq other_product.when_placed_on_market
 
-      expect(product_sheet.cell(1, 19)).to eq "reported_reason"
-      expect(product_sheet.cell(2, 19)).to eq product.investigations.first.reported_reason
-      expect(product_sheet.cell(3, 19)).to eq other_product.investigations.first.reported_reason
-
-      expect(product_sheet.cell(1, 20)).to eq "hazard_type"
-      expect(product_sheet.cell(2, 20)).to eq product.investigations.first.hazard_type
-      expect(product_sheet.cell(3, 20)).to eq other_product.investigations.first.hazard_type
-
-      expect(product_sheet.cell(1, 21)).to eq "non_compliant_reason"
-      expect(product_sheet.cell(2, 21)).to eq product.investigations.first.non_compliant_reason
-      expect(product_sheet.cell(3, 21)).to eq other_product.investigations.first.non_compliant_reason
-
-      expect(product_sheet.cell(1, 22)).to eq "risk_level"
-      expect(product_sheet.cell(2, 22)).to eq product.investigations.first.risk_level
-      expect(product_sheet.cell(3, 22)).to eq other_product.investigations.first.risk_level
-
       expect(test_result_sheet.cell(1, 1)).to eq "psd_ref"
       expect(test_result_sheet.cell(2, 1)).to eq product.psd_ref
       expect(test_result_sheet.cell(3, 1)).to eq product.psd_ref


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1170

## Description
This change removes the hazard_type filter on the products page and replaces it with a category filter. It also includes some copy/design changes to the products pages and a couple of fixes relating to indexing updated products to fix existing bugs on the my products/team products pages.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
