### PR TITLE
Fix the resend invitation link

### DIFF
--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -61,7 +61,7 @@
               <%= mail_to user.email, user.email, class: "govuk-link govuk-link--no-visited-state" %>
               <% if !user.has_filled_out_account_setup_form_and_verified_number? && current_user.is_team_admin? %>
                 <br>
-                <%= link_to resend_team_invitation_path(@team, user), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold" , method: :put do %>
+                <%= button_to resend_team_invitation_path(@team, user), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold" , method: :put do %>
                   Resend invitation <span class="govuk-visually-hidden"> to <%= user.email %></span>
                 <% end %>
               <% end %>

--- a/spec/features/team_spec.rb
+++ b/spec/features/team_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_opensearch, 
         expect(page).to have_user(another_active_user)
         expect(page).to have_user(another_inactive_user)
         expect(page).not_to have_user(another_user_another_team)
-        expect(page).not_to have_resend_link_button_for(another_inactive_user)
+        expect(page).not_to have_resend_button_for(another_inactive_user)
         expect(page).not_to have_link("Invite a team member")
         expect(page).not_to have_css("tfoot", text: "Name Email")
       end
@@ -56,14 +56,14 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_opensearch, 
 
       scenario "displays the invite a team member link, awaiting confirmation text and the resend invite link for inactive users that have not yet filled out their details" do
         expect(page).to have_link("Invite another team member")
-        expect(page).to have_resend_link_button_for(user_without_details)
+        expect(page).to have_resend_button_for(user_without_details)
         expect(page).to have_content("Awaiting confirmation for #{user_without_details.email}")
-        expect(page).not_to have_resend_link_button_for(another_active_user)
+        expect(page).not_to have_resend_button_for(another_active_user)
         expect(page).not_to have_content("Awaiting confirmation for #{another_active_user.email}")
       end
 
       scenario "resending an invitation sends an email to the user and shows a confirmation message" do
-        click_link "Resend invitation to #{user_without_details.email}"
+        click_button "Resend invitation to #{user_without_details.email}"
         expect_confirmation_banner "Invite sent to #{user_without_details.email}"
 
         email = delivered_emails.last
@@ -80,7 +80,7 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_opensearch, 
     have_link(user.email)
   end
 
-  def have_resend_link_button_for(user)
-    have_link("Resend invitation to #{user.email}")
+  def have_resend_button_for(user)
+    have_button("Resend invitation to #{user.email}")
   end
 end


### PR DESCRIPTION
## Description
After the rails 7 upgrade links which have been overridden to use non-GET requests no longer work (see [here](https://guides.rubyonrails.org/working_with_javascript_in_rails.html#replacements-for-rails-ujs-functionality)).

This PR changes the resend invitation link to a button which allows the functionality to work as expected. There is a minor visual change caused by this fix, which may need to be addressed in a future PR.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
