### PR TITLE
Updated investigation decorator to show title link for super users

### DIFF
--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -46,8 +46,12 @@ class InvestigationDecorator < ApplicationDecorator
     end
   end
 
-  def case_title_key
-    object.is_private? ? "Case restricted" : h.link_to(title, h.investigation_path(object), class: "govuk-link govuk-link--no-visited-state")
+  def case_title_key(viewing_user)
+    if object.is_private? && !viewing_user.has_role?(:super_user)
+      "Case restricted"
+    else
+      h.link_to("Case restricted - #{title}", h.investigation_path(object), class: "govuk-link govuk-link--no-visited-state")
+    end
   end
 
   def case_summary_values

--- a/app/views/products/_cases.html.erb
+++ b/app/views/products/_cases.html.erb
@@ -8,7 +8,7 @@
 
 <% if @product.investigations.any? %>
   <% rows = @product.investigations.uniq.map do |investigation| %>
-    <% { key: { text: investigation.case_title_key }, values: investigation.case_summary_values } %>
+    <% { key: { text: investigation.case_title_key(@current_user) }, values: investigation.case_summary_values } %>
   <% end %>
 
   <%= govukSummaryList(rows: rows, classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--sm-font opss-summary-list-mixed--4-cols capy-cases") %>

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_opensearch, :with_stubbed_m
       it { expect(case_title_key).to eq("Case restricted") }
     end
 
-    context 'with restricted case as a super user' do
+    context "with restricted case as a super user" do
       let(:investigation) { create(:allegation, user_title:, is_private: true) }
       let(:viewing_user) { create(:user, :super_user) }
 

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -256,7 +256,8 @@ RSpec.describe InvestigationDecorator, :with_stubbed_opensearch, :with_stubbed_m
   end
 
   describe "#case_title_key" do
-    let(:case_title_key) { decorated_investigation.case_title_key }
+    let(:viewing_user) { create(:user) }
+    let(:case_title_key) { decorated_investigation.case_title_key(viewing_user) }
     let(:user_title)     { "user title" }
 
     context "with unrestricted case" do
@@ -269,6 +270,13 @@ RSpec.describe InvestigationDecorator, :with_stubbed_opensearch, :with_stubbed_m
       let(:investigation) { create(:allegation, user_title:, is_private: true) }
 
       it { expect(case_title_key).to eq("Case restricted") }
+    end
+
+    context 'with restricted case as a super user' do
+      let(:investigation) { create(:allegation, user_title:, is_private: true) }
+      let(:viewing_user) { create(:user, :super_user) }
+
+      it { expect(case_title_key).to include("Case restricted - user title") }
     end
   end
 


### PR DESCRIPTION
(https://regulatorydelivery.atlassian.net/browse/PSD-1478?atlOrigin=eyJpIjoiYjA5NTVmNjFhNGI3NDRjOTllMjdlZjM0YmYyZmZjNTgiLCJwIjoiaiJ9)

## Description
This is a response to a bug when super users do not see the link to restricted cases created against a given product.

We removed the ability to restrict cases so this is really a bug for older cases. I've added some extra logic to the decorator - rather than creating extra partials and methods into the policy for now.
