### PR TITLE
Fix a bug where products are selectable multiple times when adding risk assessments

### DIFF
--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -81,7 +81,7 @@ class RiskAssessmentForm
   end
 
   def products
-    investigation.products
+    investigation.products.uniq
     .pluck(:name, :id).collect do |row|
       {
         text: row[0],

--- a/app/views/investigations/accident_or_incidents/_form.html.erb
+++ b/app/views/investigations/accident_or_incidents/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form.govuk_radios :is_date_known, legend: "Do you know when the #{form.object.type.downcase} happened?", items: [{ text: "Yes", value: "true", conditional: { html: form.govuk_date_input(:date, legend: "Date of #{form.object.type.downcase}", hint: "For example, 12 11 2020", classes: "govuk-fieldset__legend") } }, { text: "No", value: "false" }] %>
 
-<% if  investigation.products.size == 1 %>
+<% if investigation.products.uniq.one? %>
   <h2 class="govuk-heading-m"><%= "Product involved" %></h2>
   <p class="govuk-body"><%= investigation.products.first.name %></p>
   <%= form.hidden_field :product_id, value: investigation.products.first.id %>
 <% else %>
-  <%= form.govuk_autocomplete :product_id, label: "Which product was involved?", label_classes: "govuk-label--m", items: investigation.products.map { |product| { text: product.name, value: product.id } } %>
+  <%= form.govuk_autocomplete :product_id, label: "Which product was involved?", label_classes: "govuk-label--m", items: investigation.products.uniq.map { |product| { text: product.name, value: product.id } } %>
 <% end %>
 
 <% other = capture do %>

--- a/app/views/investigations/corrective_actions/_form.html.erb
+++ b/app/views/investigations/corrective_actions/_form.html.erb
@@ -17,15 +17,14 @@ hint: "This may be in the future. For example, #{two_weeks_from_now.day} #{two_w
           <%= link_to "Add a product", new_investigation_product_path(investigation) %>
           to record a corrective action.
         </span>
-      <% elsif  investigation.products.size == 1 %>
+      <% elsif investigation.products.uniq.one? %>
         <p class="govuk-body"><%= investigation.products.first.name %></p>
         <%= form.hidden_field :product_id, value: investigation.products.first.id %>
       <% else %>
-
         <%= form.govuk_select :product_id,
           label: "Product",
           label_classes: "govuk-visually-hidden",
-          items: [{text: "", value: ""}] + investigation.products.map { |product| { text: product.name, value: product.id }},
+          items: [{text: "", value: ""}] + investigation.products.uniq.map { |product| { text: product.name, value: product.id }},
          hint: "Only products already added to the case are listed."
         %>
       <% end %>

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -6,7 +6,7 @@
       <span class="govuk-hint">
         There are no products on this case. <%= link_to "Add a product", new_investigation_product_path(investigation) %> to send it for testing.
       </span>
-    <% elsif @investigation.products.size == 1 %>
+    <% elsif @investigation.products.uniq.one? %>
       <h2 class="govuk-heading-m">Product tested</h2>
       <p class="govuk-body"><%= @investigation.products.first.name %></p>
       <%= form.hidden_field :product_id, value: @investigation.products.first.id %>
@@ -15,7 +15,7 @@
         Only products already added to the case are listed.
         <%= link_to "Add a product", new_investigation_product_path(investigation) %>
       <% end %>
-      <%= form.govuk_autocomplete :product_id, label: "Which product was tested?", label_classes: "govuk-label--m", items: investigation.products.map { |product| { text: product.name, value: product.id } }, hint: span_html %>
+      <%= form.govuk_autocomplete :product_id, label: "Which product was tested?", label_classes: "govuk-label--m", items: investigation.products.uniq.map { |product| { text: product.name, value: product.id } }, hint: span_html %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1359

## Description

The `risk_assessed_products` table has a `unique` index on `product_id` and `investigation_id`. The introduction of versioned products on a case produces a problem: A user can add the same `Product` to a case multiple times (by adding it, closing the case, reopening the case, and adding again). This is intended behaviour, however the Risk Assessment creation/edit flow has not been updated to take this into account. Accordingly, in this scenario the same `product_id`/checkbox was presented on the form twice. Selecting _both_ checkboxes for the same logical product caused a 500 error.

Work to address the relationship of supporting information to products is ongoing, however in the meantime, this PR mitigates the issue by deduplicating the list of products, so that each product is only presented to the user once for selection.

I have also made the product list on other supporting information forms (accidents/incidents, corrective actions, and test results) unique. These didn't cause errors but in this scenario the user would be presented with the same option in a dropdown list more than once which would have been confusing.