### PR TITLE
Fix case and product page UI

### DIFF
--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -156,13 +156,13 @@ module InvestigationsHelper
       {
         key: { text: "Last updated" },
         value: {
-          text: "#{time_ago_in_words(@investigation.updated_at).capitalize} ago"
+          text: time_ago_or_date(@investigation.updated_at)
         }
       },
       {
         key: { text: "Created" },
         value: {
-          text: "#{time_ago_in_words(@investigation.created_at).capitalize} ago"
+          text: time_ago_or_date(@investigation.created_at)
         }
       },
       {
@@ -472,5 +472,13 @@ private
 
   def summary_html(investigation)
     "<span class='opss-text-limit-scroll-s'>#{investigation.object.description}</span>".html_safe
+  end
+
+  def time_ago_or_date(date)
+    if date > 24.hours.ago
+      "#{time_ago_in_words(date).capitalize} ago"
+    else
+      date.to_formatted_s(:govuk)
+    end
   end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -30,7 +30,7 @@
       <% end %>
       <span class="govuk-visually-hidden">|</span>
       <% if policy(@product).can_spawn_case? %>
-        <%= link_to new_investigation_ts_investigation_path(product_id: @product.id), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-14 govuk-!-text-align-centre govuk-!-padding-2 govuk-!-display-inline-block govuk-!-margin-top-4 govuk-!-margin-bottom-6 govuk-link--no-underline opss-border-all opss-float-left--mobile", data: { cy: "create-new-case" } do %>
+        <%= link_to new_investigation_ts_investigation_path(product_id: @product.id), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-text-align-centre govuk-!-padding-2 govuk-!-display-inline-block govuk-!-margin-top-4 govuk-!-margin-bottom-6 govuk-link--no-underline opss-border-all opss-float-left--mobile", data: { cy: "create-new-case" } do %>
           Create a new case<br class="opss-br-desktop"> for this product
         <% end %>
       <% end %>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1481

## Description

Makes tweaks to the case and product pages:

* On the case page, displays full dates when they are more than 24 hours ago
* On the product page, increases the size of the link to create a new product

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-05-12 at 15 24 54](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/40e5baf1-74f7-49f6-8708-b784ebf93dee)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
