### PR TITLE
PRISM: add details about products in use and safety

### DIFF
--- a/db/migrate/20230704140908_add_safety_legislation_to_prism_product_market_details.prism.rb
+++ b/db/migrate/20230704140908_add_safety_legislation_to_prism_product_market_details.prism.rb
@@ -1,0 +1,11 @@
+# This migration comes from prism (originally 20230704140750)
+class AddSafetyLegislationToPrismProductMarketDetails < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_product_market_details, bulk: true do |t|
+        t.string :safety_legislation_standards, array: true, default: []
+        t.string :other_safety_legislation_standard
+      end
+    end
+  end
+end

--- a/db/migrate/20230705110026_fix_foreign_keys_for_prism_tables.prism.rb
+++ b/db/migrate/20230705110026_fix_foreign_keys_for_prism_tables.prism.rb
@@ -1,0 +1,30 @@
+# This migration comes from prism (originally 20230705105415)
+class FixForeignKeysForPrismTables < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_products, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_product_market_details, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_product_hazards, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_harm_scenarios, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_134002) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_110026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -308,31 +308,33 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_134002) do
     t.string "hazard_type"
     t.string "level_of_uncertainty"
     t.boolean "multiple_casualties"
-    t.bigint "prism_risk_assessment_id"
+    t.uuid "risk_assessment_id"
     t.boolean "sensitivity_analysis"
     t.string "severity"
     t.datetime "updated_at", null: false
-    t.index ["prism_risk_assessment_id"], name: "index_prism_harm_scenarios_on_prism_risk_assessment_id"
+    t.index ["risk_assessment_id"], name: "index_prism_harm_scenarios_on_risk_assessment_id"
   end
 
   create_table "prism_product_hazards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "number_of_hazards"
-    t.bigint "prism_risk_assessment_id"
     t.string "product_aimed_at"
+    t.uuid "risk_assessment_id"
     t.string "unintended_risks_for"
     t.datetime "updated_at", null: false
-    t.index ["prism_risk_assessment_id"], name: "index_prism_product_hazards_on_prism_risk_assessment_id"
+    t.index ["risk_assessment_id"], name: "index_prism_product_hazards_on_risk_assessment_id"
   end
 
   create_table "prism_product_market_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "prism_risk_assessment_id"
+    t.string "other_safety_legislation_standard"
+    t.uuid "risk_assessment_id"
     t.jsonb "routing_questions"
+    t.string "safety_legislation_standards", default: [], array: true
     t.string "selling_organisation"
     t.integer "total_products_sold"
     t.datetime "updated_at", null: false
-    t.index ["prism_risk_assessment_id"], name: "index_prism_product_market_details_on_prism_risk_assessment_id"
+    t.index ["risk_assessment_id"], name: "index_prism_product_market_details_on_risk_assessment_id"
   end
 
   create_table "prism_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -346,11 +348,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_134002) do
     t.string "markings"
     t.string "name"
     t.string "placed_on_market_before_eu_exit"
-    t.bigint "prism_risk_assessment_id"
+    t.uuid "risk_assessment_id"
     t.jsonb "routing_questions"
     t.string "subcategory"
     t.datetime "updated_at", null: false
-    t.index ["prism_risk_assessment_id"], name: "index_prism_products_on_prism_risk_assessment_id"
+    t.index ["risk_assessment_id"], name: "index_prism_products_on_risk_assessment_id"
   end
 
   create_table "prism_risk_assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/prism/app/models/prism/harm_scenario.rb
+++ b/prism/app/models/prism/harm_scenario.rb
@@ -1,7 +1,7 @@
 module Prism
   class HarmScenario < ApplicationRecord
     belongs_to :risk_assessment
-    has_many :harm_scenario_steps
+    has_many :harm_scenario_steps, autosave: true
 
     enum hazard_type: {
       "mechanical" => "mechanical",

--- a/prism/app/models/prism/product_market_detail.rb
+++ b/prism/app/models/prism/product_market_detail.rb
@@ -1,5 +1,28 @@
+require "store_attribute"
+
 module Prism
   class ProductMarketDetail < ApplicationRecord
     belongs_to :risk_assessment
+
+    store_attribute :routing_questions, :total_products_sold_estimatable, :boolean
+
+    validates :selling_organisation, presence: true
+    validates :total_products_sold_estimatable, inclusion: [true, false]
+    validates :total_products_sold, presence: true, numericality: { only_integer: true }, if: -> { total_products_sold_estimatable }
+    validates :safety_legislation_standards, presence: true, array_intersection: { in: %w[regulation_4404 regulation_129 bs_en_17072_2018 bs_en_17022_2018 other] }
+    validates :other_safety_legislation_standard, presence: true, if: -> { safety_legislation_standards.include?("other") }
+
+    before_save :clear_total_products_sold
+    before_save :clear_other_safety_legislation_standard
+
+  private
+
+    def clear_total_products_sold
+      self.total_products_sold = nil unless total_products_sold_estimatable
+    end
+
+    def clear_other_safety_legislation_standard
+      self.other_safety_legislation_standard = nil unless safety_legislation_standards.include?("other")
+    end
   end
 end

--- a/prism/app/models/prism/risk_assessment.rb
+++ b/prism/app/models/prism/risk_assessment.rb
@@ -5,10 +5,10 @@ module Prism
   class RiskAssessment < ApplicationRecord
     include AASM
 
-    has_one :product
-    has_one :product_market_detail
-    has_one :product_hazard
-    has_many :harm_scenarios
+    has_one :product, autosave: true
+    has_one :product_market_detail, autosave: true
+    has_one :product_hazard, autosave: true
+    has_many :harm_scenarios, autosave: true
 
     enum risk_type: {
       "normal_risk" => "normal_risk",

--- a/prism/app/validators/array_intersection_validator.rb
+++ b/prism/app/validators/array_intersection_validator.rb
@@ -1,0 +1,33 @@
+# Inspired by https://github.com/rafaelbiriba/active_model_validates_intersection_of
+
+class ArrayIntersectionValidator < ActiveModel::EachValidator
+  def check_validity!
+    unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
+      raise ArgumentError, "An object with the method #include? or a proc, lambda or symbol is required, and must be supplied as the :in (or :within) option"
+    end
+  end
+
+  def validate_each(record, attribute, value)
+    raise ArgumentError, "value must be an array" unless value.is_a?(Array)
+
+    if (value - members(record)).size.positive?
+      record.errors.add(attribute, :inclusion)
+    end
+  end
+
+private
+
+  def members(record)
+    if delimiter.respond_to?(:call)
+      delimiter.call(record)
+    elsif delimiter.respond_to?(:to_sym)
+      record.send(delimiter)
+    else
+      delimiter
+    end
+  end
+
+  def delimiter
+    @delimiter ||= options[:in] || options[:within]
+  end
+end

--- a/prism/app/views/prism/tasks/add_details_about_products_in_use_and_safety.html.erb
+++ b/prism/app/views/prism/tasks/add_details_about_products_in_use_and_safety.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title, "Add details about products in use and safety" %>
+<% @back_link_href = risk_assessment_tasks_path(@prism_risk_assessment) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @product_market_detail, url: wizard_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Define the product</span>
+        Add details about products in use and safety
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <p class="govuk-body-l">Placeholder product</p>
+      <% end %>
+      <%= f.govuk_text_field :selling_organisation, label: { text: "Name of the business that sold the product", size: "m" }, hint: { text: "This information is essential for product traceability." } %>
+      <%= f.govuk_radio_buttons_fieldset :total_products_sold_estimatable, legend: { text: "Can the total number of products in use be estimated?", size: "m" } do %>
+        <%= f.govuk_radio_button :total_products_sold_estimatable, true, label: { text: "Yes" }, hint: { text: "Based on information provided by the business or other evidence." }, link_errors: true do %>
+          <%= f.govuk_number_field :total_products_sold, label: { text: "Estimated number of products in use" }, width: 4 %>
+        <% end %>
+        <%= f.govuk_radio_button :total_products_sold_estimatable, false, label: { text: "No" }, hint: { text: "Insufficient information available to make a reasonable estimate." } %>
+      <% end %>
+      <%= f.govuk_check_boxes_fieldset :safety_legislation_standards, legend: { text: "Product safety legislation and standards", size: "m" }, hint: { text: "Review the provided legislations and standards and choose the ones that you feel are relevant to your product." } do %>
+        <%= f.govuk_check_box :safety_legislation_standards, :regulation_4404, label: { text: "Regulation No 44/04 UN ECE approval of restraining devices for child occupants (child restraint systems)" }, link_errors: true,checked: @product_market_detail.safety_legislation_standards.include?("regulation_4404") %>
+        <%= f.govuk_check_box :safety_legislation_standards, :regulation_129, label: { text: "Regulation No 129 UN ECE R129 approval of enhanced child restraint systems (i-size)" }, checked: @product_market_detail.safety_legislation_standards.include?("regulation_129") %>
+        <%= f.govuk_check_box :safety_legislation_standards, :bs_en_17072_2018, label: { text: "BS EN 17072:2018" }, checked: @product_market_detail.safety_legislation_standards.include?("bs_en_17072_2018") %>
+        <%= f.govuk_check_box :safety_legislation_standards, :bs_en_17022_2018, label: { text: "BS EN 17022:2018" }, checked: @product_market_detail.safety_legislation_standards.include?("bs_en_17022_2018") %>
+        <%= f.govuk_check_box :safety_legislation_standards, :other, label: { text: "Other" }, checked: @product_market_detail.safety_legislation_standards.include?("other") do %>
+          <%= f.govuk_text_field :other_safety_legislation_standard, label: { text: "Name of safety legislation or standard" } %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/prism/app/views/prism/tasks/search_or_add_a_new_product.html.erb
+++ b/prism/app/views/prism/tasks/search_or_add_a_new_product.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Search or add a new product" %>
+<% @back_link_href = risk_assessment_tasks_path(@prism_risk_assessment) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @prism_risk_assessment, url: wizard_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Define the product</span>
+        Have you previously searched and found the same product on the PSD?
+      </h1>
+      <p class="govuk-body">This is a placeholder page.</p>
+      <%= f.govuk_submit "Save and continue" do %>
+        <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/prism/config/locales/en.yml
+++ b/prism/config/locales/en.yml
@@ -52,6 +52,21 @@ en:
               blank: Enter the full name of the assessor
             assessment_organisation:
               blank: Enter the name of the assessment organisation
+        prism/product_market_detail:
+          attributes:
+            selling_organisation:
+              blank: Enter the name of the business that sold the product
+            total_products_sold_estimatable:
+              inclusion: Select whether the total number of products in use can be calculated
+            total_products_sold:
+              blank: Enter the estimated number of products in use
+              not_a_number: The estimated number of products in use must be a whole number
+              not_an_integer: The estimated number of products in use must be a whole number
+            safety_legislation_standards:
+              blank: Select the product safety legislation and standards that are relevant to your product
+              inclusion: Select the product safety legislation and standards that are relevant to your product
+            other_safety_legislation_standard:
+              blank: Enter the name of the safety legislation or standard
   prism:
     tasks:
       task_list:

--- a/prism/db/migrate/20230704140750_add_safety_legislation_to_prism_product_market_details.rb
+++ b/prism/db/migrate/20230704140750_add_safety_legislation_to_prism_product_market_details.rb
@@ -1,0 +1,10 @@
+class AddSafetyLegislationToPrismProductMarketDetails < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_product_market_details, bulk: true do |t|
+        t.string :safety_legislation_standards, array: true, default: []
+        t.string :other_safety_legislation_standard
+      end
+    end
+  end
+end

--- a/prism/db/migrate/20230705105415_fix_foreign_keys_for_prism_tables.rb
+++ b/prism/db/migrate/20230705105415_fix_foreign_keys_for_prism_tables.rb
@@ -1,0 +1,29 @@
+class FixForeignKeysForPrismTables < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_products, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_product_market_details, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_product_hazards, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+
+      change_table :prism_harm_scenarios, bulk: true do |t|
+        t.remove_references :prism_risk_assessment
+
+        t.references :risk_assessment, type: :uuid
+      end
+    end
+  end
+end

--- a/spec/factories/prism/risk_assessment.rb
+++ b/spec/factories/prism/risk_assessment.rb
@@ -1,9 +1,32 @@
 FactoryBot.define do
   factory :prism_risk_assessment, class: "Prism::RiskAssessment" do
     risk_type { "normal_risk" }
+    tasks_status do
+      {
+        "add_assessment_details" => "not_started",
+        "search_or_add_a_new_product" => "not_started",
+        "add_details_about_products_in_use_and_safety" => "not_started",
+        "add_a_number_of_hazards_and_subjects_of_harm" => "not_started",
+        "choose_hazard_type" => "not_started",
+        "add_a_harm_scenario_and_probability_of_harm" => "not_started",
+        "determine_severity_of_harm" => "not_started",
+        "add_uncertainty_and_sensitivity_analysis" => "not_started",
+        "confirm_overall_product_risk" => "not_started",
+        "complete_product_risk_evaluation" => "not_started",
+        "review_and_submit_results_of_the_assessment" => "not_started"
+      }
+    end
 
     trait :serious_risk do
       risk_type { "serious_risk" }
+      tasks_status do
+        {
+          "add_evaluation_details" => "not_started",
+          "search_or_add_a_new_product" => "not_started",
+          "complete_product_risk_evaluation" => "not_started",
+          "review_and_submit_results_of_the_evaluation" => "not_started"
+        }
+      end
     end
   end
 end

--- a/spec/features/prism/tasks_spec.rb
+++ b/spec/features/prism/tasks_spec.rb
@@ -40,8 +40,7 @@ RSpec.feature "PRISM tasks", type: :feature do
       fill_in "Name of assessor", with: "Test name"
       fill_in "Name of assessment organisation", with: "Test organisation"
 
-      # TODO(ruben): change once the next task is ready
-      expect { click_button "Save and continue" }.to raise_error(ActionView::MissingTemplate)
+      click_button "Save and continue"
 
       visit prism.risk_assessment_tasks_path(prism_risk_assessment)
 
@@ -58,6 +57,29 @@ RSpec.feature "PRISM tasks", type: :feature do
       click_button "Save as draft"
 
       expect(page).to have_text("Determine and evaluate the level of product risk")
+    end
+
+    context "when completing the final task of a section" do
+      before do
+        prism_risk_assessment.tasks_status["add_assessment_details"] = "completed"
+        prism_risk_assessment.tasks_status["search_or_add_a_new_product"] = "completed"
+        prism_risk_assessment.save!
+      end
+
+      scenario "task completion" do
+        visit prism.risk_assessment_tasks_path(prism_risk_assessment)
+
+        click_link "Add details about products in use and safety"
+
+        fill_in "Name of the business that sold the product", with: "Test organisation"
+        choose "No"
+        check "BS EN 17022:2018"
+
+        click_button "Save and complete tasks in this section"
+
+        expect(page).to have_text("Determine and evaluate the level of product risk")
+        expect(page).to have_text("You have completed 1 of 4 sections.")
+      end
     end
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1730

## Description

Adds the “Add details about products in use and safety” page.

Also fixes some database fields and adds a placeholder product search page pending work on general product search.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-07-05 at 13 25 45](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/9ced01c3-63f6-4783-8a20-9cec40c1e7cd)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [ ] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
