### PR TITLE
Remember cookie consent

### DIFF
--- a/app/controllers/concerns/cookies_concern.rb
+++ b/app/controllers/concerns/cookies_concern.rb
@@ -42,6 +42,6 @@ module CookiesConcern
   end
 
   def set_analytics_cookies(accept_analytics_cookies)
-    cookies[:accept_analytics_cookies] = accept_analytics_cookies
+    cookies[:accept_analytics_cookies] = { value: accept_analytics_cookies, expires: 1.year.from_now }
   end
 end

--- a/app/views/help/cookies_policy.html.erb
+++ b/app/views/help/cookies_policy.html.erb
@@ -3,89 +3,128 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="cookie-settings__confirmation display: block;">
-
-    <% if flash[:cookies_updated_successfully] && !analytics_cookies_not_set? %>
-      <div class="gem-c-success-alert govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-3" role="alert" tabindex="-1" aria-labelledby="govuk-notification-banner-title-1e84d50f" data-module="initial-focus" data-initial-focus-module-started="true">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title-1e84d50f">Success</h2>
+    <div class="cookie-settings__confirmation">
+      <% if flash[:cookies_updated_successfully] && !analytics_cookies_not_set? %>
+        <div class="gem-c-success-alert govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-0" role="alert" tabindex="-1" aria-labelledby="govuk-notification-banner-title-1e84d50f" data-module="initial-focus" data-initial-focus-module-started="true">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title-1e84d50f">Success</h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading">Your cookie settings were saved</h3>
+            <p class="govuk-body">Government services may set additional cookies and, if so, will have their own cookie policy and banner.</p>
+            <a class="govuk-link govuk-notification-banner__link cookie-settings__prev-page" href="/" style="display: inline;">Go to the Product Safety Database home page</a>
+          </div>
         </div>
-        <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading">Your cookie settings were saved</h3>
-          <p class="govuk-body">Government services may set additional cookies and, if so, will have their own cookie policy and banner.</p>
-          <a class="govuk-link govuk-notification-banner__link cookie-settings__prev-page" href="/" style="display: inline;">Go to the Product Safety Database home page</a>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <h1 class="govuk-heading-l" id="cookies-policy">Cookies policy</h1>
+      <h1 class="govuk-heading-l govuk-!-margin-top-8">Cookies policy</h1>
 
-    <h2 class="govuk-heading-m">What are cookies?</h2>
-    <p>Cookies are small text files that are saved on your device to help the website perform a number of functions. On your first visit to our website, a popup banner asked you to accept our use of cookies and similar technologies. The information these cookies collect is based on your browsing device's IP-address (hardware identifier).</p>
+      <h2 class="govuk-heading-m">What are cookies?</h2>
 
-    <h2 class="govuk-heading-m">What do the cookies do?</h2>
-    <p>The cookies we use:</p>
-    <p>DO NOT: store personally identifiable information about you; store information such as passwords (and cannot) allow us to access other information stored on your device, store information about you others could understand, compromise your security</p>
-    <p>DO: allow us to see how many people use our website and monitor their activities; allow us to see how people arrive at our site (e.g. via search engine); allow us to gather geographic location and browser information.</p>
+      <p>This website puts small files (known as ‘cookies’) onto your computer to collect information
+      about how you browse the site. Find out more about the cookies we use, what they’re for and when
+      they expire.</p>
 
-    <h2 class="govuk-heading-m">What cookies does the website use?</h2>
-    <p>This website uses two types of cookies:</p>
-    <p>1. Persistent cookies, which remain on your device to capture and remember your preferences (if chosen) for any future re-visit (e.g. your location).</p>
-    <p>2. Session cookies, which are deleted when your browser is closed. These cookies are used for analytical services provided by Google Inc. in the US on our behalf. The analysis allows an insight into where and how our website is used so that we can continuously work on its improvement. Google will not associate your IP address with any other data held by Google. However, if you don't wish to be part of this analysis, feel free to download and install a browser plug-in to opt-out under <%= link_to "https://tools.google.com/dlpage/gaoptout?hl=en-G", "https://tools.google.com/dlpage/gaoptout?hl=en-G" %>.</p>
-    <p>The cookies we use, what they are used for and how long they remain on your device are set out below:</p>
+      <h2 class="govuk-heading-m">What do the cookies do?</h2>
 
-    <h2 class="govuk-heading-m">Product Safety Database:</h2>
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header">Name</th>
-          <th class="govuk-table__header">Purpose</th>
-          <th class="govuk-table__header">Lifetime of cookie</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_psd_session</td>
-          <td class="govuk-table__cell">This stores information relating to recent actions that have been taken. For example, partial information from a wizard.</td>
-          <td class="govuk-table__cell">When you close your browser</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">two-factor-[<abbr title="Universally unique identifier">UUID</abbr>]</td>
-          <td class="govuk-table__cell">This allows you to sign in without re-entering a security code.</td>
-          <td class="govuk-table__cell"><%= distance_of_time_in_words(SecondaryAuthentication::TIMEOUTS[SecondaryAuthentication::DEFAULT_OPERATION]) %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">accept_analytics_cookies</td>
-          <td class="govuk-table__cell">Stores whether you have accepted or rejected the use of analytics cookies</td>
-          <td class="govuk-table__cell">When you close your browser</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_ga</td>
-          <td class="govuk-table__cell">This helps us count how many people visit our site by tracking if you’ve visited before.</td>
-          <td class="govuk-table__cell">2 years</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_gid</td>
-          <td class="govuk-table__cell">This helps us count how many people visit our site by tracking if you’ve visited before.</td>
-          <td class="govuk-table__cell">24 hours</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_gat</td>
-          <td class="govuk-table__cell">Used to manage the rate at which page view requests are made.</td>
-          <td class="govuk-table__cell">1 minute</td>
-        </tr>
-      </tbody>
-    </table>
+      <p>The cookies we use:</p>
 
-    <%= render 'cookie_form' %>
+      <p>DO NOT: store personally identifiable information about you; store information such as passwords;
+      (and cannot) allow us to access other information stored on your device; store information about
+      you others could understand; compromise your security</p>
 
-    <p>You can also <%= link_to "opt out of Google Analytics cookies here", "https://tools.google.com/dlpage/gaoptout" %>.</p>
+      <p>DO: allow us to see how many people use our website and monitor their activities; allow us to see
+      how people arrive at our site (e.g. via search engine); allow us to gather geographic location and
+      browser information.</p>
 
-    <h2 class="govuk-heading-m">How are cookies deleted?</h2>
-    <p>To delete or stop cookies being placed on your device, please check the help menu of your internet browser. Blocking cookies may reduce the functionality of this website.</p>
+      <h2 class="govuk-heading-m">What cookies does this website use?</h2>
 
-    <h2 class="govuk-heading-m">For more information</h2>
-    <p>To learn more about cookies and similar technologies, we recommend you visit: <%= link_to "http://www.allaboutcookies.org/", "http://www.allaboutcookies.org/" %></p>
+      <p>This website uses two types of cookies:</p>
 
+      <ol class="govuk-list govuk-list--number">
+        <li>Persistent cookies, which remain on your device to capture and remember your preferences (if chosen)
+          for any future re-visit (e.g. your location).
+        <li>Session cookies, which are deleted when you close your browser. These cookies are used for analytical
+          services provided by Google Inc. in the US on our behalf. The analysis allows an insight into where and
+          how our website is used so that we can continuously work on its improvement. Google will not associate
+          your IP address with any other data held by Google. However, if you do not wish to be part of this analysis,
+          feel free to amend your browser settings or
+          <%= link_to "install a browser plug-in", "https://tools.google.com/dlpage/gaoptout" %> to opt-out.
+      </ol>
+
+      <p>The cookies we use, what they are used for and how long they remain on your device are set out below:</p>
+
+      <h3 class="govuk-heading-m">Google Analytics</h3>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Name</th>
+            <th class="govuk-table__header">Purpose</th>
+            <th class="govuk-table__header">Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_ga</td>
+            <td class="govuk-table__cell">This helps us count how many people visit our site by tracking if you’ve visited before.</td>
+            <td class="govuk-table__cell">2 years</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_gid</td>
+            <td class="govuk-table__cell">This helps us count how many people visit our site by tracking if you’ve visited before.</td>
+            <td class="govuk-table__cell">24 hours</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_gat</td>
+            <td class="govuk-table__cell">This is used to manage the rate at which page view requests are made.</td>
+            <td class="govuk-table__cell">1 minute</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 class="govuk-heading-m">Product Safety Database</h3>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Name</th>
+            <th class="govuk-table__header">Purpose</th>
+            <th class="govuk-table__header">Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_psd_session</td>
+            <td class="govuk-table__cell">Saves information about your progress as you browse the website.</td>
+            <td class="govuk-table__cell">When you close your browser</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">accept_analytics_cookies</td>
+            <td class="govuk-table__cell">Saves whether you have chosen to accept or reject analytics cookies.</td>
+            <td class="govuk-table__cell">1 year</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">two-factor-*</td>
+            <td class="govuk-table__cell">Saves when you last used your secondary authentication method to log in. There may be several instances of this cookie.</td>
+            <td class="govuk-table__cell">When you close your browser</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <%= render 'cookie_form' %>
+
+      <p>You can also <%= link_to "opt out of Google Analytics cookies", "https://tools.google.com/dlpage/gaoptout" %>.</p>
+
+      <h2 class="govuk-heading-m">How can I delete cookies?</h2>
+
+      <p>To delete or stop cookies being placed on your device, check the help menu of your internet browser.
+      Blocking cookies may reduce the functionality of this website.</p>
+
+      <h2 class="govuk-heading-m">For more information</h2>
+
+      <p>To learn more about cookies and similar technologies, visit
+      <%= link_to "https://www.allaboutcookies.org/", "https://www.allaboutcookies.org/" %>.</p>
+    </div>
   </div>
 </div>

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-describe "user declarations", type: :request do
+describe "cookies", type: :request do
   before do
     cookies["essential"] = "psd"
     cookies["_ga_NSLSMEMX9S"] = "foo"
     cookies["_gid"] = "bar"
     cookies["_gat_gtag_UA_126364208_2"] = "baz"
 
-    cookies["accept_analytics_cookies"] = accept_analytics_cookies
+    cookies["accept_analytics_cookies"] = { value: accept_analytics_cookies, expires: 1.year.from_now }
 
     get "/help/terms-and-conditions"
   end
@@ -17,8 +17,7 @@ describe "user declarations", type: :request do
 
     it "has analytics cookies" do
       # response is not returning any cookies to delete
-      # returned cookie is the one that stores cookie options
-      expect(response.cookies.to_hash.size).to eq(1)
+      expect(cookies.to_hash.size).to eq(6)
     end
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1490

## Description

Changes the cookie consent cookie to be remembered for 1 year rather than the duration of the browser session.

This means users that respond to the cookie banner will not see it again for 1 year or until they delete all cookies.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
