### PR TITLE
Add missing decorator methods, fixing mailers - PSD-1712

### DIFF
--- a/app/decorators/investigation/enquiry_decorator.rb
+++ b/app/decorators/investigation/enquiry_decorator.rb
@@ -1,6 +1,10 @@
 class Investigation < ApplicationRecord
   require_dependency "investigation"
   class EnquiryDecorator < InvestigationDecorator
+    def title
+      user_title || pretty_id
+    end
+
   private
 
     def should_display_date_received?

--- a/app/decorators/investigation/project_decorator.rb
+++ b/app/decorators/investigation/project_decorator.rb
@@ -1,5 +1,8 @@
 class Investigation < ApplicationRecord
   require_dependency "investigation"
   class ProjectDecorator < InvestigationDecorator
+    def title
+      user_title || pretty_id
+    end
   end
 end

--- a/spec/decorators/investigation/enquiry_decorator_spec.rb
+++ b/spec/decorators/investigation/enquiry_decorator_spec.rb
@@ -23,4 +23,21 @@ RSpec.describe Investigation::EnquiryDecorator, :with_stubbed_opensearch, :with_
       expect(source_details_summary_list).to summarise("Received by", text: investigation.received_type.upcase_first)
     end
   end
+
+  describe "#title" do
+    context "with a user_title" do
+      let(:investigation) { create(:enquiry, user_title:) }
+      let(:user_title)    { "user title" }
+
+      it { expect(decorated_investigation.title).to eq(user_title) }
+    end
+
+    context "without a user_title" do
+      let(:investigation) { create(:enquiry, user_title: nil) }
+
+      it "uses the pretty_id" do
+        expect(decorated_investigation.title).to eq(investigation.pretty_id)
+      end
+    end
+  end
 end

--- a/spec/decorators/investigation/project_decorator_spec.rb
+++ b/spec/decorators/investigation/project_decorator_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Investigation::ProjectDecorator, :with_stubbed_opensearch, :with_stubbed_mailer do
+  include ActionView::Helpers::DateHelper
+
+  subject(:decorated_investigation) { investigation.decorate }
+
+  let(:user)          { build_stubbed(:user) }
+  let(:investigation) { create(:project) }
+
+  before do
+    create(:complainant, investigation:)
+  end
+
+  describe "#title" do
+    context "with a user_title" do
+      let(:investigation) { create(:project, user_title:) }
+      let(:user_title)    { "user title" }
+
+      it { expect(decorated_investigation.title).to eq(user_title) }
+    end
+
+    context "without a user_title" do
+      let(:investigation) { create(:project, user_title: nil) }
+
+      it "uses the pretty_id" do
+        expect(decorated_investigation.title).to eq(investigation.pretty_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1712

This should fix the broken mailers

- Added missing #title decorator method for enquiry, project cases

I did add a action mailer preview file for these, but because the mail is going through Notify, only the template params are rendered, so not that helpful