### PR TITLE
First-party visitor tracking with ahoy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "kaminari", "~> 1.2" # Must be loaded before elasticsearch gems
 
 gem "activerecord-pg_enum", "~> 2.0"
 gem "active_storage_validations", "~> 1.0.3"
+gem "ahoy_matey", "~> 4.2"
 gem "aws-sdk-s3", "~> 1.119"
 gem "aws-sdk-s3control", "~> 1.62"
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,10 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    ahoy_matey (4.2.1)
+      activesupport (>= 5.2)
+      device_detector
+      safely_block (>= 0.2.1)
     ansi (1.5.0)
     ast (2.4.2)
     attr_extras (7.0.0)
@@ -149,6 +153,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.3)
+    device_detector (1.1.0)
     devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -186,6 +191,7 @@ GEM
     elasticsearch-transport (7.17.7)
       faraday (~> 1)
       multi_json
+    errbase (0.2.2)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -308,8 +314,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.2)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
@@ -489,6 +494,8 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.8.2)
       fugit (~> 1.1, >= 1.1.6)
+    safely_block (0.3.0)
+      errbase (>= 0.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -621,13 +628,14 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   active_storage_validations (~> 1.0.3)
   activerecord-pg_enum (~> 2.0)
+  ahoy_matey (~> 4.2)
   awesome_print (~> 1.9)
   aws-sdk-s3 (~> 1.119)
   aws-sdk-s3control (~> 1.62)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,6 +6,8 @@ class Activity < ApplicationRecord
                        :created_at, :investigation_id, :investigation_product_id,
                        :type, :updated_at
 
+  visitable :ahoy_visit
+
   def has_attachment?
     false
   end

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,0 +1,8 @@
+class Ahoy::Event < ApplicationRecord
+  include Ahoy::QueryMethods
+
+  self.table_name = "ahoy_events"
+
+  belongs_to :visit
+  belongs_to :user, optional: true
+end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,0 +1,6 @@
+class Ahoy::Visit < ApplicationRecord
+  self.table_name = "ahoy_visits"
+
+  has_many :events, class_name: "Ahoy::Event"
+  belongs_to :user, optional: true
+end

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,10 @@
+class Ahoy::Store < Ahoy::DatabaseStore
+end
+
+# set to true for JavaScript tracking
+Ahoy.api = false
+
+# set to true for geocoding (and add the geocoder gem to your Gemfile)
+# we recommend configuring local geocoding as well
+# see https://github.com/ankane/ahoy#geocoding
+Ahoy.geocode = false

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -8,3 +8,4 @@ Ahoy.api = false
 # we recommend configuring local geocoding as well
 # see https://github.com/ankane/ahoy#geocoding
 Ahoy.geocode = false
+Ahoy.cookies = false

--- a/db/migrate/20230320145730_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20230320145730_create_ahoy_visits_and_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Rails/CreateTableWithTimestamps
 class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[7.0]
   def change
     create_table :ahoy_visits do |t|
@@ -55,7 +56,9 @@ class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[7.0]
       t.datetime :time
     end
 
-    add_index :ahoy_events, [:name, :time]
+    add_index :ahoy_events, %i[name time]
     add_index :ahoy_events, :properties, using: :gin, opclass: :jsonb_path_ops
   end
 end
+
+# rubocop:enable Rails/CreateTableWithTimestamps

--- a/db/migrate/20230320145730_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20230320145730_create_ahoy_visits_and_events.rb
@@ -1,0 +1,61 @@
+class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ahoy_visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+
+      # the rest are recommended but optional
+      # simply remove any you don't want
+
+      # user
+      t.references :user
+
+      # standard
+      t.string :ip
+      t.text :user_agent
+      t.text :referrer
+      t.string :referring_domain
+      t.text :landing_page
+
+      # technology
+      t.string :browser
+      t.string :os
+      t.string :device_type
+
+      # location
+      t.string :country
+      t.string :region
+      t.string :city
+      t.float :latitude
+      t.float :longitude
+
+      # utm parameters
+      # t.string :utm_source
+      # t.string :utm_medium
+      # t.string :utm_term
+      # t.string :utm_content
+      # t.string :utm_campaign
+
+      # native apps
+      # t.string :app_version
+      # t.string :os_version
+      # t.string :platform
+
+      t.datetime :started_at
+    end
+
+    add_index :ahoy_visits, :visit_token, unique: true
+
+    create_table :ahoy_events do |t|
+      t.references :visit
+      t.references :user
+
+      t.string :name
+      t.jsonb :properties
+      t.datetime :time
+    end
+
+    add_index :ahoy_events, [:name, :time]
+    add_index :ahoy_events, :properties, using: :gin, opclass: :jsonb_path_ops
+  end
+end

--- a/db/migrate/20230320151233_add_ahoy_visit_id_to_audit_activities.rb
+++ b/db/migrate/20230320151233_add_ahoy_visit_id_to_audit_activities.rb
@@ -1,0 +1,7 @@
+class AddAhoyVisitIdToAuditActivities < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :activities, :ahoy_visit, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_142207) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_145730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,6 +74,40 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_142207) do
     t.index ["investigation_id"], name: "index_activities_on_investigation_id"
     t.index ["investigation_product_id"], name: "index_activities_on_investigation_product_id"
     t.index ["type"], name: "index_activities_on_type"
+  end
+
+  create_table "ahoy_events", force: :cascade do |t|
+    t.string "name"
+    t.jsonb "properties"
+    t.datetime "time"
+    t.bigint "user_id"
+    t.bigint "visit_id"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
+    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", force: :cascade do |t|
+    t.string "browser"
+    t.string "city"
+    t.string "country"
+    t.string "device_type"
+    t.string "ip"
+    t.text "landing_page"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "os"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.string "region"
+    t.datetime "started_at"
+    t.text "user_agent"
+    t.bigint "user_id"
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
 
   create_table "alerts", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_20_145730) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_151233) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_145730) do
 
   create_table "activities", id: :serial, force: :cascade do |t|
     t.uuid "added_by_user_id"
+    t.bigint "ahoy_visit_id"
     t.text "body"
     t.bigint "business_id"
     t.bigint "correspondence_id"
@@ -68,7 +69,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_20_145730) do
     t.jsonb "metadata"
     t.string "title"
     t.string "type", null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "updated_at", null: false
+    t.index ["ahoy_visit_id"], name: "index_activities_on_ahoy_visit_id"
     t.index ["business_id"], name: "index_activities_on_business_id"
     t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
     t.index ["investigation_id"], name: "index_activities_on_investigation_id"


### PR DESCRIPTION
Uses [ankane/ahoy](https://github.com/ankane/ahoy) to track visitors, users, and activity on PSD. Data is stored alongside everything else, so we can query the activity of users, the sessions that they change and objects that are created as we do with everything else. 

A few choices have been made here:

- [Anonymity set tracking](https://privacypatterns.org/patterns/Anonymity-set): A cookie is not being used to track a user across page views. Ahoy uses the browser user agent and IP address to form anonymous hash that's used internally to track user visitors. Once a user authenticates with devise, the `user_id` is persisted on all the visit records. This will allow us to join the user and teams with visits and activity permanently, and just allows us to not need another cookie. 
- Visit sessions timeout after 4 hours: the default of Ahoy, it'll mean for PSD that most users daily usage will be included as one session.
- Audit activities tracked: Nearly everything of note that happens in PSD has an audit activity made. Using ahoy, a `ahoy_visit_id` is added via the `visitable :ahoy_visit` helper. The ID is set given the current visit ID automatically. Activities for the same visit session can therefore be easily strung together, and an idea of how users use the system is much easier to gather from this data.

Things not covered:

- Discreet page views: this isn't included in ahoy. We can perhaps see if this current data is enough and if not then add page visits as a separate ticket. 
- Time spent on pages: similar to above, not included in Ahoy. We'd need to implement this with javascript along with the above work. Both of these datapoints are available currently with Google Analytics.

https://regulatorydelivery.atlassian.net/browse/PSD-1417