### PR TITLE
Add overseas regulator field to cases

### DIFF
--- a/app/controllers/investigations/overseas_regulator_controller.rb
+++ b/app/controllers/investigations/overseas_regulator_controller.rb
@@ -1,0 +1,37 @@
+module Investigations
+  class OverseasRegulatorController < ApplicationController
+    def edit
+      investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+      authorize investigation, :change_overseas_regulator?
+      @overseas_regulator_form = OverseasRegulatorForm.from(investigation)
+      @investigation = investigation.decorate
+    end
+
+    def update
+      investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+      authorize investigation, :change_overseas_regulator?
+      @overseas_regulator_form = OverseasRegulatorForm.new(overseas_regulator_params)
+
+      if @overseas_regulator_form.valid?
+        ChangeOverseasRegulator.call!(
+          @overseas_regulator_form.serializable_hash.merge({
+            investigation:,
+            user: current_user
+          })
+        )
+
+        @investigation = investigation.decorate
+        redirect_to investigation_path(@investigation), flash: { success: "The overseas regulator was updated." }
+      else
+        @investigation = investigation.decorate
+        render :edit
+      end
+    end
+
+  private
+
+    def overseas_regulator_params
+      params.require(:investigation).permit(:is_from_overseas_regulator, :overseas_regulator_country)
+    end
+  end
+end

--- a/app/forms/overseas_regulator_form.rb
+++ b/app/forms/overseas_regulator_form.rb
@@ -1,0 +1,15 @@
+class OverseasRegulatorForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :is_from_overseas_regulator, :boolean, default: nil
+  attribute :overseas_regulator_country, :string
+
+  validates :is_from_overseas_regulator, inclusion: { in: [true, false] }
+  validates :overseas_regulator_country, inclusion: { in: Country.overseas_regulator_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
+
+  def self.from(investigation)
+    new(is_from_overseas_regulator: investigation.is_from_overseas_regulator, overseas_regulator_country: investigation.overseas_regulator_country)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,21 +4,28 @@ module ApplicationHelper
     content_for(:page_title, title)
   end
 
-  def error_summary(errors, ordered_attributes = [])
+  # The map_errors parameters can be used to link error messages for multi-answer
+  # so they focus on a specific attribute option when clicked.
+  # Eg: "map_errors: { colours: :red }" will cause validation errors messages for
+  # "colours" in the error summary to link to "#red" instead of to "#colours".
+  def error_summary(errors, ordered_attributes = [], map_errors: {})
     return unless errors.any?
 
     ordered_errors = ActiveSupport::OrderedHash.new
     ordered_attributes.map { |attr| ordered_errors[attr] = [] }
 
-    errors.each do |error|
-      next if error.message.blank?
+    errors.map do |error|
+      next if error.blank? || error.message.blank?
+
+      href = map_errors[error.attribute] || error.attribute
+      href = "##{href}"
 
       # Errors for attributes that are not included in the ordered list will be
       # added at the end after the errors for ordered attributes.
       if ordered_errors[error.attribute]
-        ordered_errors[error.attribute] << { text: error.message, href: "##{error.attribute}" }
+        ordered_errors[error.attribute] << { text: error.message, href: }
       else
-        ordered_errors[error.attribute] = [{ text: error.message, href: "##{error.attribute}" }]
+        ordered_errors[error.attribute] = [{ text: error.message, href: }]
       end
     end
     error_list = ordered_errors.values.flatten.compact

--- a/app/models/audit_activity/investigation/change_overseas_regulator.rb
+++ b/app/models/audit_activity/investigation/change_overseas_regulator.rb
@@ -1,0 +1,44 @@
+class AuditActivity::Investigation::ChangeOverseasRegulator < AuditActivity::Investigation::Base
+  def self.build_metadata(investigation)
+    updated_values = investigation.previous_changes.slice(:is_from_overseas_regulator, :overseas_regulator_country)
+
+    {
+      updates: updated_values
+    }
+  end
+
+  def title(*)
+    "Overseas regulator changed"
+  end
+
+  def body
+    if previous_from_overseas_regulator.nil? && previous_country == "None"
+      "Overseas regulator set to #{country_from_code(new_country)}"
+    else
+      "Overseas regulator changed from #{country_from_code(previous_country)} to #{country_from_code(new_country)}"
+    end
+  end
+
+  def previous_from_overseas_regulator
+    metadata["updates"]["is_from_overseas_regulator"]&.first
+  end
+
+  def new_from_overseas_regulator
+    metadata["updates"]["is_from_overseas_regulator"]&.second
+  end
+
+  def previous_country
+    metadata["updates"]["overseas_regulator_country"].first || "None"
+  end
+
+  def new_country
+    metadata["updates"]["overseas_regulator_country"].second || "None"
+  end
+
+private
+
+  def country_from_code(code)
+    country = Country.overseas_regulator_countries.find { |c| c[1] == code }
+    (country && country[0]) || code
+  end
+end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -8,6 +8,10 @@ class Country
     ["Northern Ireland", "country:GB-NIR"]
   ].freeze
 
+  UNITED_KINGDOM = [
+    ["United Kingdom", "country:GB"]
+  ].freeze
+
   class << self
     def all
       @all ||= JSON.parse(File.read(PATH_TO_COUNTRIES_LIST))
@@ -15,6 +19,10 @@ class Country
 
     def notifying_countries
       all + ADDITIONAL_COUNTRIES
+    end
+
+    def overseas_regulator_countries
+      all - UNITED_KINGDOM
     end
   end
 end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -62,8 +62,20 @@ class InvestigationPolicy < ApplicationPolicy
     user.can_validate_risk_level?
   end
 
+  def view_notifying_country?(user: @user)
+    record.notifying_country.present? || user.is_opss? || user.has_role?(:super_user)
+  end
+
   def change_notifying_country?(user: @user)
     user.notifying_country_editor? || user.has_role?(:super_user)
+  end
+
+  def view_overseas_regulator?(user: @user)
+    user.is_opss? || user.has_role?(:super_user)
+  end
+
+  def change_overseas_regulator?(user: @user)
+    user.is_opss? || user.has_role?(:super_user)
   end
 
   def comment?
@@ -74,9 +86,5 @@ class InvestigationPolicy < ApplicationPolicy
 
   def can_be_deleted?
     record.products.none?
-  end
-
-  def view_notifying_country?(user: @user)
-    record.notifying_country.present? || user.is_opss? || user.has_role?(:super_user)
   end
 end

--- a/app/services/change_overseas_regulator.rb
+++ b/app/services/change_overseas_regulator.rb
@@ -1,0 +1,57 @@
+class ChangeOverseasRegulator
+  include Interactor
+  include EntitiesToNotify
+
+  delegate :investigation, :is_from_overseas_regulator, :overseas_regulator_country, :user, to: :context
+
+  def call
+    context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+
+    assign_overseas_regulator
+    return if investigation.changes.none?
+
+    ActiveRecord::Base.transaction do
+      investigation.save!
+      create_audit_activity_for_overseas_regulator_changed
+    end
+
+    send_notification_email(investigation, user)
+  end
+
+private
+
+  def create_audit_activity_for_overseas_regulator_changed
+    metadata = activity_class.build_metadata(investigation)
+
+    activity_class.create!(
+      added_by_user: user,
+      investigation:,
+      metadata:
+    )
+  end
+
+  def activity_class
+    AuditActivity::Investigation::ChangeOverseasRegulator
+  end
+
+  def assign_overseas_regulator
+    country = is_from_overseas_regulator ? overseas_regulator_country : nil
+    investigation.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country)
+  end
+
+  def send_notification_email(investigation, user)
+    return unless investigation.sends_notifications?
+
+    email_recipients_for_team_with_access(investigation, user).each do |entity|
+      email = entity.is_a?(Team) ? entity.team_recipient_email : entity.email
+      NotifyMailer.investigation_updated(
+        investigation.pretty_id,
+        entity.name,
+        email,
+        "#{user.name} (#{user.team.name}) edited overseas regulator on the case.",
+        "Overseas regulator edited for Case"
+      ).deliver_later
+    end
+  end
+end

--- a/app/views/investigations/_pages_top.html.erb
+++ b/app/views/investigations/_pages_top.html.erb
@@ -1,11 +1,7 @@
 <% content_for :after_header do %>
   <% if content_for?(:back_link) || has_badges?(investigation) %>
-    <div class="govuk-grid-row">
-      <% if content_for?(:back_link) %>
-        <div class="govuk-grid-column-one-half">
-          <%= yield :back_link %>
-        </div>
-      <% end %>
-    </div>
+    <% if content_for?(:back_link) %>
+      <%= yield :back_link %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/investigations/activities/investigation/_change_overseas_regulator.html.erb
+++ b/app/views/investigations/activities/investigation/_change_overseas_regulator.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  <% if activity.previous_from_overseas_regulator.nil? && activity.previous_country == "None" %>
+    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_set", new_country: country_from_code(activity.new_country, Country.overseas_regulator_countries) ) %>
+  <% else %>
+    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_changed", previous_country: country_from_code(activity.previous_country, Country.overseas_regulator_countries), new_country: country_from_code(activity.new_country, Country.overseas_regulator_countries) ) %>
+  <% end %>
+</p>

--- a/app/views/investigations/overseas_regulator/edit.html.erb
+++ b/app/views/investigations/overseas_regulator/edit.html.erb
@@ -1,0 +1,48 @@
+<% page_heading = "Was the allegation made by an overseas regulator?" %>
+<% page_title page_heading, errors: @overseas_regulator_form.errors.any? %>
+
+<% content_for :back_link do %>
+  <%= govukBackLink(
+    text: "Back",
+    href: investigation_path(@investigation)
+  ) %>
+<% end %>
+
+<%= render "investigations/pages_top", investigation: @investigation %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), html: {novalidate: true}, method: :put, local: true do |form| %>
+      <%= error_summary @overseas_regulator_form.errors, map_errors: {
+        is_from_overseas_regulator: :investigation_is_from_overseas_regulator_true,
+        overseas_regulator_country: :investigation_overseas_regulator_country
+      } %>
+
+      <% select_menu_html = capture do %>
+        <%= govukSelect(
+          form: form,
+          key: :overseas_regulator_country,
+          items: options_for_overseas_regulator(Country.overseas_regulator_countries, @overseas_regulator_form),
+          include_blank: true,
+          label: { text: "Select which country" }
+        ) %>
+      <% end %>
+      <%= govukRadios(
+        form: form,
+        key: :is_from_overseas_regulator,
+        fieldset: { legend: { html: "<h1 class=\"govuk-fieldset__heading\">Was the allegation made by an overseas regulator?</h1>".html_safe, classes: "govuk-fieldset__legend--l" } },
+        hint: { html: "Select no if the allegation was from the <abbr>UK</abbr> (or <abbr>GB</abbr>).".html_safe, classes: "govuk-!-margin-bottom-5" },
+        items: [{ text: t("investigations.overseas_regulator.option_yes"),
+                  value: true,
+                  conditional: { html: select_menu_html } },
+                { text: t("investigations.overseas_regulator.option_no"),
+                  value: false }]
+      ) %>
+
+      <div class="govuk-button-group">
+        <%= govukButton(text: t("Save")) %>
+        <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,8 +149,9 @@ en:
             label: Fulfillment house
           distributor:
             label: Distributor
-
-
+    overseas_regulator:
+      option_yes: "Yes"
+      option_no: "No"
     tabs:
       businesses:
         remove_business_hint: "Removing a business from a case cannot be undone"
@@ -355,6 +356,9 @@ en:
         body: "Permission level changed to '%{new_permission}' from '%{old_permission}'."
       update_notifying_country:
         body: "Notifying country changed from %{previous_country} to %{new_country}."
+      update_overseas_regulator:
+        body_set: Overseas regulator set to %{new_country}
+        body_changed: "Overseas regulator changed from %{previous_country} to %{new_country}"
   cases:
     filters:
       coronavirus_cases_only: "Coronavirus cases only"
@@ -463,6 +467,12 @@ en:
           attributes:
             country:
               inclusion: Enter the notifying country
+        overseas_regulator_form:
+          attributes:
+            is_from_overseas_regulator:
+              inclusion: Select yes if the allegation was made by an overseas regulator
+            overseas_regulator_country:
+              inclusion: Select which country
         comment_form:
           attributes:
             body:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
 
     resource :coronavirus_related, only: %i[update show], path: "edit-coronavirus-related", controller: "investigations/coronavirus_related"
     resource :notifying_country, only: %i[update edit], path: "edit-notifying-country", controller: "investigations/notifying_country"
+    resource :overseas_regulator, only: %i[update edit], path: "edit-overseas-regulator", controller: "investigations/overseas_regulator"
     resource :risk_level, only: %i[update show], path: "edit-risk-level", controller: "investigations/risk_level"
     resource :risk_validations, only: %i[edit update], path: "validate-risk-level", controller: "investigations/risk_validations"
     resource :reference_numbers, only: %i[edit update], controller: "investigations/reference_numbers"

--- a/db/migrate/20230511145908_add_overseas_regulator_to_investigations.rb
+++ b/db/migrate/20230511145908_add_overseas_regulator_to_investigations.rb
@@ -1,0 +1,10 @@
+class AddOverseasRegulatorToInvestigations < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :investigations, bulk: true do |t|
+        t.boolean :is_from_overseas_regulator
+        t.string :overseas_regulator_country
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_203419) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_145908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -239,9 +239,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_203419) do
     t.text "hazard_description"
     t.string "hazard_type"
     t.boolean "is_closed", default: false
+    t.boolean "is_from_overseas_regulator"
     t.boolean "is_private", default: false, null: false
     t.text "non_compliant_reason"
     t.string "notifying_country"
+    t.string "overseas_regulator_country"
     t.string "pretty_id", null: false
     t.string "product_category"
     t.string "received_type"

--- a/spec/features/change_notifying_country_spec.rb
+++ b/spec/features/change_notifying_country_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Changing the notifying country of a case", :with_stubbed_mailer, 
     end
 
     # skipping until the notifying country change is carried out on the new case page work.
-    xit "can succesfully change pre-populated notifying_country" do
+    xit "can succesfully change pre-populated notifying country" do
       investigation.update!(notifying_country: "country:GB-ENG")
 
       sign_in_and_visit_change_notifying_country_page("England")
@@ -22,12 +22,12 @@ RSpec.feature "Changing the notifying country of a case", :with_stubbed_mailer, 
 
       click_link "Activity"
       expect(page).to have_css("h3", text: "Notifying country changed")
-      expect(page).to have_css("p", text: "Notifying country changed from England to Scotland.")
+      expect(page).to have_css("p", text: "Notifying country changed from England to Scotland")
     end
   end
 
   context "when user is not a notifying_country_editor" do
-    xit "does not allow user to change country" do
+    xit "does not allow user to change notifying country" do
       sign_in user
       visit "/cases/#{investigation.pretty_id}"
       expect(page.find("dt", text: "Notifying country")).to have_sibling("dd", text: "England")
@@ -40,7 +40,7 @@ RSpec.feature "Changing the notifying country of a case", :with_stubbed_mailer, 
     sign_in user
     visit "/cases/#{investigation.pretty_id}"
     expect(page.find("dt", text: "Notifying country")).to have_sibling("dd", text: country)
-    click_link "Change notifying_country"
+    click_link "Change notifying country"
     expect(page).to have_css("h1", text: "Change notifying country")
     expect(page).to have_select("Notifying country", selected: country)
   end

--- a/spec/features/change_overseas_regulator_spec.rb
+++ b/spec/features/change_overseas_regulator_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.feature "Changing the overseas regulator of a case", :with_stubbed_mailer, :with_stubbed_opensearch do
+  let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"), name: "Bob Jones") }
+  let(:investigation)  { create(:allegation, creator: user) }
+
+  context "when user is an OPSS member" do
+    before do
+      user.roles.create!(name: "opss")
+    end
+
+    it "can succesfully set the overseas regulator" do
+      sign_in_and_visit_change_overseas_regulator_page("")
+
+      choose "Yes"
+      select "Armenia", from: "Select which country"
+      click_button "Save"
+      expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
+      expect(page.find("dt", text: "Overseas regulator")).to have_sibling("dd", text: "Armenia")
+
+      click_link "Activity"
+      expect(page).to have_css("h3", text: "Overseas regulator changed")
+      expect(page).to have_css("p", text: "Overseas regulator set to Armenia")
+    end
+
+    it "can succesfully change the pre-populated overseas regulator" do
+      investigation.update!(is_from_overseas_regulator: true, overseas_regulator_country: "country:AM")
+
+      sign_in_and_visit_change_overseas_regulator_page("Armenia")
+
+      select "United States", from: "Select which country"
+      click_button "Save"
+      expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
+      expect(page.find("dt", text: "Overseas regulator")).to have_sibling("dd", text: "United States")
+
+      click_link "Activity"
+      expect(page).to have_css("h3", text: "Overseas regulator changed")
+      expect(page).to have_css("p", text: "Overseas regulator changed from Armenia to United States")
+    end
+
+    it "can succesfully clear the pre-populated overseas regulator" do
+      investigation.update!(is_from_overseas_regulator: true, overseas_regulator_country: "country:AM")
+
+      sign_in_and_visit_change_overseas_regulator_page("Armenia")
+
+      choose "No"
+      click_button "Save"
+      expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
+      expect(page.find("dt", text: "Overseas regulator")).to have_sibling("dd", text: "No")
+
+      click_link "Activity"
+      expect(page).to have_css("h3", text: "Overseas regulator changed")
+      expect(page).to have_css("p", text: "Overseas regulator changed from Armenia to None")
+    end
+  end
+
+  context "when user is not an OPSS member" do
+    it "does not allow user to view or change the overseas regulator" do
+      sign_in user
+      visit "/cases/#{investigation.pretty_id}"
+      expect(page).not_to have_css("dt", text: "Overseas regulator")
+    end
+  end
+
+  def sign_in_and_visit_change_overseas_regulator_page(country)
+    sign_in user
+    visit "/cases/#{investigation.pretty_id}"
+    expect(page.find("dt", text: "Overseas regulator")).to have_sibling("dd", text: country)
+    click_link "Change overseas regulator"
+    expect(page).to have_css("h1", text: "Was the allegation made by an overseas regulator?")
+    expect(page).to have_select("Select which country", selected: country)
+  end
+end

--- a/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
+++ b/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe AuditActivity::Investigation::ChangeOverseasRegulator, :with_stubbed_mailer, :with_stubbed_opensearch do
+  subject(:metadata) { described_class.build_metadata(investigation) }
+
+  let(:audit_activity) { described_class.from(investigation) }
+
+  let(:user) { create(:user).decorate }
+  let(:investigation) { create(:enquiry, is_from_overseas_regulator: true, overseas_regulator_country: previous_country) }
+  let(:previous_country) { "country:AM" }
+  let(:new_country) { "country:US" }
+  let(:previous_country_human) { "Armenia" }
+  let(:new_country_human) { "United States" }
+
+  let(:activity) { described_class.create(metadata:) }
+
+  before { investigation.update!(overseas_regulator_country: new_country) }
+
+  describe ".build_metadata" do
+    context "when the case's overseas regulator has been updated" do
+      it "produces a Hash of the change" do
+        expect(metadata).to eq({
+          updates: {
+            "overseas_regulator_country" => [previous_country, new_country]
+          }
+        })
+      end
+    end
+  end
+
+  describe "#body" do
+    it "returns a string" do
+      expect(activity.body).to eq("Overseas regulator changed from #{previous_country_human} to #{new_country_human}")
+    end
+  end
+
+  describe "#new_country" do
+    it "returns the newly assigned country" do
+      expect(activity.new_country).to eq(new_country)
+    end
+  end
+
+  describe "#previous_country" do
+    it "returns the previously assigned country" do
+      expect(activity.previous_country).to eq(previous_country)
+    end
+  end
+end

--- a/spec/policies/investigation_policy_spec.rb
+++ b/spec/policies/investigation_policy_spec.rb
@@ -213,6 +213,14 @@ RSpec.describe InvestigationPolicy, :with_stubbed_opensearch, :with_stubbed_mail
       it "can edit the notifying country" do
         expect(policy.change_notifying_country?).to be true
       end
+
+      it "can view the overseas regulator" do
+        expect(policy.view_overseas_regulator?).to be true
+      end
+
+      it "can edit the overseas regulator" do
+        expect(policy.change_overseas_regulator?).to be true
+      end
     end
   end
 

--- a/spec/services/change_overseas_regulator_spec.rb
+++ b/spec/services/change_overseas_regulator_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe ChangeOverseasRegulator, :with_stubbed_opensearch, :with_stubbed_mailer, :with_stubbed_antivirus, :with_test_queue_adapter do
+  let(:investigation) { create(:allegation, is_from_overseas_regulator: true, overseas_regulator_country: "country:AM") }
+  let(:user) { create(:user, name: "User One") }
+
+  describe ".call" do
+    context "with no parameters" do
+      let(:result) { described_class.call }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with no investigation parameter" do
+      let(:result) { described_class.call(user:) }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with no user parameter" do
+      let(:result) { described_class.call(investigation:) }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with the required parameters" do
+      let(:result) do
+        described_class.call(
+          user:,
+          investigation:,
+          is_from_overseas_regulator: true,
+          overseas_regulator_country:
+        )
+      end
+
+      let(:activity_entry) { investigation.activities.where(type: AuditActivity::Investigation::ChangeOverseasRegulator.to_s).order(:created_at).last }
+
+      context "when no changes have been made" do
+        let(:overseas_regulator_country) { "country:AM" }
+
+        it "does not generate an activity entry" do
+          result
+
+          expect(investigation.activities.where(type: AuditActivity::Investigation::ChangeOverseasRegulator.to_s)).to eq []
+        end
+
+        it "does not send any case updated emails" do
+          expect { result }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
+        end
+      end
+
+      context "when changes have been made" do
+        let(:overseas_regulator_country) { "country:US" }
+
+        it "updates the investigation", :aggregate_failures do
+          result
+
+          expect(investigation.overseas_regulator_country).to eq("country:US")
+        end
+
+        it "creates an activity entry" do
+          result
+
+          expect(activity_entry.metadata).to eql({
+            "updates" => {
+              "overseas_regulator_country" => ["country:AM", "country:US"]
+            }
+          })
+        end
+
+        it "sends an email to notify of the change" do
+          expect { result }.to have_enqueued_mail(NotifyMailer, :investigation_updated).with(
+            investigation.pretty_id,
+            investigation.owner_team.name,
+            investigation.owner_team.email,
+            "#{user.name} (#{user.team.name}) edited overseas regulator on the case.",
+            "Overseas regulator edited for Case"
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1480

## Description

Adds a new overseas regulator field to cases and allows OPSS users and super users to view and change it.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-05-12 at 14 02 32](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/b8049f31-3b41-44e1-b21d-0145f1b63d77)

![Screenshot 2023-05-15 at 09 57 35](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/197a5c51-c589-4be8-9f57-de8d311be9ab)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
