### PR TITLE
Fix product link on images tab

### DIFF
--- a/app/views/products/case_product_info_tabs/_images.html.erb
+++ b/app/views/products/case_product_info_tabs/_images.html.erb
@@ -11,36 +11,36 @@
   <ul class="govuk-list govuk-!-margin-top-9">
     <li>
       <dl class="govuk-summary-list govuk-!-padding-bottom-9 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--image">
-          <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                  Image and title
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <figure class="opss-margin-bottom-1-desktop">
-                  <% link_content = capture do %>
-                    <%= image_tag(image) %>
-                    <span class="govuk-visually-hidden">(opens in new tab)</span>
-                  <% end %>
-                  <%= link_to link_content, image, target: "_blank", rel: 'noopener', title: "Opens in a new tab" %>
-                  <figcaption><%= image.title %></figcaption>
-                </figure>
-              </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-                Image description
-            </dt>
-            <dd class="govuk-summary-list__value">
-                <%= image.blob.metadata["description"] %>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-                Updated
-            </dt>
-            <dd class="govuk-summary-list__value">
-                <%= image.blob.metadata["updated"] %>
-            </dd>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Image and title
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <figure class="opss-margin-bottom-1-desktop">
+              <% link_content = capture do %>
+                <%= image_tag(image) %>
+                <span class="govuk-visually-hidden">(opens in new tab)</span>
+              <% end %>
+              <%= link_to link_content, image, target: "_blank", rel: 'noopener', title: "Opens in a new tab" %>
+              <figcaption><%= image.title %></figcaption>
+            </figure>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Image description
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= image.blob.metadata["description"] %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Updated
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= image.blob.metadata["updated"] %>
+          </dd>
         </div>
       </dl>
     </li>


### PR DESCRIPTION
Fix the link to the product page on images tab in cases

https://regulatorydelivery.atlassian.net/browse/PSD-1073

## Description
- Fixed link to product
- Fixed indentation in file

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
