### PR TITLE
Fix business form regression

### DIFF
--- a/app/controllers/investigations/businesses_controller.rb
+++ b/app/controllers/investigations/businesses_controller.rb
@@ -18,8 +18,6 @@ class Investigations::BusinessesController < ApplicationController
 
   def new
     @business_form = AddBusinessToCaseForm.new(current_user:)
-    @business_form.locations = [Location.new]
-    @business_form.contacts = [Contact.new]
   end
 
   def create

--- a/app/forms/add_business_to_case_form.rb
+++ b/app/forms/add_business_to_case_form.rb
@@ -18,6 +18,12 @@ class AddBusinessToCaseForm
 
   validates :current_user, :trading_name, presence: true
 
+  def initialize(*args)
+    super
+    self.locations = [Location.new] if locations.empty?
+    self.contacts = [Contact.new] if contacts.empty?
+  end
+
   def business_object
     object = Business.new(
       legal_name:,

--- a/spec/rake/redacted_export_rake_task_spec.rb
+++ b/spec/rake/redacted_export_rake_task_spec.rb
@@ -1,0 +1,21 @@
+# rubocop:disable RSpec/DescribeClass
+require "rails_helper"
+Rails.application.load_tasks
+
+describe "redacted_export:generate_sql" do
+  it "generates the SQL" do
+    output = run_rake_and_capture_output("redacted_export:generate_sql")
+    expect(output).to include("Redacted export generation SQL complete")
+  end
+end
+
+def run_rake_and_capture_output(task_name)
+  stdout = StringIO.new
+  $stdout = stdout
+  Rake::Task[task_name].invoke
+  $stdout = STDOUT
+  Rake.application[task_name].reenable
+  stdout.string
+end
+
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1681

The fix to redacted export was broken due to `Location` and `Business` being instantiated at class level, breaking the eager load of the Rails app. The fix however meant that on the new business form, if a user submits with nothing filled in, they are then presented with a form without Contact and Address fieldsets (as they are now blank on the object)

Moving them to the form here means the attributes always built, and the form works as it should

I've also here added a rake task spec to run the redacted export rake, to make sure we don't break eager loading again in the same way