### PR TITLE
Remove case restrictions

### DIFF
--- a/app/controllers/investigations/visibility_controller.rb
+++ b/app/controllers/investigations/visibility_controller.rb
@@ -2,7 +2,7 @@ module Investigations
   class VisibilityController < ApplicationController
     def show
       @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
-      authorize @investigation, :change_owner_or_status?
+      authorize @investigation, :can_unrestrict?
       @last_update_visibility_activity = @investigation.activities.where(type: "AuditActivity::Investigation::UpdateVisibility").order(:created_at).first
     end
 
@@ -18,7 +18,7 @@ module Investigations
 
     def change_case_visibility(new_visibility:, template:, flash:)
       @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
-      authorize @investigation, :change_owner_or_status?
+      authorize @investigation, :can_unrestrict?
 
       @change_case_visibility_form = ChangeCaseVisibilityForm.from(@investigation)
       @change_case_visibility_form.assign_attributes(change_case_visibility_form_params.merge(new_visibility:))

--- a/app/controllers/investigations/visibility_controller.rb
+++ b/app/controllers/investigations/visibility_controller.rb
@@ -1,7 +1,8 @@
 module Investigations
   class VisibilityController < ApplicationController
+    before_action :set_investigation
+
     def show
-      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
       authorize @investigation, :can_unrestrict?
       @last_update_visibility_activity = @investigation.activities.where(type: "AuditActivity::Investigation::UpdateVisibility").order(:created_at).first
     rescue Pundit::NotAuthorizedError
@@ -9,14 +10,24 @@ module Investigations
     end
 
     def restrict
+      authorize @investigation, :can_unrestrict?
       change_case_visibility(new_visibility: "restricted", template: :restrict, flash: "restricted")
+    rescue Pundit::NotAuthorizedError
+      render_404_page
     end
 
     def unrestrict
+      authorize @investigation, :can_unrestrict?
       change_case_visibility(new_visibility: "unrestricted", template: :unrestrict, flash: "unrestricted")
+    rescue Pundit::NotAuthorizedError
+      render_404_page
     end
 
   private
+
+    def set_investigation
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
+    end
 
     def change_case_visibility(new_visibility:, template:, flash:)
       @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])

--- a/app/controllers/investigations/visibility_controller.rb
+++ b/app/controllers/investigations/visibility_controller.rb
@@ -4,6 +4,8 @@ module Investigations
       @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
       authorize @investigation, :can_unrestrict?
       @last_update_visibility_activity = @investigation.activities.where(type: "AuditActivity::Investigation::UpdateVisibility").order(:created_at).first
+    rescue Pundit::NotAuthorizedError
+      render_404_page
     end
 
     def restrict

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -6,8 +6,6 @@ class InvestigationsController < ApplicationController
   before_action :build_breadcrumbs, only: %i[show]
 
   # GET /cases
-  # GET /cases.json
-  # GET /cases.xlsx
   def index
     respond_to do |format|
       format.html do
@@ -21,7 +19,6 @@ class InvestigationsController < ApplicationController
   end
 
   # GET /cases/1
-  # GET /cases/1.json
   def show
     authorize @investigation, :view_non_protected_details?
     @complainant = @investigation.complainant&.decorate

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -185,14 +185,20 @@ module InvestigationsHelper
           html: team_list_html
         },
         actions: case_teams_actions(investigation)
-      },
-      {
+      }
+    ]
+
+    if investigation.is_private?
+      rows << {
         key: { text: "Case restriction" },
         value: {
           html: case_restriction_value(investigation)
         },
         actions: case_restriction_actions(investigation, user)
-      },
+      }
+    end
+
+    rows << [
       {
         key: { text: "Case risk level" },
         value: {
@@ -206,6 +212,7 @@ module InvestigationsHelper
         actions: risk_validation_actions(investigation, user)
       }
     ]
+    rows.flatten!
 
     rows.insert(7, notifying_country_section(investigation, user)) if policy(investigation).view_notifying_country?(user:)
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -368,7 +368,7 @@ private
   end
 
   def case_restriction_actions(investigation, user)
-    return {} unless policy(investigation).change_owner_or_status?(user:)
+    return {} unless policy(investigation).can_unrestrict?(user:)
 
     {
       items: [

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -29,6 +29,10 @@ class InvestigationPolicy < ApplicationPolicy
     @record.owner.in_same_team_as?(user)
   end
 
+  def can_unrestrict?(user: @user)
+    change_owner_or_status?(user:) && record.is_private?
+  end
+
   # Ability to see most of the details of the case, with the exception of
   # 'protected' details, such as personal contact details or correspondance
   # with businesses.

--- a/app/views/investigations/_status_table_row.html.erb
+++ b/app/views/investigations/_status_table_row.html.erb
@@ -20,13 +20,6 @@
     %>
   <% end %>
 <% end %>
-<% if investigation.is_private? %>
-  <% badges << capture do %>
-    <%= tag.span t(:restricted, scope: "case.badges"),
-          class: "opss-tag opss-tag--risk2"
-    %>
-  <% end %>
-<% end %>
 
 <tr class="govuk-table__row">
   <th headers="<%= dom_id investigation, :item %>" id="<%= dom_id investigation, :status %>" class="govuk-visually-hidden">

--- a/spec/features/change_case_visibility_restriction_spec.rb
+++ b/spec/features/change_case_visibility_restriction_spec.rb
@@ -2,47 +2,24 @@ require "rails_helper"
 
 RSpec.feature "Change case restriction status", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
   let(:user) { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"), name: "Bob Jones") }
-  let(:investigation) { create(:allegation, creator: user) }
-
   let(:case_id) { investigation.pretty_id }
 
   before { sign_in(user) }
 
   context "when the user is the owner of the case" do
     context "when the case is unrestricted" do
-      scenario "user can change the restriction status of the case" do
+      let(:investigation) { create(:allegation, creator: user) }
+
+      scenario "user cannot make the case restricted" do
         visit "/cases/#{case_id}"
 
         expect_to_be_on_case_page(case_id:)
-        expect(page).to have_summary_item(key: "Case restriction", value: "Unrestricted")
-        expect(page).to have_link "Change the case restriction"
-        click_link "Change the case restriction"
-
-        expect_to_be_on_case_visiblity_page(case_id:, status: "unrestricted", action: "restrict")
-
-        click_on "Continue"
-
-        expect_to_be_on_change_case_visiblity_page(case_id:, future_status: "restricted", action: "restrict")
-        fill_in "Why is the case being restricted?", with: "Restriction reason"
-        click_button "Restrict this case"
-
-        expect_to_be_on_case_page(case_id:)
-        expect_confirmation_banner("Allegation was restricted")
-        expect(page).to have_summary_item(key: "Case restriction", value: "This case is Restricted")
-        click_link "Activity"
-        expect(page).to have_css("h3", text: "Allegation restricted")
-        expect(page).to have_css("p", text: "Restriction reason")
+        expect(page).not_to have_text "Case restriction"
       end
     end
 
     context "when the case is restricted" do
-      before do
-        visit "/cases/#{case_id}"
-        click_link "Change the case restriction"
-        click_on "Continue"
-        fill_in "Why is the case being restricted?", with: "Restriction reason"
-        click_button "Restrict this case"
-      end
+      let(:investigation) { create(:allegation, :restricted, creator: user) }
 
       scenario "user can change the restriction status of the case" do
         visit "/cases/#{case_id}"
@@ -60,9 +37,10 @@ RSpec.feature "Change case restriction status", :with_stubbed_opensearch, :with_
         fill_in "Why is the case being unrestricted?", with: "Unrestricted reason"
         click_button "Unrestrict this case"
 
+        # Now back on the case page, the user cannot see the restriction status
         expect_to_be_on_case_page(case_id:)
         expect_confirmation_banner("Allegation was unrestricted")
-        expect(page).to have_summary_item(key: "Case restriction", value: "Unrestricted")
+        expect(page).not_to have_text "Case restriction"
 
         click_link "Activity"
         expect(page).to have_css("h3", text: "Allegation unrestricted")
@@ -87,10 +65,10 @@ RSpec.feature "Change case restriction status", :with_stubbed_opensearch, :with_
   context "when the user is not the case owner" do
     let(:investigation) { create(:allegation, creator: create(:user)) }
 
-    scenario "user can’t change the restriction status of the case" do
+    scenario "user can't change the restriction status of the case" do
       visit "/cases/#{case_id}"
+
       expect_to_be_on_case_page(case_id:)
-      expect(page).to have_summary_item(key: "Case restriction", value: "Unrestricted")
       expect(page).not_to have_link "Change the case restriction"
     end
   end

--- a/spec/features/change_case_visibility_restriction_spec.rb
+++ b/spec/features/change_case_visibility_restriction_spec.rb
@@ -18,7 +18,11 @@ RSpec.feature "Change case restriction status", :with_stubbed_opensearch, :with_
       end
 
       scenario "user cannot direct browser to the change case restriction page" do
-        expect { visit "/cases/#{case_id}/visibility" }.to raise_error(Pundit::NotAuthorizedError)
+        visit "/cases/#{case_id}/visibility"
+
+        # The case cannot be made restricted, so expect a 404
+        expect(page).to have_http_status(:not_found)
+        expect(page).to have_text("Page not found")
       end
     end
 

--- a/spec/features/change_case_visibility_restriction_spec.rb
+++ b/spec/features/change_case_visibility_restriction_spec.rb
@@ -16,6 +16,10 @@ RSpec.feature "Change case restriction status", :with_stubbed_opensearch, :with_
         expect_to_be_on_case_page(case_id:)
         expect(page).not_to have_text "Case restriction"
       end
+
+      scenario "user cannot direct browser to the change case restriction page" do
+        expect { visit "/cases/#{case_id}/visibility" }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
     context "when the case is restricted" do

--- a/spec/policies/investigation_policy_spec.rb
+++ b/spec/policies/investigation_policy_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
   let(:investigation) { create(:allegation, is_private: false) }
 
   context "when the investigation is not restricted" do
-    context "when the user’s team has not been added to the case" do
+    context "when the user's team has not been added to the case" do
       it "cannot update the case" do
         expect(policy.update?).to be false
       end
 
       it "cannot change case owner or status" do
         expect(policy.change_owner_or_status?).to be false
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be false
       end
 
       it "cannot manage collaborators" do
@@ -30,7 +34,7 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
       end
     end
 
-    context "when the user’s has been given read-only access" do
+    context "when the user's has been given read-only access" do
       before do
         create(:read_only_collaboration, investigation:, collaborator: team)
         investigation.reload
@@ -42,6 +46,10 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
 
       it "cannot change case owner or status" do
         expect(policy.change_owner_or_status?).to be false
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be false
       end
 
       it "cannot manage collaborators" do
@@ -61,7 +69,7 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
       end
     end
 
-    context "when the user’s has been given edit access" do
+    context "when the user's has been given edit access" do
       before do
         create(:collaboration_edit_access, investigation:, collaborator: team)
         investigation.reload
@@ -73,6 +81,10 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
 
       it "cannot change case owner or status" do
         expect(policy.change_owner_or_status?).to be false
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be false
       end
 
       it "cannot manage collaborators" do
@@ -92,7 +104,7 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
       end
     end
 
-    context "when the user’s team is the current case owner" do
+    context "when the user's team is the current case owner" do
       before do
         ChangeCaseOwner.call!(investigation:, owner: team, user: create(:user))
       end
@@ -103,6 +115,46 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
 
       it "can change case owner or status" do
         expect(policy.change_owner_or_status?).to be true
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be false
+      end
+
+      it "can manage collaborators" do
+        expect(policy.manage_collaborators?).to be true
+      end
+
+      it "can view non-protected details" do
+        expect(policy.view_non_protected_details?).to be true
+      end
+
+      it "can view all details about the case" do
+        expect(policy.view_protected_details?).to be true
+      end
+
+      it "is not readonly" do
+        expect(policy.readonly?).to be false
+      end
+    end
+
+    context "when the user's team is the current case owner and the case is restricted" do
+      before do
+        ChangeCaseOwner.call!(investigation:, owner: team, user: create(:user))
+        investigation.update!(is_private: true)
+        investigation.reload
+      end
+
+      it "can update the case" do
+        expect(policy.update?).to be true
+      end
+
+      it "can change case owner or status" do
+        expect(policy.change_owner_or_status?).to be true
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be true
       end
 
       it "can manage collaborators" do
@@ -126,13 +178,17 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
   context "when the investigation has been restricted" do
     let(:investigation) { create(:allegation, is_private: true) }
 
-    context "when the user’s team has not been added to the case" do
+    context "when the user's team has not been added to the case" do
       it "cannot update the case" do
         expect(policy.update?).to be false
       end
 
       it "cannot change case owner or status" do
         expect(policy.change_owner_or_status?).to be false
+      end
+
+      it "cannot unrestrict the case" do
+        expect(policy.can_unrestrict?).to be false
       end
 
       it "cannot manage collaborators" do


### PR DESCRIPTION
Removes the ability for cases to be restricted on PSD. Existing cases that are open cannot be made restricted, but previously restricted cases can still be made public.

https://regulatorydelivery.atlassian.net/browse/PSD-1062
