### PR TITLE
Add links to investigation sub nav

### DIFF
--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -86,7 +86,7 @@ module Investigations::DisplayTextHelper
   end
 
   def investigation_sub_items(investigation)
-    [
+    rows = [
       {
         text: "Safety and compliance",
         href: investigation_path(investigation, anchor: "safety")
@@ -94,12 +94,17 @@ module Investigations::DisplayTextHelper
       {
         text: "Case specific product information",
         href: investigation_path(investigation, anchor: "product-info-1")
-      },
-      {
+      }
+    ]
+
+    if investigation.complainant
+      rows << {
         text: "Case source",
         href: investigation_path(investigation, anchor: "source")
       }
-    ]
+    end
+
+    rows
   end
 
   def products_sub_items(investigation)

--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -14,7 +14,8 @@ module Investigations::DisplayTextHelper
         href: investigation_path(investigation),
         html: safe_join(["Case ", tag.span(" #{investigation.pretty_id}", class: "govuk-!-font-weight-regular")]),
         text: "Case",
-        active: is_current_tab.overview?
+        active: is_current_tab.overview?,
+        sub_items: investigation_sub_items(investigation)
       },
       {
         href: investigation_products_path(investigation),
@@ -82,6 +83,23 @@ module Investigations::DisplayTextHelper
       }
     ]
     render "investigations/sub_nav", items:
+  end
+
+  def investigation_sub_items(investigation)
+    [
+      {
+        text: "Safety and compliance",
+        href: investigation_path(investigation, anchor: "safety")
+      },
+      {
+        text: "Case specific product information",
+        href: investigation_path(investigation, anchor: "product-info-1")
+      },
+      {
+        text: "Case source",
+        href: investigation_path(investigation, anchor: "source")
+      }
+    ]
   end
 
   def products_sub_items(investigation)

--- a/spec/features/case_source_spec.rb
+++ b/spec/features/case_source_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.feature "Case source info", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+
+  before do
+    sign_in user
+    visit investigation_path(investigation)
+  end
+
+  context "when investigation has no source info" do
+    let(:investigation) { create(:allegation, creator: user) }
+
+    it "does not show the source info on the page" do
+      expect(page).not_to have_link "Case source"
+      expect(page).not_to have_css("h3", text: "Case source")
+    end
+  end
+
+  context "when investigation has source info" do
+    let(:complainant) { create(:complainant) }
+
+    context "when user is not opss" do
+      context "when the user's team is added to the case" do
+        let(:investigation) { create(:allegation, complainant:, creator: user) }
+
+        it "shows the source info on the page" do
+          expect(page).to have_link "Case source"
+          expect(page).to have_css("h3", text: "Case source")
+          expect(page).to have_content(complainant.name)
+          expect(page).to have_content(complainant.complainant_type)
+          expect(page).not_to have_content("Only teams added to the case can view enquiry contact details")
+        end
+      end
+
+      context "when the user's team is not owner of the case" do
+        let(:other_team) { create(:team) }
+        let(:other_user) { create(:user, :activated, has_viewed_introduction: true, team: other_team) }
+        let(:investigation) { create(:allegation, complainant:, creator: other_user) }
+
+        it "does not show source info on the page" do
+          expect(page).to have_link "Case source"
+          expect(page).to have_css("h3", text: "Case source")
+          expect(page).not_to have_content(complainant.name)
+          expect(page).to have_content(complainant.complainant_type)
+          expect(page).to have_content("Only teams added to the case can view allegation contact details")
+        end
+      end
+    end
+
+    context "when the user is opss" do
+      let(:investigation) { create(:allegation, complainant:, creator: user) }
+
+      it "shows the source info on the page" do
+        expect(page).to have_link "Case source"
+        expect(page).to have_css("h3", text: "Case source")
+        expect(page).to have_content(complainant.name)
+        expect(page).to have_content(complainant.complainant_type)
+        expect(page).not_to have_content("Only teams added to the case can view enquiry contact details")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1313

## Description
Add links to the sub nav for the safety and compliance, case specific product information and case source sections

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
