### PR TITLE
Fix product cases hover, could only select link for first product

### DIFF
--- a/app/views/products/_cases.html.erb
+++ b/app/views/products/_cases.html.erb
@@ -6,12 +6,10 @@
   </div>
 </div>
 
-<div class="psd-case-card">
-  <% if @product.investigations.any? %>
-    <% rows = @product.investigations.uniq.map do |investigation| %>
-      <% { key: { text: investigation.case_title_key }, values: investigation.case_summary_values } %>
-    <% end %>
-
-    <%= govukSummaryList(rows: rows, classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--sm-font opss-summary-list-mixed--4-cols") %>
+<% if @product.investigations.any? %>
+  <% rows = @product.investigations.uniq.map do |investigation| %>
+    <% { key: { text: investigation.case_title_key }, values: investigation.case_summary_values } %>
   <% end %>
-</div>
+
+  <%= govukSummaryList(rows: rows, classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--sm-font opss-summary-list-mixed--4-cols capy-cases") %>
+<% end %>

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
       visit "/products/#{iphone.id}"
       expect(page).to have_text("This product record has been added to 1 case")
 
-      within ".psd-case-card" do
+      within ".capy-cases" do
         expect(page).to have_link(investigation.title, href: "/cases/#{investigation.pretty_id}")
         expect(page).to have_css("dd", text: investigation.pretty_id)
         expect(page).to have_css("dd", text: investigation.owner_team.name)
@@ -84,7 +84,7 @@ RSpec.feature "Products listing", :with_opensearch, :with_stubbed_mailer, type: 
 
       expect(page).to have_text("This product record has been added to 1 case")
 
-      within ".psd-case-card" do
+      within ".capy-cases" do
         expect(page).to have_css("dt", text: "Allegation restricted")
         expect(page).not_to have_css("dd", text: investigation.pretty_id)
         expect(page).not_to have_css("dd", text: investigation.owner_team.name)


### PR DESCRIPTION
Fix to CSS where it was found multiple product links couldn't be selected -

Added new `.capy-cases` to select for feature spec use, and not styled

https://regulatorydelivery.atlassian.net/browse/PSD-1351