### PR TITLE
Whitelist torfaen.gov.uk

### DIFF
--- a/config/constants/whitelisted_emails.yml
+++ b/config/constants/whitelisted_emails.yml
@@ -188,6 +188,7 @@ email_domains:
   - "tameside.gov.uk"
   - "telford.gov.uk"
   - "thurrock.gov.uk"
+  - "torfaen.gov.uk"
   - "towerhamlets.gov.uk"
   - "trafford.gov.uk"
   - "valeofglamorgan.gov.uk"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1716

## Description

Adds the domain `torfaen.gov.uk` to the email whitelist after splitting from `blaenau-gwent.gov.uk`.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
