### PR TITLE
Removing a product from a case should use investigation_product

### DIFF
--- a/app/controllers/investigations/investigation_products_controller.rb
+++ b/app/controllers/investigations/investigation_products_controller.rb
@@ -12,7 +12,7 @@ module Investigations
     def remove
       authorize @investigation_product, :remove?
 
-      @supporting_information = @product.supporting_information.select { |si| si.investigation == @investigation }
+      @supporting_information = @investigation_product.supporting_information.select { |si| si.investigation == @investigation }
       render "supporting_information_warning" and return if @supporting_information.any?
 
       @remove_product_form = RemoveProductForm.new

--- a/app/controllers/investigations/investigation_products_controller.rb
+++ b/app/controllers/investigations/investigation_products_controller.rb
@@ -12,7 +12,7 @@ module Investigations
     def remove
       authorize @investigation_product, :remove?
 
-      @supporting_information = @investigation_product.supporting_information.select { |si| si.investigation == @investigation }
+      @supporting_information = @investigation_product.supporting_information
       render "supporting_information_warning" and return if @supporting_information.any?
 
       @remove_product_form = RemoveProductForm.new

--- a/app/controllers/investigations/investigation_products_controller.rb
+++ b/app/controllers/investigations/investigation_products_controller.rb
@@ -43,7 +43,7 @@ module Investigations
     end
 
     def set_investigation_product
-      @investigation_product = InvestigationProduct.find(params[:id])
+      @investigation_product = @investigation.investigation_products.find(params[:id])
     end
 
     def set_product

--- a/app/models/investigation_product.rb
+++ b/app/models/investigation_product.rb
@@ -31,6 +31,10 @@ class InvestigationProduct < ApplicationRecord
     investigation_closed_at ? super.paper_trail.version_at(investigation_closed_at) || super : super
   end
 
+  def supporting_information
+    tests + corrective_actions + unexpected_events + risk_assessments
+  end
+
   def psd_ref
     product.psd_ref timestamp: investigation_closed_at&.to_i, investigation_was_closed: investigation_closed_at.present?
   end

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -12,7 +12,7 @@ class RemoveProductFromCase
 
     InvestigationProduct.transaction do
       product.reload
-      investigation.products.delete product
+      investigation.investigation_products.delete investigation_product
       change_product_ownership
     end
 

--- a/spec/features/remove_product_from_a_case_spec.rb
+++ b/spec/features/remove_product_from_a_case_spec.rb
@@ -84,7 +84,6 @@ RSpec.feature "Remove product from investigation", :with_stubbed_opensearch, :wi
   context "when product has linked supporting information" do
     let!(:accident) { create :accident, investigation_product:, investigation: }
     let!(:risk_assessment) { create :risk_assessment, investigation_products: [investigation_product], investigation: }
-    let!(:corrective_action) { create :corrective_action, investigation_product: }
 
     it "does not allow user to remove product from investigation" do
       sign_in user
@@ -173,5 +172,4 @@ RSpec.feature "Remove product from investigation", :with_stubbed_opensearch, :wi
     product.update!(description: "wowthisisnew!")
     ChangeCaseStatus.call!(investigation:, new_status: "open", user:)
   end
-
 end

--- a/spec/features/remove_product_from_a_case_spec.rb
+++ b/spec/features/remove_product_from_a_case_spec.rb
@@ -97,9 +97,81 @@ RSpec.feature "Remove product from investigation", :with_stubbed_opensearch, :wi
       expect(page).to have_css("p", text: "This is because the product is associated with the following supporting information:")
       expect(page).to have_css("a", text: accident.decorate.supporting_information_title)
       expect(page).to have_css("a", text: risk_assessment.decorate.supporting_information_title)
-
-      # NOTE: corrective_action belongs to another investigation
-      expect(page).not_to have_css("a", text: corrective_action.decorate.supporting_information_title)
     end
   end
+
+  context "when there are two investigation products from the same base product model" do
+    let(:investigation) { create(:enquiry, :with_products, creator: user) }
+    let(:investigation_product) { investigation.investigation_products.first }
+    let(:product) { investigation_product.product }
+
+    it "allows the user to remove the product that was just added" do
+      sign_in user
+      visit "/cases/#{investigation.pretty_id}/products"
+
+      close_and_reopen_case
+
+      # Add the same product to the case
+      click_link "Add a product to the case"
+      expect(page).to have_text("Enter a PSD product record reference number")
+
+      fill_in "reference", with: product.id
+      click_button "Continue"
+
+      expect(page).to have_text("Is this the correct product record to add to your case?")
+      expect(page).to have_text("#{product.brand} #{product.name}")
+
+      choose "Yes"
+      click_button "Save and continue"
+
+      expect(page).to have_current_path("/cases/#{investigation.pretty_id}/products")
+      expect(page).to have_text("The product record was added to the case")
+
+      # Now we see two products with the same PSD ref, one timestamped & the other not
+      old_product_psd_text = "#{product.psd_ref}_#{investigation.reload.investigation_products.first.investigation_closed_at.to_i}"
+
+      expect(page).to have_css(".govuk-summary-list__value", text: old_product_psd_text)
+      expect(page).to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The PSD reference number for this product record")
+
+      # Only the timestamped product can be removed
+      click_link "Remove this #{product.name} product from the case"
+      expect(page).to have_content("The product record '#{product.name}' (#{product.psd_ref}) will be removed from the case.")
+
+      click_on "Save and continue"
+
+      expect(page).to have_error_messages
+
+      errors_list = page.find(".govuk-error-summary__list").all("li")
+      expect(errors_list[0].text).to eq "Select yes if you want to remove the product from the case"
+
+      choose("Yes")
+      click_on "Save and continue"
+
+      expect(page).to have_error_messages
+      errors_list = page.find(".govuk-error-summary__list").all("li")
+      expect(errors_list[0].text).to eq "Enter the reason for removing the product"
+
+      fill_in "Enter the reason for removing the product", with: removal_reason
+      click_on "Save and continue"
+
+      expect_confirmation_banner("The product record was removed from the case")
+      expect_to_be_on_investigation_products_page(case_id: investigation.pretty_id)
+
+      expect(page).to have_css(".govuk-summary-list__value", text: old_product_psd_text)
+      expect(page).not_to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The PSD reference number for this product record")
+
+      click_link "Activity"
+      expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
+
+      expect(page.find("h3", text: "#{product.name} removed"))
+        .to have_sibling(".govuk-body", text: removal_reason)
+    end
+  end
+
+  def close_and_reopen_case
+    ChangeCaseStatus.call!(investigation:, new_status: "closed", user:)
+    product.update!(description: "wowthisisnew!")
+    ChangeCaseStatus.call!(investigation:, new_status: "open", user:)
+  end
+
 end


### PR DESCRIPTION
The services here were still pointing to `investigation.product` instead of `investigation_product`

This was leading to product being not able to be removed from cases if other adjacent investigation products had already been added with the same product parent.

https://regulatorydelivery.atlassian.net/browse/PSD-1401