### PR TITLE
Fix remove product indexing bug

### DIFF
--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -22,7 +22,9 @@ class AddProductToCase
 
     change_product_owner_if_unowned
 
-    product.__elasticsearch__.update_document
+    investigation.reload.__elasticsearch__.update_document
+
+    product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_added
 

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -16,7 +16,7 @@ class RemoveProductFromCase
       change_product_ownership
     end
 
-    investigation.__elasticsearch__.update_document
+    investigation.reload.__elasticsearch__.update_document
     product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_removed

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -17,7 +17,7 @@ class RemoveProductFromCase
     end
 
     investigation.__elasticsearch__.update_document
-    investigation_product.product.__elasticsearch__.update_document
+    product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_removed
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1349

## Description
Prior to this change when a product was removed from an investigation, it was still showing on the 'your product/team product' pages. This was because the product was not reloaded before being indexed. This change fixes this bug.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
