### PR TITLE
PRISM: risk assessment from PSD (PSD-1691)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,6 +61,7 @@ class ApplicationController < ActionController::Base
     items.push text: "Cases", href: your_cases_investigations_path, active: highlight_cases?
     items.push text: "Businesses", href: your_businesses_path, active: highlight_businesses?
     items.push text: "Products", href: your_products_path, active: highlight_products?
+    items.push text: "Risk assessments", href: your_prism_risk_assessments_path, active: params[:controller] == "prism_risk_assessments" if current_user.is_prism_user?
     items.push text: "Your team", href: team_path(current_user.team), active: params[:controller].start_with?("teams"), right: true
     items
   end

--- a/app/controllers/prism_risk_assessments_controller.rb
+++ b/app/controllers/prism_risk_assessments_controller.rb
@@ -1,0 +1,14 @@
+class PrismRiskAssessmentsController < ApplicationController
+  def your_prism_risk_assessments
+    authorize PrismRiskAssessment, :index?
+
+    # TODO(ruben): search for PRISM risk assessments here
+    @draft_risk_assessments_count = 0
+    @draft_risk_assessments = []
+    @submitted_risk_assessments_count = 0
+    @submitted_risk_assessments = []
+    @page_name = "your_prism_risk_assessments"
+
+    render "prism_risk_assessments/index"
+  end
+end

--- a/app/models/prism_risk_assessment.rb
+++ b/app/models/prism_risk_assessment.rb
@@ -1,0 +1,2 @@
+class PrismRiskAssessment < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,10 @@ class User < ApplicationRecord
     has_role? :super_user
   end
 
+  def is_prism_user?
+    has_role? :prism
+  end
+
   def can_validate_risk_level?
     has_role? :risk_level_validator
   end

--- a/app/policies/prism_risk_assessment_policy.rb
+++ b/app/policies/prism_risk_assessment_policy.rb
@@ -1,0 +1,5 @@
+class PrismRiskAssessmentPolicy < ApplicationPolicy
+  def index?
+    user.is_prism_user?
+  end
+end

--- a/app/views/homepage/authenticated.html.erb
+++ b/app/views/homepage/authenticated.html.erb
@@ -84,7 +84,11 @@
               Add further information to the case
             </h3>
             <p class="govuk-body-s govuk-!-margin-bottom-1">
-              The case can be found in the Cases area, where you can continue to add information and your supporting case information.
+              <% if current_user.is_prism_user? %>
+              You can access the case within the Cases area, where you have the option to add or modify supporting case information, including product <a href="<%= your_prism_risk_assessments_path %>" class="govuk-link govuk-link--no-visited-state">risk assessments</a>.
+              <% else %>
+              You can access the case within the Cases area, where you have the option to add or modify supporting case information.
+              <% end %>
             </p>
           </div>
         </li>

--- a/app/views/prism_risk_assessments/_no_prism_risk_assessments.html.erb
+++ b/app/views/prism_risk_assessments/_no_prism_risk_assessments.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full" role="region" aria-label="Risk assessments">
+    <p class="govuk-body opss-text-align-center">
+      There are no <%= type %> risk assessments.
+    </p>
+  </div>
+</div>

--- a/app/views/prism_risk_assessments/heading/_your_prism_risk_assessments.html.erb
+++ b/app/views/prism_risk_assessments/heading/_your_prism_risk_assessments.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Risk assessments</h1>
+  </div>
+</div>

--- a/app/views/prism_risk_assessments/index.html.erb
+++ b/app/views/prism_risk_assessments/index.html.erb
@@ -1,0 +1,41 @@
+<%= page_title I18n.t(".prism_risk_assessments.titles.#{@page_name}") %>
+
+<%= render "prism_risk_assessments/heading/#{@page_name}" %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-three-quarters" id="page-content">
+    <h2 class="govuk-heading-m">Draft risk assessments</h2>
+    <% if @draft_risk_assessments.any? %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full" role="region" aria-label="Draft risk assessments">
+          <%= render "table", products: @draft_risk_assessments %>
+          <%= paginate @draft_risk_assessments.object %>
+        </div>
+      </div>
+    <% elsif ["team_prism_risk_assessments", "your_prism_risk_assessments"].include?(@page_name) %>
+      <%= render "prism_risk_assessments/no_prism_risk_assessments", page_name: @page_name, type: "draft" %>
+    <% end %>
+  </section>
+</div>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m">Submitted risk assessments</h2>
+    <% if @submitted_risk_assessments.any? %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full" role="region" aria-label="Submitted risk assessments">
+          <%= render "table", products: @submitted_risk_assessments %>
+          <%= paginate @submitted_risk_assessments.object %>
+        </div>
+      </div>
+    <% elsif ["team_prism_risk_assessments", "your_prism_risk_assessments"].include?(@page_name) %>
+      <%= render "prism_risk_assessments/no_prism_risk_assessments", page_name: @page_name, type: "submitted" %>
+    <% end %>
+  </section>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= govukButton(text: "Start a new risk assessment", href: prism.serious_risk_path) %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,9 @@ en:
     ts_investigations:
       coronavirus:
         caption: "Report an unsafe or non-compliant product"
+  prism_risk_assessments:
+    titles:
+      your_prism_risk_assessments: Risk assessments
   audit_activity:
     investigation:
       coronavirus_related: Case is related to the coronavirus outbreak.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,10 @@ Rails.application.routes.draw do
     resource :number_of_affected_units, only: %i[edit update], path: "edit-number-of-affected-units", controller: "investigation_products/number_of_affected_units"
   end
 
+  resource :prism_risk_assessments, only: [], path: "prism-risk-assessments" do
+    get "your-prism-risk-assessments", to: "prism_risk_assessments#your_prism_risk_assessments", as: "your"
+  end
+
   resources :businesses, except: %i[new create destroy], concerns: %i[document_attachable] do
     resources :locations do
       member do

--- a/spec/features/prism_risk_assessment_spec.rb
+++ b/spec/features/prism_risk_assessment_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "PRISM risk assessment dashboard", type: :feature do
+  context "when the user has access to PRISM" do
+    let(:user) { create(:user, :activated, roles: %w[prism]) }
+
+    before do
+      sign_in user
+    end
+
+    scenario "visiting the PRISM risk assessment dashboard via the header link" do
+      visit "/"
+
+      expect(page).to have_link("Risk assessments", class: "psd-header__link")
+
+      click_link "Risk assessments"
+
+      expect(page).to have_text("Risk assessments")
+      expect(page).to have_link("Start a new risk assessment")
+    end
+  end
+
+  context "when the user does not have access to PRISM" do
+    let(:user) { create(:user, :activated) }
+
+    before do
+      sign_in user
+    end
+
+    scenario "visiting the PRISM risk assessment dashboard via the header link" do
+      visit "/"
+
+      expect(page).not_to have_link("Risk assessments", class: "psd-header__link")
+    end
+
+    scenario "visiting the PRISM risk assessment dashboard directly" do
+      expect { visit "/prism-risk-assessments/your-prism-risk-assessments" }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1691

## Description

Adds links to a new PRISM risk assessment dashboard from PSD for users with the `prism` role.

The dashboard will be populated once the PRISM data structures are finalised.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-06-26 at 15 37 15](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/8501c8fa-500a-4e3f-bc00-790f91e4b30c)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
