### PR TITLE
PRISM: number of hazards and subjects of harm

### DIFF
--- a/db/migrate/20230705124426_add_fields_to_prism_product_hazards.prism.rb
+++ b/db/migrate/20230705124426_add_fields_to_prism_product_hazards.prism.rb
@@ -1,0 +1,13 @@
+# This migration comes from prism (originally 20230705124301)
+class AddFieldsToPrismProductHazards < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_product_hazards, bulk: true do |t|
+        t.remove :unintended_risks_for, type: :string
+
+        t.string :product_aimed_at_description
+        t.string :unintended_risks_for, array: true, default: []
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_05_110026) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_124426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -319,8 +319,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_05_110026) do
     t.datetime "created_at", null: false
     t.string "number_of_hazards"
     t.string "product_aimed_at"
+    t.string "product_aimed_at_description"
     t.uuid "risk_assessment_id"
-    t.string "unintended_risks_for"
+    t.string "unintended_risks_for", default: [], array: true
     t.datetime "updated_at", null: false
     t.index ["risk_assessment_id"], name: "index_prism_product_hazards_on_risk_assessment_id"
   end

--- a/prism/app/controllers/prism/tasks_controller.rb
+++ b/prism/app/controllers/prism/tasks_controller.rb
@@ -39,6 +39,8 @@ module Prism
       case step
       when :add_details_about_products_in_use_and_safety
         @product_market_detail = @prism_risk_assessment.product_market_detail || @prism_risk_assessment.build_product_market_detail
+      when :add_a_number_of_hazards_and_subjects_of_harm
+        @product_hazard = @prism_risk_assessment.product_hazard || @prism_risk_assessment.build_product_hazard
       end
 
       render_wizard
@@ -51,6 +53,9 @@ module Prism
       when :add_details_about_products_in_use_and_safety
         @product_market_detail = @prism_risk_assessment.product_market_detail || @prism_risk_assessment.build_product_market_detail
         @product_market_detail.assign_attributes(add_details_about_products_in_use_and_safety_params)
+      when :add_a_number_of_hazards_and_subjects_of_harm
+        @product_hazard = @prism_risk_assessment.product_hazard || @prism_risk_assessment.build_product_hazard
+        @product_hazard.assign_attributes(add_a_number_of_hazards_and_subjects_of_harm_params)
       end
 
       @prism_risk_assessment.tasks_status[step.to_s] = "completed"
@@ -101,6 +106,15 @@ module Prism
         .permit(:selling_organisation, :total_products_sold_estimatable, :total_products_sold, :other_safety_legislation_standard, :final, safety_legislation_standards: [])
       # The form builder inserts an empty hidden field that needs to be removed before validation and saving
       allowed_params[:safety_legislation_standards].reject!(&:blank?)
+      allowed_params
+    end
+
+    def add_a_number_of_hazards_and_subjects_of_harm_params
+      allowed_params = params
+        .require(:product_hazard)
+        .permit(:number_of_hazards, :product_aimed_at, :product_aimed_at_description, :final, unintended_risks_for: [])
+      # The form builder inserts an empty hidden field that needs to be removed before validation and saving
+      allowed_params[:unintended_risks_for].reject!(&:blank?)
       allowed_params
     end
 

--- a/prism/app/helpers/prism/tasks_helper.rb
+++ b/prism/app/helpers/prism/tasks_helper.rb
@@ -39,9 +39,22 @@ module Prism
         govuk_tag(text: "Cannot start yet", colour: "grey")
       when "not_started"
         govuk_tag(text: "Not started", colour: "grey")
+      when "in_progress"
+        govuk_tag(text: "In progress")
       when "completed"
-        govuk_tag(text: "Completed", colour: "blue")
+        govuk_tag(text: "Completed")
       end
+    end
+
+    def number_of_hazards_radios
+      [
+        OpenStruct.new(id: "one", name: "1"),
+        OpenStruct.new(id: "two", name: "2"),
+        OpenStruct.new(id: "three", name: "3"),
+        OpenStruct.new(id: "four", name: "4"),
+        OpenStruct.new(id: "five", name: "5"),
+        OpenStruct.new(id: "more_than_five", name: "More than 5"),
+      ]
     end
   end
 end

--- a/prism/app/models/prism/product_hazard.rb
+++ b/prism/app/models/prism/product_hazard.rb
@@ -10,5 +10,23 @@ module Prism
       "five" => "five",
       "more_than_five" => "more_than_five",
     }
+
+    enum product_aimed_at: {
+      "particular_group_of_users" => "particular_group_of_users",
+      "general_population" => "general_population",
+    }
+
+    validates :number_of_hazards, presence: true, inclusion: %w[one two three four five more_than_five]
+    validates :product_aimed_at, presence: true, inclusion: %w[particular_group_of_users general_population]
+    validates :product_aimed_at_description, presence: true, if: -> { product_aimed_at == "particular_group_of_users" }
+    validates :unintended_risks_for, array_intersection: { in: %w[unintended_users non_users] }
+
+    before_save :clear_product_aimed_at_description
+
+  private
+
+    def clear_product_aimed_at_description
+      self.product_aimed_at_description = nil unless product_aimed_at == "particular_group_of_users"
+    end
   end
 end

--- a/prism/app/views/prism/tasks/add_a_number_of_hazards_and_subjects_of_harm.html.erb
+++ b/prism/app/views/prism/tasks/add_a_number_of_hazards_and_subjects_of_harm.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title, "Add a number of hazards and subjects of harm" %>
+<% @back_link_href = risk_assessment_tasks_path(@prism_risk_assessment) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @product_hazard, url: wizard_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Identify product hazards and subjects of harm</span>
+        Add a number of hazards and subjects of harm
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <p class="govuk-body-l">Placeholder product</p>
+      <% end %>
+      <%= f.govuk_collection_radio_buttons :number_of_hazards, number_of_hazards_radios, :id, :name, legend: { text: "Number of hazards identified" } %>
+      <%= f.govuk_radio_buttons_fieldset :product_aimed_at, legend: { text: "Who is the product aimed at?", size: "m" } do %>
+        <%= f.govuk_radio_button :product_aimed_at, "particular_group_of_users", label: { text: "Particular group of users" }, hint: { text: "For example, children, men or women, the elderly, certain ethnic or cultural groups, etc." }, link_errors: true do %>
+          <%= f.govuk_text_field :product_aimed_at_description, label: { text: "Description of user type including age group if applicable. For example, children 2-3 years." } %>
+        <% end %>
+        <%= f.govuk_radio_button :product_aimed_at, "general_population", label: { text: "General population" }, hint: { text: "Product is not aimed at a particular group but broadly at the general population." } %>
+      <% end %>
+      <%= f.govuk_check_boxes_fieldset :unintended_risks_for, legend: { text: "Who else might be at risk?", size: "m" }, hint: { text: "Select all that are applicable." } do %>
+        <%= f.govuk_check_box :unintended_risks_for, :unintended_users, label: { text: "Unintended users" }, hint: { text: "For example, young children using products intended for their parents or older children, and professional products being used by non-professional users." }, link_errors: true, checked: @product_hazard.unintended_risks_for.include?("unintended_users") %>
+        <%= f.govuk_check_box :unintended_risks_for, :non_users, label: { text: "Non-users" }, hint: { text: "For example, products that present fire hazards with the potential to cause a multi-occupied building to catch fire, and products that either in normal use or as a result of failure can produce projectiles placing people in the general vicinity at risk." }, checked: @product_hazard.unintended_risks_for.include?("non_users") %>
+      <% end %>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/prism/config/locales/en.yml
+++ b/prism/config/locales/en.yml
@@ -67,6 +67,18 @@ en:
               inclusion: Select the product safety legislation and standards that are relevant to your product
             other_safety_legislation_standard:
               blank: Enter the name of the safety legislation or standard
+        prism/product_hazard:
+          attributes:
+            number_of_hazards:
+              blank: Select the number of hazards identified
+              inclusion: Select the number of hazards identified
+            product_aimed_at:
+              blank: Select who the product is aimed at
+              inclusion: Select who the product is aimed at
+            product_aimed_at_description:
+              blank: Enter a description of the particular group of users
+            unintended_risks_for:
+              inclusion: Select who else might be at risk
   prism:
     tasks:
       task_list:

--- a/prism/db/migrate/20230705124301_add_fields_to_prism_product_hazards.rb
+++ b/prism/db/migrate/20230705124301_add_fields_to_prism_product_hazards.rb
@@ -1,0 +1,12 @@
+class AddFieldsToPrismProductHazards < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :prism_product_hazards, bulk: true do |t|
+        t.remove :unintended_risks_for, type: :string
+
+        t.string :product_aimed_at_description
+        t.string :unintended_risks_for, array: true, default: []
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1654

## Description

Adds the “number of hazards and subjects of harm” page and makes some minor design tweaks.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-07-06 at 13 29 58](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/83345013-56cd-43a0-b201-15c75a081754)

![Screenshot 2023-07-06 at 13 30 19](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/1591fb78-6318-4d39-b273-9c85dd887c19)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [ ] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
