### PR TITLE
Add case_id to supporting info in product export

### DIFF
--- a/app/decorators/corrective_action_decorator.rb
+++ b/app/decorators/corrective_action_decorator.rb
@@ -65,4 +65,8 @@ class CorrectiveActionDecorator < ApplicationDecorator
   def psd_ref
     object.investigation_product.psd_ref
   end
+
+  def case_id
+    object.investigation.pretty_id
+  end
 end

--- a/app/decorators/risk_assessment_decorator.rb
+++ b/app/decorators/risk_assessment_decorator.rb
@@ -53,6 +53,10 @@ class RiskAssessmentDecorator < ApplicationDecorator
     h.safe_join(values, h.tag.br)
   end
 
+  def case_id
+    object.investigation.pretty_id
+  end
+
 private
 
   def products_description

--- a/app/decorators/test/result_decorator.rb
+++ b/app/decorators/test/result_decorator.rb
@@ -95,5 +95,9 @@ class Test < ApplicationRecord
     def funding_issue_date
       object.tso_certificate_issue_date.to_formatted_s(:govuk)
     end
+
+    def case_id
+      object.investigation.pretty_id
+    end
   end
 end

--- a/app/models/product_export.rb
+++ b/app/models/product_export.rb
@@ -101,7 +101,7 @@ private
     return @test_results_sheet if @test_results_sheet
 
     sheet = package.workbook.add_worksheet name: "test_results"
-    sheet.add_row %w[psd_ref product_id legislation standards date_of_test result how_product_failed further_details product_name]
+    sheet.add_row %w[psd_ref product_id legislation standards date_of_test result how_product_failed further_details product_name case_id]
 
     @test_results_sheet = sheet
   end
@@ -110,7 +110,7 @@ private
     return @risk_assessments_sheet if @risk_assessments_sheet
 
     sheet = package.workbook.add_worksheet name: "risk_assessments"
-    sheet.add_row %w[psd_ref product_id date_of_assessment risk_level assessed_by further_details product_name]
+    sheet.add_row %w[psd_ref product_id date_of_assessment risk_level assessed_by further_details product_name case_id]
 
     @risk_assessments_sheet = sheet
   end
@@ -130,7 +130,8 @@ private
                      how_long
                      geographic_scope
                      further_details
-                     product_name]
+                     product_name
+                     case_id]
 
     @corrective_actions_sheet = sheet
   end
@@ -169,7 +170,8 @@ private
       test_result.result,
       test_result.failure_details,
       test_result.details,
-      product.name
+      product.name,
+      test_result.case_id
     ]
   end
 
@@ -181,7 +183,8 @@ private
       risk_assessment.risk_level,
       risk_assessment.decorate.assessed_by,
       risk_assessment.details,
-      product.name
+      product.name,
+      risk_assessment.case_id
     ]
   end
 
@@ -198,7 +201,8 @@ private
       corrective_action.duration,
       corrective_action.geographic_scopes,
       corrective_action.details,
-      product.name
+      product.name,
+      corrective_action.case_id
     ]
   end
 

--- a/spec/decorators/corrective_action_decorator_spec.rb
+++ b/spec/decorators/corrective_action_decorator_spec.rb
@@ -25,4 +25,10 @@ RSpec.describe CorrectiveActionDecorator, :with_stubbed_opensearch, :with_stubbe
       expect(decorated_corrective_action.date_of_activity_for_sorting).to eq(corrective_action.date_decided)
     end
   end
+
+  describe "#case_id" do
+    it "returns the investigation pretty id" do
+      expect(decorated_corrective_action.case_id).to eq(corrective_action.investigation.pretty_id)
+    end
+  end
 end

--- a/spec/decorators/risk_assessment_decorator_spec.rb
+++ b/spec/decorators/risk_assessment_decorator_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe RiskAssessmentDecorator, :with_stubbed_opensearch do
+  subject(:decorated_risk_assessment) { risk_assessment.decorate }
+
+  let(:risk_assessment) { build(:risk_assessment) }
+
+  describe "#case_id" do
+    it "returns the investigation pretty id" do
+      expect(decorated_risk_assessment.case_id).to eq(risk_assessment.investigation.pretty_id)
+    end
+  end
+end

--- a/spec/decorators/test/result_decorator_spec.rb
+++ b/spec/decorators/test/result_decorator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Test::ResultDecorator, :with_stubbed_opensearch, :with_stubbed_mailer do
   subject(:decorated_corrective_action) { test_result.decorate }
 
-let(:test_result) { build(:test_result) }
+  let(:test_result) { build(:test_result) }
 
   describe "#title" do
     context "when the test result has passed" do

--- a/spec/decorators/test/result_decorator_spec.rb
+++ b/spec/decorators/test/result_decorator_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Test::ResultDecorator, :with_stubbed_opensearch, :with_stubbed_mailer do
+  subject(:decorated_corrective_action) { test_result.decorate }
+
+let(:test_result) { build(:test_result) }
+
+  describe "#title" do
+    context "when the test result has passed" do
+      before { test_result.result = "passed" }
+
+      it "returns 'Passed test: <product name>'" do
+        expect(decorated_corrective_action.title).to eq("Passed test: #{test_result.investigation_product.name}")
+      end
+    end
+
+    context "when the test result has failed" do
+      before { test_result.result = "failed" }
+
+      it "returns 'Failed test: <product name>'" do
+        expect(decorated_corrective_action.title).to eq("Failed test: #{test_result.investigation_product.name}")
+      end
+    end
+
+    context "when the test result has not passed or failed" do
+      before { test_result.result = "other" }
+
+      it "returns 'Test result: <product name>'" do
+        expect(decorated_corrective_action.title).to eq("Test result: #{test_result.investigation_product.name}")
+      end
+    end
+  end
+
+  describe "#case_id" do
+    it "returns the investigation pretty id" do
+      expect(decorated_corrective_action.case_id).to eq(test_result.investigation.pretty_id)
+    end
+  end
+end

--- a/spec/models/product_export_spec.rb
+++ b/spec/models/product_export_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ProductExport, :with_opensearch, :with_stubbed_notify, :with_stub
     let(:risk_assessments_sheet) { exported_data.sheet("risk_assessments") }
     let(:corrective_actions_sheet) { exported_data.sheet("corrective_actions") }
 
-    it "exports product data" do
+    it "exports product data", :aggregate_failures do
       expect(product_sheet.cell(1, 1)).to eq "psd_ref"
       expect(product_sheet.cell(2, 1)).to eq product.psd_ref
       expect(product_sheet.cell(3, 1)).to eq other_product.psd_ref
@@ -151,6 +151,10 @@ RSpec.describe ProductExport, :with_opensearch, :with_stubbed_notify, :with_stub
       expect(test_result_sheet.cell(2, 9)).to eq product.name
       expect(test_result_sheet.cell(3, 9)).to eq product.name
 
+      expect(test_result_sheet.cell(1, 10)).to eq "case_id"
+      expect(test_result_sheet.cell(2, 10)).to eq test.investigation.pretty_id
+      expect(test_result_sheet.cell(3, 10)).to eq test_2.investigation.pretty_id
+
       expect(risk_assessments_sheet.cell(1, 1)).to eq "psd_ref"
       expect(risk_assessments_sheet.cell(2, 1)).to eq product.psd_ref
       expect(risk_assessments_sheet.cell(3, 1)).to eq product.psd_ref
@@ -178,6 +182,10 @@ RSpec.describe ProductExport, :with_opensearch, :with_stubbed_notify, :with_stub
       expect(risk_assessments_sheet.cell(1, 7)).to eq "product_name"
       expect(risk_assessments_sheet.cell(2, 7)).to eq product.name
       expect(risk_assessments_sheet.cell(3, 7)).to eq product.name
+
+      expect(risk_assessments_sheet.cell(1, 8)).to eq "case_id"
+      expect(risk_assessments_sheet.cell(2, 8)).to eq risk_assessment.investigation.pretty_id
+      expect(risk_assessments_sheet.cell(3, 8)).to eq risk_assessment_2.investigation.pretty_id
 
       expect(corrective_actions_sheet.cell(1, 1)).to eq "psd_ref"
       expect(corrective_actions_sheet.cell(2, 1)).to eq product.psd_ref
@@ -226,6 +234,10 @@ RSpec.describe ProductExport, :with_opensearch, :with_stubbed_notify, :with_stub
       expect(corrective_actions_sheet.cell(1, 12)).to eq "product_name"
       expect(corrective_actions_sheet.cell(2, 12)).to eq product.name
       expect(corrective_actions_sheet.cell(3, 12)).to eq product.name
+
+      expect(corrective_actions_sheet.cell(1, 13)).to eq "case_id"
+      expect(corrective_actions_sheet.cell(2, 13)).to eq corrective_action.investigation.pretty_id
+      expect(corrective_actions_sheet.cell(3, 13)).to eq corrective_action_2.investigation.pretty_id
     end
   end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1613

For CBAS team, to help them link supporting information with each case automatically, which is tricky now that product decoupling has taken place.

- Adds new `case_id` to all supporting information rows in product export 
- Adds specs covering decorators