### PR TITLE
update edit test result page

### DIFF
--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -45,7 +45,7 @@ class TestResultForm
   end
 
   ATTRIBUTES_FROM_TEST_RESULT = %i[
-    id date details legislation result failure_details standards_product_was_tested_against investigation_product_id
+    id date details legislation result failure_details standards_product_was_tested_against investigation_product_id tso_certificate_reference_number tso_certificate_issue_date
   ].freeze
 
   def self.from(test_result)

--- a/app/views/investigations/test_results/edit.html.erb
+++ b/app/views/investigations/test_results/edit.html.erb
@@ -15,6 +15,14 @@ investigation_test_result_path(@investigation, @test_result_form.id) %>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_title %></h1>
 
+      <% unless @test_result_form.tso_certificate_issue_date.nil? %>
+        <p class="govuk-body govuk-!-margin-bottom-9">
+          <%= sanitize(t(".result_date", date: date_or_recent_time_ago(@test_result_form.tso_certificate_issue_date))) %>
+          <%= sanitize(t(".result_certificate_reference", reference_number: @test_result_form.tso_certificate_reference_number)) unless @test_result_form.tso_certificate_reference_number.blank? %>
+          <%= sanitize(t(".result_certificate_no_reference")) if @test_result_form.tso_certificate_reference_number.blank? %>
+        </p>
+      <% end %>
+
       <%= render "investigations/test_results/form", form: form, test_result_form: @test_result_form, investigation: @investigation, allow_product_linking: true %>
 
       <%= govukButton text: "Update test result" %>

--- a/app/views/investigations/test_results/edit.html.erb
+++ b/app/views/investigations/test_results/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Edit test result" %>
+<% page_title = "Record test result" %>
 <%= page_title page_title, errors: @test_result_form.errors.any? %>
 
 <% content_for :after_header do %>
@@ -12,7 +12,6 @@ investigation_test_result_path(@investigation, @test_result_form.id) %>
 
       <%= error_summary(@test_result_form.errors, %i[legislation standards_product_was_tested_against date result base])%>
 
-      <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_title %></h1>
 
       <% unless @test_result_form.tso_certificate_issue_date.nil? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,7 +335,7 @@ en:
     test_results:
       edit:
         result_date: This test was funded under the <abbr>OPSS</abbr> Sampling Protocol and was issued on %{date}.
-        result_certificate_reference: "(TSO Sample Reference Number: %{reference_number})."
+        result_certificate_reference: "(<abbr>TSO</abbr> Sample Reference Number: %{reference_number})."
         result_certificate_no_reference: (No <abbr>TSO</abbr> Sample Reference Number was recorded).
     ts_investigations:
       coronavirus:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,6 +332,11 @@ en:
         title: "Unrestrict this case"
         label: "Why is the case being unrestricted?"
         action: "Unrestrict this case"
+    test_results:
+      edit:
+        result_date: This test was funded under the <abbr>OPSS</abbr> Sampling Protocol and was issued on %{date}.
+        result_certificate_reference: "(TSO Sample Reference Number: %{reference_number})."
+        result_certificate_no_reference: (No <abbr>TSO</abbr> Sample Reference Number was recorded).
     ts_investigations:
       coronavirus:
         caption: "Report an unsafe or non-compliant product"


### PR DESCRIPTION
Change edit page for test results on cases

## Screen-shots or screen-capture of UI changes


![Screenshot 2023-05-30 at 09-57-27 Record test result - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/ae2816f0-4b40-474d-92b5-4df3edd5bca9)

## Checklist:
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
