### PR TITLE
OPSS funded test reports (PSD-1573)

### DIFF
--- a/app/controllers/investigations/supporting_information_controller.rb
+++ b/app/controllers/investigations/supporting_information_controller.rb
@@ -21,7 +21,7 @@ module Investigations
         },
         "Test results" => {
           items: investigation.test_results.order(created_at: :desc).map(&:decorate),
-          new_path: new_investigation_test_result_path(investigation)
+          new_path: new_investigation_funding_source_path(investigation)
         },
         "Other" => {
           items: investigation.generic_supporting_information_attachments.order(created_at: :desc).map(&:decorate),
@@ -64,7 +64,7 @@ module Investigations
       when "image", "generic_information"
         redirect_to new_investigation_document_path(@investigation)
       when "testing_result"
-        redirect_to new_investigation_test_result_path(@investigation)
+        redirect_to new_investigation_funding_source_path(@investigation)
       when "risk_assessment"
         redirect_to new_investigation_risk_assessment_path(@investigation)
       when "product"

--- a/app/controllers/investigations/test_results/funding_certificate_controller.rb
+++ b/app/controllers/investigations/test_results/funding_certificate_controller.rb
@@ -3,12 +3,14 @@ class Investigations::TestResults::FundingCertificateController < ApplicationCon
 
   def new
     @test_certificate_form = SetTestResultCertificateOnCaseForm.new
+    session[:test_result_certificate] = nil
   end
 
   def create
     @test_certificate_form = SetTestResultCertificateOnCaseForm.new(test_funding_certificate_params)
     if @test_certificate_form.valid?
-
+      session[:test_result_certificate] = test_funding_certificate_params.to_h
+      redirect_to new_investigation_test_result_path(@investigation)
     else
       render :new
     end

--- a/app/controllers/investigations/test_results/funding_certificate_controller.rb
+++ b/app/controllers/investigations/test_results/funding_certificate_controller.rb
@@ -22,6 +22,8 @@ private
     investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize investigation, :update?
     @investigation = investigation.decorate
+  rescue ActiveRecord::RecordNotFound
+    render_404_page
   end
 
   def test_funding_certificate_params

--- a/app/controllers/investigations/test_results/funding_certificate_controller.rb
+++ b/app/controllers/investigations/test_results/funding_certificate_controller.rb
@@ -23,6 +23,9 @@ private
   end
 
   def test_funding_certificate_params
-    params.require(:set_test_result_certificate_on_case_form).permit(:tso_certificate_reference_number, :tso_certificate_issue_date)
+    params.require(:set_test_result_certificate_on_case_form).permit(
+      :tso_certificate_reference_number,
+      tso_certificate_issue_date: %i[day month year]
+    )
   end
 end

--- a/app/controllers/investigations/test_results/funding_certificate_controller.rb
+++ b/app/controllers/investigations/test_results/funding_certificate_controller.rb
@@ -1,6 +1,28 @@
 class Investigations::TestResults::FundingCertificateController < ApplicationController
+  before_action :set_investigation
+
   def new
+    @test_certificate_form = SetTestResultCertificateOnCaseForm.new
   end
+
   def create
+    @test_certificate_form = SetTestResultCertificateOnCaseForm.new(test_funding_certificate_params)
+    if @test_certificate_form.valid?
+
+    else
+      render :new
+    end
+  end
+
+private
+
+  def set_investigation
+    investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+    authorize investigation, :update?
+    @investigation = investigation.decorate
+  end
+
+  def test_funding_certificate_params
+    params.require(:set_test_result_certificate_on_case_form).permit(:tso_certificate_reference_number, :tso_certificate_issue_date)
   end
 end

--- a/app/controllers/investigations/test_results/funding_certificate_controller.rb
+++ b/app/controllers/investigations/test_results/funding_certificate_controller.rb
@@ -1,0 +1,6 @@
+class Investigations::TestResults::FundingCertificateController < ApplicationController
+  def new
+  end
+  def create
+  end
+end

--- a/app/controllers/investigations/test_results/funding_source_controller.rb
+++ b/app/controllers/investigations/test_results/funding_source_controller.rb
@@ -24,6 +24,8 @@ private
     investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize investigation, :update?
     @investigation = investigation.decorate
+  rescue ActiveRecord::RecordNotFound
+    render_404_page
   end
 
   def test_funding_request_params

--- a/app/controllers/investigations/test_results/funding_source_controller.rb
+++ b/app/controllers/investigations/test_results/funding_source_controller.rb
@@ -2,7 +2,7 @@ class Investigations::TestResults::FundingSourceController < ApplicationControll
   before_action :set_investigation
 
   def new
-    # @test_funding_form = SetTestResultFundingOnCaseForm.new
+    @test_funding_form = SetTestResultFundingOnCaseForm.new
   end
 
   def create
@@ -12,7 +12,7 @@ class Investigations::TestResults::FundingSourceController < ApplicationControll
         session[:test_opss_funded] = true
 
         # TODO: redirect to the next step in the flow
-        # redirect_to new_investigation_test_result_path(@investigation)
+        redirect_to new_investigation_test_result_path(@investigation)
       else
         redirect_to new_investigation_test_result_path(@investigation)
       end

--- a/app/controllers/investigations/test_results/funding_source_controller.rb
+++ b/app/controllers/investigations/test_results/funding_source_controller.rb
@@ -9,10 +9,7 @@ class Investigations::TestResults::FundingSourceController < ApplicationControll
     @test_funding_form = SetTestResultFundingOnCaseForm.new(test_funding_request_params)
     if @test_funding_form.valid?
       if @test_funding_form.is_opss_funded?
-        session[:test_opss_funded] = true
-
-        # TODO: redirect to the next step in the flow
-        redirect_to new_investigation_test_result_path(@investigation)
+        redirect_to new_investigation_funding_certificate_path(@investigation)
       else
         redirect_to new_investigation_test_result_path(@investigation)
       end

--- a/app/controllers/investigations/test_results/funding_source_controller.rb
+++ b/app/controllers/investigations/test_results/funding_source_controller.rb
@@ -1,0 +1,35 @@
+class Investigations::TestResults::FundingSourceController < ApplicationController
+  before_action :set_investigation
+
+  def new
+    # @test_funding_form = SetTestResultFundingOnCaseForm.new
+  end
+
+  def create
+    @test_funding_form = SetTestResultFundingOnCaseForm.new(test_funding_request_params)
+    if @test_funding_form.valid?
+      if @test_funding_form.is_opss_funded?
+        session[:test_opss_funded] = true
+
+        # TODO: redirect to the next step in the flow
+        # redirect_to new_investigation_test_result_path(@investigation)
+      else
+        redirect_to new_investigation_test_result_path(@investigation)
+      end
+    else
+      render :new
+    end
+  end
+
+private
+
+  def set_investigation
+    investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+    authorize investigation, :update?
+    @investigation = investigation.decorate
+  end
+
+  def test_funding_request_params
+    params.require(:set_test_result_funding_on_case_form).permit(:opss_funded)
+  end
+end

--- a/app/controllers/investigations/test_results_controller.rb
+++ b/app/controllers/investigations/test_results_controller.rb
@@ -7,7 +7,10 @@ class Investigations::TestResultsController < ApplicationController
   end
 
   def create
-    @test_result_form = TestResultForm.new(test_result_params)
+    create_test_result_params = test_result_params
+    create_test_result_params.merge!(session[:test_result_certificate]) if session[:test_result_certificate].present?
+
+    @test_result_form = TestResultForm.new(create_test_result_params)
     @test_result_form.load_document_file
 
     return render :new if @test_result_form.invalid?(:create_with_investigation_product)
@@ -15,9 +18,6 @@ class Investigations::TestResultsController < ApplicationController
     service_attributes = @test_result_form
                            .serializable_hash
                            .merge(investigation: @investigation_object, user: current_user)
-
-    test_result_certificate_atttributes = session[:test_result_certificate]
-    service_attributes.merge!(test_result_certificate_atttributes) if test_result_certificate_atttributes
 
     result = AddTestResultToInvestigation.call(service_attributes)
 

--- a/app/controllers/investigations/test_results_controller.rb
+++ b/app/controllers/investigations/test_results_controller.rb
@@ -16,6 +16,9 @@ class Investigations::TestResultsController < ApplicationController
                            .serializable_hash
                            .merge(investigation: @investigation_object, user: current_user)
 
+    test_result_certificate_atttributes = session[:test_result_certificate]
+    service_attributes.merge!(test_result_certificate_atttributes) if test_result_certificate_atttributes
+
     result = AddTestResultToInvestigation.call(service_attributes)
 
     if result.success?

--- a/app/forms/set_test_result_certificate_on_case_form.rb
+++ b/app/forms/set_test_result_certificate_on_case_form.rb
@@ -12,5 +12,4 @@ class SetTestResultCertificateOnCaseForm
             complete_date: true,
             not_in_future: true,
             recent_date: { on_or_before: false }
-
 end

--- a/app/forms/set_test_result_certificate_on_case_form.rb
+++ b/app/forms/set_test_result_certificate_on_case_form.rb
@@ -1,0 +1,16 @@
+class SetTestResultCertificateOnCaseForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :tso_certificate_reference_number, :string
+  attribute :tso_certificate_issue_date, :govuk_date
+
+  validates :tso_certificate_issue_date,
+            presence: true,
+            real_date: true,
+            complete_date: true,
+            not_in_future: true,
+            recent_date: { on_or_before: false }
+
+end

--- a/app/forms/set_test_result_funding_on_case_form.rb
+++ b/app/forms/set_test_result_funding_on_case_form.rb
@@ -7,6 +7,6 @@ class SetTestResultFundingOnCaseForm
   validates_inclusion_of :opss_funded, in: %w[true false], message: "Select yes if the test was funded under the OPSS Sampling Protocol"
 
   def is_opss_funded?
-    opss_funded
+    opss_funded == "true"
   end
 end

--- a/app/forms/set_test_result_funding_on_case_form.rb
+++ b/app/forms/set_test_result_funding_on_case_form.rb
@@ -1,0 +1,12 @@
+class SetTestResultFundingOnCaseForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :opss_funded
+  validates_inclusion_of :opss_funded, in: %w[true false], message: "Select yes if the test was funded under the OPSS Sampling Protocol"
+
+  def is_opss_funded?
+    opss_funded
+  end
+end

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -21,6 +21,9 @@ class TestResultForm
   attribute :failure_details
   attribute :further_test_results
 
+  attribute :tso_certificate_reference_number, :string
+  attribute :tso_certificate_issue_date, :govuk_date
+
   validates :details, length: { maximum: 50_000 }
   validates :legislation, inclusion: { in: Rails.application.config.legislation_constants["legislation"] }
   validates :standards_product_was_tested_against, presence: true

--- a/app/services/add_test_result_to_investigation.rb
+++ b/app/services/add_test_result_to_investigation.rb
@@ -2,7 +2,9 @@ class AddTestResultToInvestigation
   include Interactor
   include EntitiesToNotify
 
-  delegate :user, :investigation, :document, :date, :details, :legislation, :result, :standards_product_was_tested_against, :investigation_product_id, :failure_details, to: :context
+  delegate :user, :investigation, :document, :date, :details, :legislation, :result,
+    :standards_product_was_tested_against, :investigation_product_id, :failure_details,
+    :tso_certificate_reference_number, :tso_certificate_issue_date, to: :context
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
@@ -16,6 +18,8 @@ class AddTestResultToInvestigation
         result:,
         failure_details:,
         standards_product_was_tested_against:,
+        tso_certificate_reference_number:,
+        tso_certificate_issue_date:,
         investigation_product_id:
       )
 

--- a/app/services/add_test_result_to_investigation.rb
+++ b/app/services/add_test_result_to_investigation.rb
@@ -3,8 +3,8 @@ class AddTestResultToInvestigation
   include EntitiesToNotify
 
   delegate :user, :investigation, :document, :date, :details, :legislation, :result,
-    :standards_product_was_tested_against, :investigation_product_id, :failure_details,
-    :tso_certificate_reference_number, :tso_certificate_issue_date, to: :context
+           :standards_product_was_tested_against, :investigation_product_id, :failure_details,
+           :tso_certificate_reference_number, :tso_certificate_issue_date, to: :context
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)

--- a/app/views/investigations/_actions.html.erb
+++ b/app/views/investigations/_actions.html.erb
@@ -50,7 +50,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Test result&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.test_results.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
       <% if policy(@investigation).update? %>
-        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_test_result_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a test result</span></a></dd>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_funding_source_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a test result</span></a></dd>
       <% end %>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/investigations/test_results/funding_certificate/new.html.erb
+++ b/app/views/investigations/test_results/funding_certificate/new.html.erb
@@ -13,10 +13,6 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-3"><%= page_title %></h1>
       <p class="govuk-body govuk-!-margin-bottom-6 opss-secondary-text">These details will help the <abbr>OPSS</abbr> match funding to individual tests.</p>
 
-<label class="govuk-label" for="sample-name">
-
-        </label>
-
       <%= govukInput(
         key: :tso_certificate_reference_number,
         form: form,

--- a/app/views/investigations/test_results/funding_certificate/new.html.erb
+++ b/app/views/investigations/test_results/funding_certificate/new.html.erb
@@ -1,0 +1,33 @@
+<% page_title = "The test certificate details" %>
+<%= page_title page_title, errors: @test_certificate_form.errors.any? %>
+
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: new_investigation_funding_source_path(@investigation) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @test_certificate_form, url: investigation_funding_certificate_path(investigation_pretty_id: @investigation.pretty_id), builder: ApplicationFormBuilder) do |form| %>
+      <%= error_summary(@test_certificate_form.errors, %i[opss_funded]) %>
+
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3"><%= page_title %></h1>
+      <p class="govuk-body govuk-!-margin-bottom-6 opss-secondary-text">These details will help the <abbr>OPSS</abbr> match funding to individual tests.</p>
+
+<label class="govuk-label" for="sample-name">
+
+        </label>
+
+      <%= govukInput(
+        key: :tso_certificate_reference_number,
+        form: form,
+        classes: "govuk-!-width-one-third",
+        label: { html: "What is the <abbr title='Trading Standards Officer'>TSO</abbr> Sample Reference Number?".html_safe },
+        hint: { html: "The reference number, for a specific product, that was<br>provided to the test lab for product testing.".html_safe, classes: "govuk-!-font-size-16" }
+      ) %>
+
+      <%= form.govuk_date_input :tso_certificate_issue_date, legend: "What date was the test certificate issued?", hint: "For example, 12 7 2019", classes: "govuk-fieldset__legend" %>
+
+      <%= govukButton(text: "Continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/investigations/test_results/funding_source/new.html.erb
+++ b/app/views/investigations/test_results/funding_source/new.html.erb
@@ -1,0 +1,43 @@
+<% page_title = "Was the test funded under the Sampling Protocol?" %>
+<%= page_title page_title, errors: @test_funding_form.errors.any? %>
+
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: investigation_supporting_information_index_path(@investigation) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @test_funding_form, url: investigation_funding_source_path(investigation_pretty_id: @investigation.pretty_id)) do |form| %>
+      <%= error_summary(@test_funding_form.errors, %i[opss_funded]) %>
+
+      <%= form.hidden_field :opss_funded, value: "" %>
+
+      <%= govukRadios(
+        form: form,
+        key: :opss_funded,
+        classes: "",
+        fieldset: {
+          legend: {
+            html: "Was the test funded under the <abbr>OPSS</abbr> Sampling Protocol?".html_safe,
+            is_page_heading: false,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            id: "opss_funded",
+            text: "Yes",
+            value: true
+          },
+          {
+            id: "opss_funded_no",
+            text: "No",
+            value: false
+          }
+        ]
+      ) %>
+
+      <%= govukButton(text: "Continue") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,10 @@ en:
               too_short: The barcode must be between 5 and 15 digits
               only_integer: Enter a valid barcode number
               not_a_number: Enter a valid barcode number
+        set_test_result_certificate_on_case_form:
+          attributes:
+            tso_certificate_issue_date:
+              blank: Enter the date the test certificate was issued
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,8 @@ Rails.application.routes.draw do
 
     resources :test_results, controller: "investigations/test_results", only: %i[new show edit update create], path: "test-results" do
       collection do
+        resource :funding_source, controller: "investigations/test_results/funding_source", only: %i[new create], path: "funding-source"
+
         put :create_draft, path: "confirm"
         get :confirm
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,7 @@ Rails.application.routes.draw do
     resources :test_results, controller: "investigations/test_results", only: %i[new show edit update create], path: "test-results" do
       collection do
         resource :funding_source, controller: "investigations/test_results/funding_source", only: %i[new create], path: "funding-source"
+        resource :funding_certificate, controller: "investigations/test_results/funding_certificate", only: %i[new create], path: "funding-certificate"
 
         put :create_draft, path: "confirm"
         get :confirm

--- a/db/migrate/20230518151137_add_opss_funding_info_fields_to_tests.rb
+++ b/db/migrate/20230518151137_add_opss_funding_info_fields_to_tests.rb
@@ -1,0 +1,10 @@
+class AddOpssFundingInfoFieldsToTests < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :tests, bulk: true do |t|
+        t.string :tso_certificate_reference_number
+        t.date :tso_certificate_issue_date
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_142343) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_18_151137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -445,6 +445,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_142343) do
     t.string "legislation"
     t.string "result"
     t.string "standards_product_was_tested_against", default: [], array: true
+    t.date "tso_certificate_issue_date"
+    t.string "tso_certificate_reference_number"
     t.string "type"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["investigation_id"], name: "index_tests_on_investigation_id"

--- a/spec/factories/correspondences.rb
+++ b/spec/factories/correspondences.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     overview { Faker::Lorem.sentence }
     details { Faker::Lorem.paragraph }
     correspondent_name { Faker::Name.name }
-    email_address { Faker::Internet.safe_email }
+    email_address { Faker::Internet.email }
     email_subject { Faker::Lorem.sentence }
     email_direction { Correspondence::Email.email_directions[:inbound] }
     phone_number { Faker::PhoneNumber.phone_number }

--- a/spec/features/add_new_page_spec.rb
+++ b/spec/features/add_new_page_spec.rb
@@ -74,18 +74,6 @@ RSpec.feature "Adding new data to a case from the add new page", :with_stubbed_o
     end
   end
 
-  context "when user selects `product`" do
-    # TODO: Test linking an existing product when this feature is introduced
-    xit "takes user to the new product page" do
-      within_fieldset("What are you adding to the case?") do
-        choose "Product"
-      end
-
-      click_button "Continue"
-      expect_to_be_on_add_product_to_investigation_page(investigation)
-    end
-  end
-
   context "when user selects `business`" do
     it "takes user to the new business page" do
       within_fieldset("What are you adding to the case?") do

--- a/spec/features/add_new_page_spec.rb
+++ b/spec/features/add_new_page_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Adding new data to a case from the add new page", :with_stubbed_o
       end
 
       click_button "Continue"
-      expect_to_be_on_record_test_result_page
+      expect_to_be_on_record_test_result_opss_funding_decision_page(case_id: investigation.pretty_id)
     end
   end
 

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Case actions", :with_stubbed_opensearch, :with_stubbed_antivirus,
       expect(page).to have_link("Add a corrective action", href: new_investigation_corrective_action_path(investigation_1))
       expect(page).to have_link("Add a risk assessment", href: new_investigation_risk_assessment_path(investigation_1))
       expect(page).to have_link("Add a correspondence", href: new_investigation_correspondence_path(investigation_1))
-      expect(page).to have_link("Add a test result", href: new_investigation_test_result_path(investigation_1))
+      expect(page).to have_link("Add a test result", href: new_investigation_funding_source_path(investigation_1))
       expect(page).to have_link("Add a document or attachment", href: new_investigation_document_path(investigation_1))
       expect(page).to have_link("Add a comment", href: new_investigation_activity_comment_path(investigation_1))
     end

--- a/spec/features/invite_user_spec.rb
+++ b/spec/features/invite_user_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Inviting a user", :with_stubbed_mailer, :with_stubbed_opensearch, :with_errors_rendered, type: :feature do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, team:, has_viewed_introduction: true) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:name) { "Named User" }
 
   context "when the user is not a team admin" do

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
     perform_enqueued_jobs do
       expect(page).to have_css("h1", text: "Reset your password")
-      fill_in "Email address", with: Faker::Internet.safe_email
+      fill_in "Email address", with: Faker::Internet.email
       click_on "Send email"
 
       expect(delivered_emails).to be_empty

--- a/spec/features/record_email_activity_spec.rb
+++ b/spec/features/record_email_activity_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Adding a record email activity to a case", :with_stubbed_opensear
   let(:investigation) { create(:allegation, creator: user) }
 
   let(:name) { "Test name" }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:date) { Date.parse("2020-02-01") }
 
   let(:file) { Rails.root.join("test/fixtures/files/email_file.txt") }

--- a/spec/features/redirect_after_2fa_spec.rb
+++ b/spec/features/redirect_after_2fa_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Redirecting after 2fa", :with_stubbed_mailer, :with_stubbed_notify, :with_stubbed_opensearch do
   let(:team) { create(:team) }
   let(:admin) { create(:user, :team_admin, has_accepted_declaration: true, has_viewed_introduction: true, team:) }
-  let(:invitee_email) { Faker::Internet.safe_email }
+  let(:invitee_email) { Faker::Internet.email }
 
   before do
     set_whitelisting_enabled(false)

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify do
   let(:team) { create(:team) }
   let(:admin) { create(:user, :team_admin, has_accepted_declaration: true, has_viewed_introduction: true, team:) }
-  let(:invitee_email) { Faker::Internet.safe_email }
+  let(:invitee_email) { Faker::Internet.email }
   let(:name) { "Bill Smith" }
 
   before do

--- a/spec/features/remove_a_user_spec.rb
+++ b/spec/features/remove_a_user_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Removing a user", :with_stubbed_mailer, :with_stubbed_opensearch, :with_errors_rendered, type: :feature do
   let(:team) { create(:team) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let!(:other_user) { create(:user, :activated, team:, has_viewed_introduction: true) }
 
   context "when the user is a team admin" do

--- a/spec/forms/set_test_result_certificate_on_case_form_spec.rb
+++ b/spec/forms/set_test_result_certificate_on_case_form_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe SetTestResultCertificateOnCaseForm, type: :model do
+  subject(:form) { described_class.new(params) }
+
+  let(:tso_certificate_reference_number) { "abc123" }
+  let(:tso_certificate_issue_date) do
+    { day: "1", month: "2", year: "2020" }
+  end
+  let(:params) do
+    {
+      tso_certificate_reference_number:,
+      tso_certificate_issue_date:
+    }
+  end
+
+  describe "validations" do
+    it "is valid with a valid setup" do
+      expect(form).to be_valid
+    end
+
+    context "when tso_certificate_reference_number is missing" do
+      let(:tso_certificate_reference_number) { nil }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    it_behaves_like "it does not allow far away dates", :tso_certificate_issue_date, nil, on_or_before: false
+
+    context "when tso_certificate_issue_date is missing" do
+      let(:tso_certificate_issue_date) { { day: '', month: '', year: ''} }
+
+      it "is invalid with an invalid type" do
+        expect(form).not_to be_valid
+        expect(form.errors[:tso_certificate_issue_date]).to include("Enter the date the test certificate was issued")
+      end
+    end
+  end
+end

--- a/spec/forms/set_test_result_certificate_on_case_form_spec.rb
+++ b/spec/forms/set_test_result_certificate_on_case_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SetTestResultCertificateOnCaseForm, type: :model do
     it_behaves_like "it does not allow far away dates", :tso_certificate_issue_date, nil, on_or_before: false
 
     context "when tso_certificate_issue_date is missing" do
-      let(:tso_certificate_issue_date) { { day: '', month: '', year: ''} }
+      let(:tso_certificate_issue_date) { { day: "", month: "", year: "" } }
 
       it "is invalid with an invalid type" do
         expect(form).not_to be_valid

--- a/spec/forms/set_test_result_funding_on_case_form_spec.rb
+++ b/spec/forms/set_test_result_funding_on_case_form_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe SetTestResultFundingOnCaseForm, type: :model do
+  subject(:form) { described_class.new(params) }
+
+  let(:opss_funded) { "true" }
+  let(:params) do
+    {
+      opss_funded:
+    }
+  end
+
+  describe "validations" do
+    it "is valid with a valid type" do
+      expect(form).to be_valid
+    end
+
+    context "when opss_funded is missing" do
+      let(:opss_funded) { nil }
+
+      it "is invalid with an invalid type" do
+        expect(form).not_to be_valid
+        expect(form.errors[:opss_funded]).to include("Select yes if the test was funded under the OPSS Sampling Protocol")
+      end
+    end
+
+    context "when opss_funded is not in the list" do
+      let(:opss_funded) { "invalid" }
+
+      it "is invalid with an invalid type" do
+        expect(form).not_to be_valid
+        expect(form.errors[:opss_funded]).to include("Select yes if the test was funded under the OPSS Sampling Protocol")
+      end
+    end
+  end
+end

--- a/spec/requests/add_supporting_information_spec.rb
+++ b/spec/requests/add_supporting_information_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Adding supporting information to a case", type: :request, with_s
       let(:type) { "testing_result" }
 
       it "redirects to new test result page" do
-        expect(response).to redirect_to(new_investigation_test_result_path(investigation))
+        expect(response).to redirect_to(new_investigation_funding_source_path(investigation))
       end
     end
   end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Inviting users to your team", :with_stubbed_mailer, :with_stubbe
 
   describe "#create" do
     let(:params) { { invite_user_to_team_form: { email: } } }
-    let(:email) { Faker::Internet.safe_email }
+    let(:email) { Faker::Internet.email }
     let(:form_errors_double) { instance_double(ActiveModel::Errors).as_null_object }
 
     it "requires secondary authentication", :with_2fa do

--- a/spec/services/add_test_result_to_investigation_spec.rb
+++ b/spec/services/add_test_result_to_investigation_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe AddTestResultToInvestigation, :with_stubbed_opensearch, :with_stu
   let(:test_result)                          { Test::Result.results[:passed] }
   let(:standards_product_was_tested_against) { %w[EN71] }
   let(:investigation_product_id)             { create(:investigation_product).id }
+  let(:tso_certificate_reference_number)     { Faker::Number.number(digits: 10).to_s }
+  let(:tso_certificate_issue_date)           { Date.current }
+
   let(:params) do
     {
       investigation:,
@@ -22,7 +25,9 @@ RSpec.describe AddTestResultToInvestigation, :with_stubbed_opensearch, :with_stu
       legislation:,
       result: test_result,
       standards_product_was_tested_against:,
-      investigation_product_id:
+      investigation_product_id:,
+      tso_certificate_reference_number:,
+      tso_certificate_issue_date:
     }
   end
 
@@ -43,6 +48,7 @@ RSpec.describe AddTestResultToInvestigation, :with_stubbed_opensearch, :with_stu
       expect(command.test_result).to have_attributes(
         date:, details:, legislation:, result: "passed", investigation_product_id:,
         standards_product_was_tested_against:,
+        tso_certificate_reference_number:, tso_certificate_issue_date:,
         document_blob: document
       )
     end

--- a/spec/services/create_organisation_with_team_and_admin_user_spec.rb
+++ b/spec/services/create_organisation_with_team_and_admin_user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CreateOrganisationWithTeamAndAdminUser, :with_stubbed_mailer do
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:org_name) { Faker::Team.name }
 
   describe ".call" do

--- a/spec/services/invite_user_to_team_spec.rb
+++ b/spec/services/invite_user_to_team_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_opensearch,
   describe ".call" do
     subject(:result) { described_class.call(params) }
 
-    let(:email) { Faker::Internet.safe_email }
+    let(:email) { Faker::Internet.email }
     let(:team) { create(:team) }
     let(:inviting_user) { create(:user, :activated, team:) }
 

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -278,6 +278,14 @@ module PageExpectations
     expect(page).to have_css(".govuk-label--l", text: "Why is the case being #{future_status}?")
   end
 
+  def expect_to_be_on_record_test_result_opss_funding_decision_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/test-results/funding-source/new")
+  end
+
+  def expect_to_be_on_record_test_result_opss_funding_form_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/test-results/funding-certificate/new")
+  end
+
   def expect_to_be_on_record_test_result_page
     expect_page_to_have_h1("Record test result")
     expect(page).to have_field("Which standard was the product tested against?")

--- a/spec/support/shared_contexts/entities_to_notify.rb
+++ b/spec/support/shared_contexts/entities_to_notify.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples "a service which notifies teams with access" do
-  let(:team_with_edit_access_email)     { Faker::Internet.unique.safe_email }
-  let(:team_with_readonly_access_email) { Faker::Internet.unique.safe_email }
+  let(:team_with_edit_access_email)     { Faker::Internet.unique.email }
+  let(:team_with_readonly_access_email) { Faker::Internet.unique.email }
   let(:team_with_edit_access)           { create(:team, team_recipient_email: team_with_edit_access_email) }
   let(:team_with_readonly_access)       { create(:team, team_recipient_email: team_with_readonly_access_email) }
   let(:user_with_edit_access)           { create(:user, :activated, team: team_with_readonly_access) }

--- a/spec/support/shared_contexts/phone_call_correspondence.rb
+++ b/spec/support/shared_contexts/phone_call_correspondence.rb
@@ -1,7 +1,7 @@
 RSpec.shared_context "with phone call correspondence setup" do
   include ActionDispatch::TestProcess::FixtureFile
 
-  let(:team_recipient_email) { Faker::Internet.safe_email }
+  let(:team_recipient_email) { Faker::Internet.email }
   let(:team)                 { create :team, team_recipient_email: }
   let(:user)                 { create :user, :activated, team: }
   let(:investigation)        { create :allegation, creator: user || create(:user) }


### PR DESCRIPTION
Create OPSS funded test reports 

https://regulatorydelivery.atlassian.net/browse/PSD-1573

- Adds a form asking the user if the test report was funded by OPSS
- If no, they go to the normal test report form page as it is now
- If yes, they are asked more info about the test certificate, and when it was issued. This is then captured and stored on the test report.
