### PR TITLE
Add aliases:true keyword for yaml loading, error given with staging/prod deploy action

### DIFF
--- a/db/migrate/20230323103006_migrate_papertrail_to_json_blobs.rb
+++ b/db/migrate/20230323103006_migrate_papertrail_to_json_blobs.rb
@@ -6,11 +6,11 @@ class MigratePapertrailToJsonBlobs < ActiveRecord::Migration[7.0]
     add_column :versions, :new_object_changes, :jsonb, if_not_exists: true
 
     PaperTrail::Version.where.not(object: nil).find_each do |version|
-      new_object = Psych.safe_load(version.object, permitted_classes: [Date, Time])
+      new_object = Psych.safe_load(version.object, aliases: true, permitted_classes: [Date, Time])
       version.update_column(:new_object, new_object)
 
       if version.object_changes
-        new_object_changes = Psych.safe_load(version.object_changes, permitted_classes: [Date, Time])
+        new_object_changes = Psych.safe_load(version.object_changes, aliases: true, permitted_classes: [Date, Time])
         version.update_column(:new_object_changes, new_object_changes)
       end
     end


### PR DESCRIPTION
The staging & production build is broken 

```
   2023-04-04T10:43:12.84+0100 [CELL/0] OUT Starting health monitoring of container
   2023-04-04T10:43:20.46+0100 [APP/PROC/WEB/0] ERR rake aborted!
   2023-04-04T10:43:20.47+0100 [APP/PROC/WEB/0] ERR StandardError: An error has occurred, all later migrations canceled:
   2023-04-04T10:43:20.47+0100 [APP/PROC/WEB/0] ERR Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
   2023-04-04T10:43:20.47+0100 [APP/PROC/WEB/0] ERR /home/vcap/app/db/migrate/20230323103006_migrate_papertrail_to_json_blobs.rb:9:in `block in up'
```

The current migration version for production is one behind `master`, signifying the build didn't complete

```
ApplicationRecord.connection.migration_context.current_version
=> 20230223145950
```

The review app for the PR that merged this change worked, and the db migrated. 

But the production/staging deploy broke: https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/actions/runs/4595087517/jobs/8114911103#step:6:481 

Unsure as to what changed between these two points