### PR TITLE
Move investigation listings from OpenSearch to ActiveRecord

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -12,7 +12,7 @@ class InvestigationsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @answer         = search_for_investigations(20)
+        @answer         = opensearch_for_investigations(20)
         @count          = count_to_display
         @investigations = InvestigationDecorator
                             .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
@@ -40,7 +40,7 @@ class InvestigationsController < ApplicationController
                                  "page_name" => "team_cases" })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
-                        .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
+                        .decorate_collection(@answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
 
     render "investigations/index"
   end
@@ -59,7 +59,7 @@ class InvestigationsController < ApplicationController
     )
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
-                        .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
+                        .decorate_collection(@answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
 
     render "investigations/index"
   end
@@ -72,7 +72,7 @@ class InvestigationsController < ApplicationController
                                  "page_name" => @page_name })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
-                        .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
+                        .decorate_collection(@answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
 
     render "investigations/index"
   end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -6,7 +6,7 @@ class SearchesController < ApplicationController
     if @search.q.blank?
       redirect_to investigations_path(query_params.except(:page_name))
     else
-      @answer = search_for_investigations(20)
+      @answer = opensearch_for_investigations(20)
       @investigations = @answer.records(includes: [{ owner_team: :organisation, owner_user: :organisation }, :products])
     end
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1740

## Description

Changes the investigation listing pages to use normal ActiveRecord queries rather than OpenSearch. Searches across all investigations still use OpenSearch.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
