### PR TITLE
Revert "Bump pg from 1.4.6 to 1.5.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "net-pop"
 gem "net-smtp"
 
 gem "paper_trail"
-gem "pg", "~> 1.5"
+gem "pg", "~> 1.4"
 gem "pghero", "~> 3.3"
 gem "puma", "~> 6.2"
 gem "pundit", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,7 +690,7 @@ DEPENDENCIES
   net-smtp
   paper_trail
   parallel_tests (~> 4.2.0)
-  pg (~> 1.5)
+  pg (~> 1.4)
   pghero (~> 3.3)
   prism!
   pry (~> 0.14)


### PR DESCRIPTION
This PR updating postgres pg gem might be breaking the production redacted export 

Reverts OfficeForProductSafetyAndStandards/product-safety-database#2393
