### PR TITLE
Business country validation - PSD-1620

### DIFF
--- a/app/forms/add_business_to_case_form.rb
+++ b/app/forms/add_business_to_case_form.rb
@@ -19,6 +19,7 @@ class AddBusinessToCaseForm
   attribute :contacts_attributes
 
   validates :current_user, :trading_name, presence: true
+  validate :validate_country_set_for_location
 
   def initialize(*args)
     super
@@ -51,6 +52,12 @@ class AddBusinessToCaseForm
   end
 
 private
+
+  def validate_country_set_for_location
+    return if location_attrs[:country].present?
+
+    errors.add(:base, "Country cannot be blank")
+  end
 
   def new_location
     location = Location.new(location_attrs)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,7 +3,7 @@ class Location < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
-  validates :name, presence: true
+  validates :name, :country, presence: true
 
   belongs_to :business
   belongs_to :added_by_user, class_name: :User, optional: true

--- a/app/views/locations/_address_form.html.erb
+++ b/app/views/locations/_address_form.html.erb
@@ -37,7 +37,7 @@
     key: :country,
     items: all_countries_with_uk_first.map { |country| { text: country[0], value: country[1] } },
     formGroup: { classes: "govuk-!-width-two-thirds" },
-    classes: "govuk-!-font-size-16",
+    include_blank: true,
     label: { text: "Country" } ) %>
 
 </fieldset>

--- a/spec/features/add_business_to_a_case_spec.rb
+++ b/spec/features/add_business_to_a_case_spec.rb
@@ -73,18 +73,10 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
     end
 
     within_fieldset "Contacts" do
-      fill_in "Name",                          with: name
+      fill_in "Name", with: name
       fill_in "Email",                         with: email
       fill_in "Telephone",                     with: phone_number
       fill_in "Job title or role description", with: job_title
-  end
-
-    click_on "Save"
-
-    expect(page).to have_error_summary("Country cannot be blank")
-
-    within_fieldset "Official address" do
-      select country, from: "Country"
     end
 
     click_on "Save"
@@ -97,6 +89,13 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
 
     click_on "Save"
 
+    expect(page).to have_error_summary("Country cannot be blank")
+
+    within_fieldset "Official address" do
+      select country, from: "Country"
+    end
+
+    click_on "Save"
 
     expect_to_be_on_investigation_businesses_page
     expect(page).not_to have_error_messages

--- a/spec/features/add_business_to_a_case_spec.rb
+++ b/spec/features/add_business_to_a_case_spec.rb
@@ -70,7 +70,6 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
       fill_in "Building and street line 2 of 2",    with: address_line_two
       fill_in "Town or city",        with: city
       fill_in "Postcode",            with: postcode
-      select country,                from: "Country"
     end
 
     within_fieldset "Contacts" do
@@ -78,6 +77,14 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
       fill_in "Email",                         with: email
       fill_in "Telephone",                     with: phone_number
       fill_in "Job title or role description", with: job_title
+  end
+
+    click_on "Save"
+
+    expect(page).to have_error_summary("Country cannot be blank")
+
+    within_fieldset "Official address" do
+      select country, from: "Country"
     end
 
     click_on "Save"
@@ -89,6 +96,7 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
     end
 
     click_on "Save"
+
 
     expect_to_be_on_investigation_businesses_page
     expect(page).not_to have_error_messages

--- a/spec/features/add_business_to_a_case_spec.rb
+++ b/spec/features/add_business_to_a_case_spec.rb
@@ -155,6 +155,10 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
       fill_in "Trading name", with: trading_name
     end
 
+    within_fieldset "Official address" do
+      select "France", from: "Country"
+    end
+
     click_on "Save"
 
     expect_to_be_on_investigation_businesses_page
@@ -203,6 +207,10 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
 
     within_fieldset "Name and company number" do
       fill_in "Trading name", with: trading_name
+    end
+
+    within_fieldset "Official address" do
+      select "France", from: "Country"
     end
 
     click_on "Save"

--- a/spec/features/editing_business_details_spec.rb
+++ b/spec/features/editing_business_details_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch do
-  let(:user)      { create(:user, :activated) }
-  let(:business)  { create(:business, trading_name: "OldCo") }
+  let(:user)     { create(:user, :activated) }
+  let(:business) { create(:business, trading_name: "OldCo") }
   let!(:investigation) { create(:allegation, businesses: [business]) }
 
   before do
     create(:contact, business:)
   end
 
-  scenario "Updating a business’s details" do
+  scenario "Updating a business's details" do
     sign_in user
     visit "/businesses/#{business.id}"
 
@@ -41,6 +41,13 @@ RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch
     end
 
     click_button "Save"
+    expect(page).to have_error_summary("Country cannot be blank")
+
+    within_fieldset "Official address" do
+      select "France", from: "Country"
+    end
+
+    click_on "Save"
 
     expect_to_be_on_business_page(business_id: business.id, business_name: "NewCo")
     expect_confirmation_banner("The business was updated")
@@ -48,7 +55,7 @@ RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch
     expect(page).to have_summary_item(key: "Trading name", value: "NewCo")
     expect(page).to have_summary_item(key: "Registered or legal name", value: "NewCo Ltd")
     expect(page).to have_summary_item(key: "Company number", value: "222 222 22")
-    expect(page).to have_summary_item(key: "Address", value: "22 New Street, New Town, Newcity, NE2 2EW, United Kingdom")
+    expect(page).to have_summary_item(key: "Address", value: "22 New Street, New Town, Newcity, NE2 2EW, France")
 
     expect(page).to have_summary_item(key: "Contact", value: "Mr New, CEO, 01632 960000, contact@newco.example")
 

--- a/spec/forms/add_business_to_case_form_spec.rb
+++ b/spec/forms/add_business_to_case_form_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe AddBusinessToCaseForm, :with_stubbed_opensearch, :with_stubbed_mailer do
   subject(:form) { described_class.new(business_form_params.merge(current_user:)) }
 
+  let(:country) { "United Kingdom" }
   let(:business_form_params) do
     {
       legal_name: "Test Business",
@@ -12,7 +13,8 @@ RSpec.describe AddBusinessToCaseForm, :with_stubbed_opensearch, :with_stubbed_ma
         "0" => {
           name: "Registered office address",
           address_line_1: "1 Test Street",
-          city: "Test Town"
+          city: "Test Town",
+          country:
         }
       },
       contacts_attributes: {
@@ -30,6 +32,14 @@ RSpec.describe AddBusinessToCaseForm, :with_stubbed_opensearch, :with_stubbed_ma
     context "with valid params" do
       it "is valid" do
         expect(form).to be_valid
+      end
+    end
+
+    context "without a country picked" do
+      let(:country) { nil }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
       end
     end
   end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Location do
   let(:county) { "L" }
   let(:country) { "C" }
 
+  describe "factory" do
+    it "is valid" do
+      expect(build(:location)).to be_valid
+    end
+  end
+
   describe "#short" do
     context "with a county" do
       it "returns a string containing county and country" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1620

## Description
For adding businesses to cases, as well as updating old businesses - allows blank country by default, but ensures one is added -

## Screen-shots or screen-capture of UI changes
<img width="560" alt="CleanShot 2023-07-12 at 17 19 39@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/978d77ec-fd04-4059-8858-5df0b4d3dde9">
