### PR TITLE
Fix risk assessment edit bug

### DIFF
--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -43,10 +43,10 @@ class UpdateRiskAssessment
 private
 
   def no_changes?
-    !risk_assessment.changed? && !risk_assessment_file && attached_investigation_products_unchanged?
+    !risk_assessment.changed? && !risk_assessment_file && investigation_products_unchanged?
   end
 
-  def attached_investigation_products_unchanged?
+  def investigation_products_unchanged?
     @previous_investigation_product_ids.sort == investigation_product_ids.sort
   end
 

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -43,7 +43,11 @@ class UpdateRiskAssessment
 private
 
   def no_changes?
-    !risk_assessment.changed? && !risk_assessment_file
+    !risk_assessment.changed? && !risk_assessment_file && attached_investigation_products_unchanged?
+  end
+
+  def attached_investigation_products_unchanged?
+    @previous_investigation_product_ids.sort == investigation_product_ids.sort
   end
 
   def create_audit_activity

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -146,4 +146,34 @@ RSpec.feature "Editing a risk assessment on a case", :with_stubbed_opensearch, :
     expect(page).to have_content("Assessed by: RiskAssessmentsRUs")
     expect(page).to have_content("Product assessed: Doll")
   end
+
+  scenario "Editing a risk assessments associated products (without any other changes)" do
+    sign_in(user)
+    visit "/cases/#{investigation.pretty_id}"
+
+    click_link "Supporting information (1)"
+    click_link "Serious risk: Teddy Bear"
+
+    expect_to_be_on_risk_assessement_for_a_case_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
+
+    click_link "Edit risk assessment"
+
+    expect_to_be_on_edit_risk_assessement_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
+
+    within_fieldset("Which products were assessed?") do
+      uncheck "Teddy Bear"
+    end
+
+    within_fieldset("Which products were assessed?") do
+      check "Doll"
+    end
+
+    click_button "Update risk assessment"
+
+    click_link "Serious risk: Doll"
+
+    expect_to_be_on_risk_assessement_for_a_case_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
+
+    expect(page).to have_summary_item(key: "Product assessed",    value: "Doll (#{doll.psd_ref})")
+  end
 end

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -174,6 +174,6 @@ RSpec.feature "Editing a risk assessment on a case", :with_stubbed_opensearch, :
 
     expect_to_be_on_risk_assessement_for_a_case_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
 
-    expect(page).to have_summary_item(key: "Product assessed",    value: "Doll (#{doll.psd_ref})")
+    expect(page).to have_summary_item(key: "Product assessed", value: "Doll (#{doll.psd_ref})")
   end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?modal=detail&selectedIssue=PSD-1383

## Description
Prior to this change, risk assessments could not be edited solely to change the products associated with them. This was because changing the related investigation_products did not cause the no_changes? method in update_risk_assessment to return true. This commit fixes this issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
