### PR TITLE
Show if tests are funded by OPSS (PSD-1576)

### DIFF
--- a/app/decorators/test/result_decorator.rb
+++ b/app/decorators/test/result_decorator.rb
@@ -23,6 +23,14 @@ class Test < ApplicationRecord
       end
     end
 
+    def product_tested
+      "#{investigation_product.name} (#{investigation_product.psd_ref})"
+    end
+
+    def attachment_description
+      document.blob.metadata["description"]
+    end
+
     def supporting_information_title
       title
     end

--- a/app/decorators/test/result_decorator.rb
+++ b/app/decorators/test/result_decorator.rb
@@ -87,5 +87,13 @@ class Test < ApplicationRecord
     def psd_ref
       object.investigation_product.psd_ref
     end
+
+    def opss_funded?
+      object.tso_certificate_issue_date.present?
+    end
+
+    def funding_issue_date
+      object.tso_certificate_issue_date.to_formatted_s(:govuk)
+    end
   end
 end

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -14,6 +14,27 @@ module TestsHelper
         value: { text: test_result.legislation }
       }
     ]
+
+    if test_result.tso_certificate_issue_date.present?
+      rows << {
+        key: { text: "Funded" },
+        value: { html: I18n.t("test_results.opss_funded.yes_html").html_safe }
+      }
+      rows << {
+        key: { text: "Sample number" },
+        value: { text: test_result.tso_certificate_reference_number }
+      }
+      rows << {
+        key: { text: "Issue date" },
+        value: { text: test_result.tso_certificate_reference_number }
+      }
+    else
+      rows << {
+        key: { text: "Funded" },
+        value: { text: "No" }
+      }
+    end
+
     if test_result.standards_product_was_tested_against.present?
       rows << {
         key: { text: "Standards" },

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -26,7 +26,7 @@ module TestsHelper
       }
       rows << {
         key: { text: "Issue date" },
-        value: { text: test_result.tso_certificate_reference_number }
+        value: { text: test_result.funding_issue_date }
       }
     else
       rows << {

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -3,11 +3,11 @@ module TestsHelper
     rows = [
       {
         key: { text: "Date of test" },
-        value: { text: test_result.date.to_formatted_s(:govuk) }
+        value: { text: test_result.date_of_activity }
       },
       {
         key: { text: "Product tested" },
-        value: { text: "#{test_result.investigation_product.name} (#{test_result.investigation_product.psd_ref})" }
+        value: { text: test_result.product_tested }
       },
       {
         key: { text: "Legislation" },
@@ -23,7 +23,7 @@ module TestsHelper
 
     rows << {
       key: { text: "Result" },
-      value: { text: test_result.decorate.event_type }
+      value: { text: test_result.event_type }
     }
 
     if test_result.result == "failed"
@@ -40,11 +40,10 @@ module TestsHelper
       }
     end
 
-    attachment_description = test_result.document.blob.metadata["description"]
-    if attachment_description.present?
+    if test_result.attachment_description.present?
       rows << {
         key: { text: "Attachment description" },
-        value: { text: attachment_description }
+        value: { text: test_result.attachment_description }
       }
     end
 

--- a/app/models/audit_activity/test/result.rb
+++ b/app/models/audit_activity/test/result.rb
@@ -43,6 +43,19 @@ class AuditActivity::Test::Result < AuditActivity::Test::Base
   def details
     metadata.dig("test_result", "details")
   end
+
+  def funded
+    metadata.dig("test_result", "tso_certificate_issue_date").present?
+  end
+
+  def funding_issue_date
+    return if metadata.dig("test_result", "tso_certificate_issue_date").nil?
+
+    Date.parse(metadata.dig("test_result", "tso_certificate_issue_date")).to_formatted_s(:govuk)
+  end
+
+  def tso_certificate_reference_number
+    metadata.dig("test_result", "tso_certificate_reference_number")
   end
 
   def date

--- a/app/models/audit_activity/test/result.rb
+++ b/app/models/audit_activity/test/result.rb
@@ -21,33 +21,34 @@ class AuditActivity::Test::Result < AuditActivity::Test::Base
   end
 
   def attached_file_name
-    metadata["test_result"]["document"]["filename"]
+    metadata.dig("test_result", "document", "filename")
   end
 
   def legislation
-    metadata["test_result"]["legislation"]
+    metadata.dig("test_result", "legislation")
   end
 
   def standards_product_was_tested_against
-    metadata["test_result"]["standards_product_was_tested_against"]
+    metadata.dig("test_result", "standards_product_was_tested_against")
   end
 
   def result
-    metadata["test_result"]["result"]
+    metadata.dig("test_result", "result")
   end
 
   def failure_details
-    metadata["test_result"]["failure_details"]
+    metadata.dig("test_result", "failure_details")
   end
 
   def details
-    metadata["test_result"]["details"]
+    metadata.dig("test_result", "details")
+  end
   end
 
   def date
-    return if metadata["test_result"]["date"].nil?
+    return if metadata.dig("test_result", "date").nil?
 
-    Date.parse(metadata["test_result"]["date"])
+    Date.parse(metadata.dig("test_result", "date"))
   end
 
 private

--- a/app/views/investigations/activities/test/_result.html.erb
+++ b/app/views/investigations/activities/test/_result.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-body">
-  Product: <%= activity.investigation_product.name %>
+  Product: <strong><%= activity.investigation_product.name %></strong>
   <br />
   Legislation: <strong><%= activity.legislation %></strong>
   <br />

--- a/app/views/investigations/activities/test/_result.html.erb
+++ b/app/views/investigations/activities/test/_result.html.erb
@@ -21,6 +21,16 @@
     Further details: <strong><%= activity.details %></strong>
   <% end %>
   <br />
+  <% if activity.funded %>
+    Funded: <strong>Yes</strong>
+    <br />
+    Issue date: <strong><%= activity.funding_issue_date %></strong>
+    <br />
+    Sample number: <strong><%= activity.tso_certificate_reference_number %></strong>
+  <% else %>
+    Funded: <strong>No</strong>
+  <% end %>
+  <br />
   <br />
   <%= link_to "View test result", investigation_test_result_path(activity.investigation, activity.test_result), class: "govuk-link govuk-link--no-visited-state" %>
 </div>

--- a/app/views/investigations/tabs/_supporting_information.html.erb
+++ b/app/views/investigations/tabs/_supporting_information.html.erb
@@ -70,6 +70,28 @@
               <dt class="govuk-summary-list__key">Added</dt>
               <dd class="govuk-summary-list__value"><%= item.date_added %></dd>
             </div>
+
+            <% if supporting_information_type_id == "test-results" %>
+              <% if item.opss_funded? %>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Funded</dt>
+                  <dd class="govuk-summary-list__value"><%= t("test_results.opss_funded.yes_html") %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Sample number</dt>
+                  <dd class="govuk-summary-list__value"><%= item.tso_certificate_reference_number %></dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Issue date</dt>
+                  <dd class="govuk-summary-list__value"><%= item.funding_issue_date %></dd>
+                </div>
+              <% else %>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Funded</dt>
+                  <dd class="govuk-summary-list__value">No</dd>
+                </div>
+              <% end %>
+            <% end %>
           </dl>
         </li>
       <% end %>

--- a/app/views/investigations/test_results/funding_certificate/new.html.erb
+++ b/app/views/investigations/test_results/funding_certificate/new.html.erb
@@ -21,7 +21,7 @@
         hint: { html: "The reference number, for a specific product, that was<br>provided to the test lab for product testing.".html_safe, classes: "govuk-!-font-size-16" }
       ) %>
 
-      <%= form.govuk_date_input :tso_certificate_issue_date, legend: "What date was the test certificate issued?", hint: "For example, 12 7 2019", classes: "govuk-fieldset__legend" %>
+      <%= form.govuk_date_input :tso_certificate_issue_date, legend: "What date was the test certificate issued?", hint: "For example, 12 5 2023", classes: "govuk-fieldset__legend govuk-!-font-size-16" %>
 
       <%= govukButton(text: "Continue") %>
     <% end %>

--- a/app/views/investigations/test_results/show.html.erb
+++ b/app/views/investigations/test_results/show.html.erb
@@ -17,9 +17,7 @@
     <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
     <div class="app-meta-area">
-      <p class="govuk-body govuk-hint">
-        Added <%= @test_result.created_at.to_formatted_s(:govuk) %>
-      </p>
+      <p class="govuk-body govuk-hint">Added <%= @test_result.date_added %></p>
     </div>
 
     <%= govukSummaryList(rows: test_result_summary_rows(@test_result)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,6 +382,11 @@ en:
     filters:
       coronavirus_cases_only: "Coronavirus cases only"
       serious_and_high_risk_level_only: "Serious and high risk cases only"
+  test_results:
+    opss_funded:
+      yes_html: "Yes <span class='govuk-!-font-size-16 govuk-!-padding-left-2 opss-secondary-text'>Funded under the <abbr>OPSS</abbr> Sampling Protocol</span>"
+      no: "No"
+
   errors:
     format: "%{message}"
     messages:

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
       click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect_activity_page_to_show_created_test_result_values(result: "Passed")
+      expect_activity_page_to_show_created_unfunded_test_result_values(result: "Passed")
 
       click_link "View test result"
 
@@ -107,7 +107,7 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
       click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect_activity_page_to_show_created_test_result_values(result: "Passed")
+      expect_activity_page_to_show_created_funded_test_result_values(result: "Passed", funded_date: date)
 
       click_link "View test result"
 
@@ -167,7 +167,7 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
       click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect_activity_page_to_show_created_test_result_values(result: "Failed")
+      expect_activity_page_to_show_created_unfunded_test_result_values(result: "Failed")
 
       click_link "View test result"
 
@@ -261,7 +261,7 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
     expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
   end
 
-  def expect_activity_page_to_show_created_test_result_values(result:)
+  def expect_activity_page_to_show_created_unfunded_test_result_values(result:)
     expect(page).to have_text("#{result} test: MyBrand washing machine")
     expect(page).to have_text(product.name)
     expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
@@ -269,6 +269,21 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
     expect(page).to have_text("Date of test: 1 January 2020")
     expect(page).to have_text("Further details: Test result includes certificate of conformity")
     expect(page).to have_text("File description: test result file")
+    expect(page).to have_text("Funded: No")
+    expect(page).to have_text("Test result includes certificate of conformity")
+    expect(page).to have_link("test_result.txt")
+  end
+
+  def expect_activity_page_to_show_created_funded_test_result_values(result:, funded_date:)
+    expect(page).to have_text("#{result} test: MyBrand washing machine")
+    expect(page).to have_text(product.name)
+    expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
+    expect(page).to have_text("Standards: EN71, EN73")
+    expect(page).to have_text("Date of test: 1 January 2020")
+    expect(page).to have_text("Further details: Test result includes certificate of conformity")
+    expect(page).to have_text("File description: test result file")
+    expect(page).to have_text("Funded: Yes")
+    expect(page).to have_text("Issue date: #{funded_date.to_formatted_s(:govuk)}")
     expect(page).to have_text("Test result includes certificate of conformity")
     expect(page).to have_link("test_result.txt")
   end

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
 
       expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
 
-      expect_summary_to_reflect_values(result: "Pass")
+      expect_summary_to_reflect_values(result: "Pass", funded: true)
 
       expect(page).to have_text("test_result.txt")
 
@@ -252,11 +252,16 @@ RSpec.feature "Adding a test result", :with_stubbed_opensearch, :with_stubbed_an
     expect(errors_list[4].text).to eq "Provide the test results file"
   end
 
-  def expect_summary_to_reflect_values(result:)
+  def expect_summary_to_reflect_values(result:, funded: false)
     expect(page).to have_summary_item(key: "Date of test", value: "1 January 2020")
     expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
     expect(page).to have_summary_item(key: "Standards", value: "EN71, EN73")
     expect(page).to have_summary_item(key: "Result", value: result)
+    if funded
+      expect(page).to have_summary_item(key: "Funded", value: "Yes Funded under the OPSS Sampling Protocol")
+    else
+      expect(page).to have_summary_item(key: "Funded", value: "No")
+    end
     expect(page).to have_summary_item(key: "Further details", value: "Test result includes certificate of conformity")
     expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
   end


### PR DESCRIPTION

## Description

Adds the funding information for test results

https://regulatorydelivery.atlassian.net/browse/PSD-1576

### To the test result details page

<img width="707" alt="CleanShot 2023-05-26 at 11 24 56@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/c7db7c00-84c6-48a8-aeb3-c161aed13249">
<img width="815" alt="CleanShot 2023-05-26 at 11 20 07@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/83ee1a4a-ed9e-4db4-b7d6-3435e9b22394">

### To the activity log

<img width="720" alt="CleanShot 2023-05-26 at 11 20 34@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/60974019-d955-4975-b816-132e7a04b969">
<img width="733" alt="CleanShot 2023-05-26 at 11 20 29@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/cd308972-1bf3-4a92-a146-779fa665e0b7">

### To the supporting information case summary 

<img width="756" alt="CleanShot 2023-05-26 at 11 20 01@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/827d18c7-50e5-4d38-a3a2-1366fcfc1881">
<img width="759" alt="CleanShot 2023-05-26 at 11 19 54@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/a1cd5ecb-7cb0-4849-8a59-4e8397c6b563">

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
