### PR TITLE
Add/Remove product indexing bug

### DIFF
--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -22,7 +22,9 @@ class AddProductToCase
 
     change_product_owner_if_unowned
 
-    product.__elasticsearch__.update_document
+    investigation.reload.__elasticsearch__.update_document
+
+    product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_added
 

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -22,9 +22,7 @@ class AddProductToCase
 
     change_product_owner_if_unowned
 
-    investigation.reload.__elasticsearch__.update_document
-
-    product.reload.__elasticsearch__.update_document
+    product.__elasticsearch__.index_document
 
     context.activity = create_audit_activity_for_product_added
 

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -16,7 +16,7 @@ class RemoveProductFromCase
       change_product_ownership
     end
 
-    investigation.__elasticsearch__.update_document
+    investigation.reload.__elasticsearch__.update_document
     product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_removed

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -17,7 +17,7 @@ class RemoveProductFromCase
     end
 
     investigation.__elasticsearch__.update_document
-    investigation_product.product.__elasticsearch__.update_document
+    product.reload.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_removed
 

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -16,8 +16,8 @@ class RemoveProductFromCase
       change_product_ownership
     end
 
-    investigation.reload.__elasticsearch__.update_document
-    product.reload.__elasticsearch__.update_document
+    investigation.__elasticsearch__.update_document
+    product.__elasticsearch__.index_document
 
     context.activity = create_audit_activity_for_product_removed
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1349

## Description
When adding a freshly created product to a case, or removing any product from a case, the investigation related fields are not being updated in open search which results in the product not being properly filtered by the investigation.owner_id and therefore not showing up correctly in the you product/team product pages.

It seems that the product.__elasticsearch__.update_document is not meeting our needs here because it looks for the changed attributes of the instance of product and performs a partial update on these changed attributes, however in this case no product attributes were changing and update_document was not updating the fields related to the investigation. To fix this I have used the index_document method which calls `as_indexed_json` and to re-index all the fields, including the investigation owner_id method which is necessary to fix these bugs.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
