### PR TITLE
run smoke test without 2FA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,7 +184,7 @@ jobs:
         SMOKE_TEST_URL: "https://www.product-safety-database.service.gov.uk/"
 
       run: |
-        bundle exec rspec ./smoke_test/cases_page_spec.rb
+        bundle exec rspec ./smoke_test/cases_page_without_2fa_spec.rb
 
     - name: Alert team via Slack of deployment failure
       if: failure()


### PR DESCRIPTION
Fix deploy workflow to run smoke test without 2FA