### PR TITLE
Delete case

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -78,9 +78,12 @@ class InvestigationsController < ApplicationController
 
   def cannot_close; end
 
-  def confirm_deletion; end
+  def confirm_deletion
+    # render "investigations/cannot_delete" unless Pundit.policy(current_user, @investigation).can_be_deleted?
+  end
 
   def destroy
+    byebug
     authorize @investigation, :change_owner_or_status?
 
     @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation)
@@ -115,6 +118,7 @@ private
   end
 
   def set_investigation
+    byebug
     investigation = Investigation.includes(:owner_team, :owner_user, :products, :teams_with_access).find_by!(pretty_id: params[:pretty_id])
     @investigation = investigation.decorate
   end

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -83,16 +83,15 @@ class InvestigationsController < ApplicationController
   end
 
   def destroy
-    byebug
     authorize @investigation, :change_owner_or_status?
 
     @delete_investigation_form = DeleteInvestigationForm.new(investigation: @investigation)
 
     if @delete_investigation_form.valid?
       DeleteInvestigation.call!(investigation: @investigation, deleted_by: current_user)
-      redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }
+      redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }, status: :see_other
     else
-      redirect_to your_cases_investigations_path, flash: { warning: "The case could not be deleted" }
+      redirect_to your_cases_investigations_path, flash: { warning: "The case could not be deleted" }, status: :see_other
     end
   end
 
@@ -118,7 +117,6 @@ private
   end
 
   def set_investigation
-    byebug
     investigation = Investigation.includes(:owner_team, :owner_user, :products, :teams_with_access).find_by!(pretty_id: params[:pretty_id])
     @investigation = investigation.decorate
   end

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -76,10 +76,12 @@ class InvestigationsController < ApplicationController
     render "investigations/index"
   end
 
-  def cannot_close; end
+  def cannot_close
+    render "investigations/cannot_delete" unless Pundit.policy(current_user, @investigation).can_be_deleted?
+  end
 
   def confirm_deletion
-    # render "investigations/cannot_delete" unless Pundit.policy(current_user, @investigation).can_be_deleted?
+    render "investigations/cannot_delete" unless Pundit.policy(current_user, @investigation).can_be_deleted?
   end
 
   def destroy
@@ -89,9 +91,9 @@ class InvestigationsController < ApplicationController
 
     if @delete_investigation_form.valid?
       DeleteInvestigation.call!(investigation: @investigation, deleted_by: current_user)
-      redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }, status: :see_other
+      redirect_to your_cases_investigations_path, flash: { success: "The case was deleted" }
     else
-      redirect_to your_cases_investigations_path, flash: { warning: "The case could not be deleted" }, status: :see_other
+      redirect_to your_cases_investigations_path, flash: { warning: "The case could not be deleted" }
     end
   end
 

--- a/app/views/investigations/cannot_delete.html.erb
+++ b/app/views/investigations/cannot_delete.html.erb
@@ -1,0 +1,25 @@
+<% page_heading = "Cannot delete the case" %>
+
+<%= page_title page_heading %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-!-margin-top-4 govuk-!-padding-bottom-4">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+            This case cannot be deleted
+          </h1>
+
+          <%= govukInsetText(text: "The status of this case prohibits its deletion.") %>
+
+          <div class="govuk-!-margin-top-8">
+            <p class="govuk-body">
+              Email <%= mail_to "opss.enquiries@beis.gov.uk", class: "govuk-link govuk-link--no-visited-state" %> if further help is required.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/investigations/cannot_delete.html.erb
+++ b/app/views/investigations/cannot_delete.html.erb
@@ -11,7 +11,13 @@
             This case cannot be deleted
           </h1>
 
-          <%= govukInsetText(text: "The status of this case prohibits its deletion.") %>
+          <% inset_html = capture do %>
+            <p class="govuk-body">
+              The status of this case prohibits its deletion.
+            </p>
+          <% end %>
+
+          <%= govukInsetText(html: inset_html,) %>
 
           <div class="govuk-!-margin-top-8">
             <p class="govuk-body">

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -14,7 +14,9 @@
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
           <div class="govuk-button-group govuk-!-margin-top-8">
-            <%= button_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= form_with url: investigation_path(@investigation), method: :delete, local: true do |form| %>
+              <%= form.submit  "Delete the case", class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <% end %>
             <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -14,7 +14,9 @@
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
           <div class="govuk-button-group govuk-!-margin-top-8">
-            <%= link_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= form_with url: investigation_path(@investigation), method: :delete, local: true do |form| %>
+              <%= form.submit  "Delete the case", class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <% end %>
             <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -14,9 +14,7 @@
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
           <div class="govuk-button-group govuk-!-margin-top-8">
-            <%= form_with url: investigation_path(@investigation), method: :delete, local: true do |form| %>
-              <%= form.submit  "Delete the case", class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
-            <% end %>
+            <%= link_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
             <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -14,7 +14,7 @@
           <%= govukWarningText(iconFallbackText: "Warning", text: "Case #{@investigation.pretty_id} – including its images and supporting information – will be deleted.") %>
 
           <div class="govuk-button-group govuk-!-margin-top-8">
-            <%= link_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= button_to "Delete the case", investigation_path(@investigation), method: :delete, class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
             <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
           </div>
         </div>

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Deleting a case", :with_opensearch, :with_stubbed_mailer, type: 
 
       expect_to_be_on_confirm_case_deletion_page(case_id: investigation.pretty_id)
 
-      click_link "Delete the case"
+      click_button "Delete the case"
 
       expect(page).to have_current_path("/cases/your-cases")
       expect_confirmation_banner("The case was deleted")

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Deleting a case", :with_opensearch, :with_stubbed_mailer, type: 
 
       expect_to_be_on_confirm_case_deletion_page(case_id: investigation.pretty_id)
 
-      click_button "Delete the case"
+      click_link "Delete the case"
 
       expect(page).to have_current_path("/cases/your-cases")
       expect_confirmation_banner("The case was deleted")

--- a/spec/features/delete_a_case_spec.rb
+++ b/spec/features/delete_a_case_spec.rb
@@ -19,14 +19,18 @@ RSpec.describe "Deleting a case", :with_opensearch, :with_stubbed_mailer, type: 
       expect_to_be_on_close_case_page(case_id: investigation.pretty_id)
     end
 
-    it "does not allow user to delete the case" do
+    it "does not allow user to delete the case from the cannot close page" do
+      sign_in user
+      visit "cases/#{investigation.pretty_id}/cannot_close"
+
+      expect(page).to have_css("h1", text: "This case cannot be deleted")
+    end
+
+    it "does not allow user to delete the case from the confirm deletion page" do
       sign_in user
       visit "cases/#{investigation.pretty_id}/confirm_deletion"
 
-      click_link "Delete the case"
-
-      expect(page).to have_current_path("/cases/your-cases")
-      expect(page).to have_css(".govuk-notification-banner", text: "The case could not be deleted")
+      expect(page).to have_css("h1", text: "This case cannot be deleted")
     end
   end
 
@@ -46,7 +50,7 @@ RSpec.describe "Deleting a case", :with_opensearch, :with_stubbed_mailer, type: 
 
       expect_to_be_on_confirm_case_deletion_page(case_id: investigation.pretty_id)
 
-      click_link "Delete the case"
+      click_button "Delete the case"
 
       expect(page).to have_current_path("/cases/your-cases")
       expect_confirmation_banner("The case was deleted")


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1149&assignee=557058%3Ac4059aae-50b8-4b82-bda9-8af742704c30

## Description
This change shows a page warning the user that they cannot delete a product if it has products attached to it. It also fixes the broken delete case link caused by changes in rails 7 (see [here](https://guides.rubyonrails.org/working_with_javascript_in_rails.html#replacements-for-rails-ujs-functionality))

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
