### PR TITLE
PRISM: add dynamic calculation of probability

### DIFF
--- a/app/javascript/dynamic_nested_step_fields.js
+++ b/app/javascript/dynamic_nested_step_fields.js
@@ -1,4 +1,5 @@
 /* global MutationObserver */
+/* global attachOpssStepEventHandler */
 
 'use strict'
 
@@ -24,6 +25,11 @@ document.addEventListener('DOMContentLoaded', () => {
       el.innerHTML = el.innerHTML.replace(/-new-record-/g, '-' + el.dataset.index + '-')
     })
 
+    // Re-attach events to newly-added step
+    if (typeof attachOpssStepEventHandler === 'function') {
+      attachOpssStepEventHandler()
+    }
+
     // Re-init GOV.UK Frontend to pick up new form fields
     window.GOVUKFrontend.initAll({ scope: document.querySelector('opss-steps') })
   }
@@ -33,4 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const dynamicNestedStepFieldsExistingObserver = new MutationObserver(dynamicNestedStepFieldsCallback)
   dynamicNestedStepFieldsNewObserver.observe(document.querySelector('form[data-controller="nested-form"]'), { childList: true })
   dynamicNestedStepFieldsExistingObserver.observe(document.querySelector('form[data-controller="nested-form"]'), { subtree: true, attributeFilter: ['style'] })
+
+  // Attach events to existing steps
+  if (typeof attachOpssStepEventHandler === 'function') {
+    attachOpssStepEventHandler()
+  }
 })

--- a/prism/app/assets/javascripts/prism/application.js
+++ b/prism/app/assets/javascripts/prism/application.js
@@ -1,3 +1,1 @@
-import * as GOVUKFrontend from 'govuk-frontend'
-
-window.GOVUKFrontend = GOVUKFrontend
+//= require_tree .

--- a/prism/app/assets/javascripts/prism/overall_probability_of_harm.js
+++ b/prism/app/assets/javascripts/prism/overall_probability_of_harm.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/* eslint-disable no-unused-vars */
+const attachOpssStepEventHandler = () => {
+  document.querySelectorAll('.opss-step-probability-decimal').forEach(probability => {
+    probability.addEventListener('input', () => {
+      getOverallProbabilityOfHarm()
+    })
+  })
+  document.querySelectorAll('.opss-step-probability-frequency').forEach(probability => {
+    probability.addEventListener('input', () => {
+      getOverallProbabilityOfHarm()
+    })
+  })
+}
+
+const getOverallProbabilityOfHarm = async () => {
+  const probabilitiesDecimal = [...document.querySelectorAll('.opss-step-probability-decimal')].map(el => el.value).filter(Number)
+  const probabilitiesFrequency = [...document.querySelectorAll('.opss-step-probability-frequency')].map(el => el.value).filter(Number)
+  const response = await fetch(`/prism/api/overall-probability-of-harm?probabilities_decimal=${probabilitiesDecimal}&probabilities_frequency=${probabilitiesFrequency}`)
+  const result = await response.json()
+
+  if (result.status === 200) {
+    document.querySelector('#overall-probability-of-harm').innerHTML = result.result.probability_human
+  }
+}

--- a/prism/app/controllers/prism/api_controller.rb
+++ b/prism/app/controllers/prism/api_controller.rb
@@ -1,0 +1,18 @@
+module Prism
+  class ApiController < ApplicationController
+    skip_before_action :authenticate_user!
+    skip_before_action :authorize_user
+
+    def overall_probability_of_harm
+      return render json: { error: "At least one of probabilities_decimal and probabilities_frequency must be provided", status: 400 } unless params[:probabilities_decimal].present? || params[:probabilities_frequency].present?
+
+      # Process probabilities by handling `nil`, splitting into an array and casting to decimals
+      probabilities_decimal = params[:probabilities_decimal].to_s.split(",").map(&:to_f)
+      probabilities_frequency = params[:probabilities_frequency].to_s.split(",").map(&:to_f)
+
+      overall_probability_of_harm = Prism::ProbabilityService.overall_probability_of_harm(harm_scenario: nil, probabilities_decimal:, probabilities_frequency:)
+
+      render json: { result: { probability: overall_probability_of_harm.probability, probability_human: overall_probability_of_harm.probability_human }, status: 200 }
+    end
+  end
+end

--- a/prism/app/helpers/prism/api_helper.rb
+++ b/prism/app/helpers/prism/api_helper.rb
@@ -1,0 +1,4 @@
+module Prism
+  module ApiHelper
+  end
+end

--- a/prism/app/services/prism/probability_service.rb
+++ b/prism/app/services/prism/probability_service.rb
@@ -1,0 +1,52 @@
+module Prism
+  class ProbabilityService
+    def self.overall_probability_of_harm(harm_scenario:, probabilities_decimal: nil, probabilities_frequency: nil)
+      probabilities = if probabilities_decimal.blank? && probabilities_frequency.blank?
+                        # Get the probability of harm for all harm scenario steps
+                        probabilities = []
+                        steps = harm_scenario.harm_scenario_steps.select(:probability_type, :probability_decimal, :probability_frequency)
+
+                        # For any probability expressed as a frequency, transform it into a decimal
+                        steps.each do |step|
+                          probabilities << if step.probability_type == "frequency"
+                                             step.probability_frequency.zero? ? 0 : (1.0 / step.probability_frequency)
+                                           else
+                                             step.probability_decimal
+                                           end
+                        end
+
+                        probabilities
+                      else
+                        # Use the provided probabilities
+                        probabilities_frequency.map { |probability| probability.zero? ? 0 : 1.0 / probability } + probabilities_decimal
+                      end
+
+      probabilities = probabilities.reject(&:zero?)
+
+      # If there are no harm scenarios or they all had a probability of zero, return
+      if probabilities.blank?
+        return OpenStruct.new(
+          probability: nil,
+          probability_human: "N/A",
+        )
+      end
+
+      # Multiply all the probabilities together, transform into a frequency and round
+      # since we don't want any decimal places
+      probability = (1.0 / probabilities.reduce(:*)).round
+
+      # If probability is zero, return
+      if probability.zero?
+        return OpenStruct.new(
+          probability: nil,
+          probability_human: "N/A",
+        )
+      end
+
+      OpenStruct.new(
+        probability:,
+        probability_human: "1 in #{ActiveSupport::NumberHelper.number_to_delimited(probability)}",
+      )
+    end
+  end
+end

--- a/prism/app/services/prism/risk_matrix_service.rb
+++ b/prism/app/services/prism/risk_matrix_service.rb
@@ -1,5 +1,5 @@
 module Prism
-  class RiskMatrix
+  class RiskMatrixService
     RISK_MATRIX = {
       more_than_or_equal_to_1_in_2: {
         level_1: "high",

--- a/prism/app/views/layouts/prism/application.html.erb
+++ b/prism/app/views/layouts/prism/application.html.erb
@@ -120,6 +120,7 @@
     </div>
   </footer>
   <%= javascript_include_tag "application", nonce: true %>
+  <%= javascript_include_tag "prism/application", nonce: true %>
   <%= javascript_tag nonce: true do -%>
     window.GOVUKFrontend.initAll()
   <% end -%>

--- a/prism/app/views/prism/tasks/_harm_scenario_step_fields.html.erb
+++ b/prism/app/views/prism/tasks/_harm_scenario_step_fields.html.erb
@@ -7,10 +7,10 @@
   <%= f.govuk_text_area :description, label: { text: "Step description", size: "s" }, hint: { text: step_hint, class: "opss-step-hint", style: step_hint_display } %>
   <%= f.govuk_radio_buttons_fieldset :probability_type, legend: { text: "In what format would you like to express the probability of harm?", size: "s" } do %>
     <%= f.govuk_radio_button :probability_type, "decimal", label: { text: "Decimal number" }, hint: { text: "For example, 0.25" }, link_errors: true do %>
-      <%= f.govuk_number_field :probability_decimal, label: { text: "Enter the probability as a decimal number." }, width: 4 %>
+      <%= f.govuk_number_field :probability_decimal, label: { text: "Enter the probability as a decimal number." }, width: 4, class: %w[opss-step-probability-decimal] %>
     <% end %>
     <%= f.govuk_radio_button :probability_type, "frequency", label: { text: "Frequency number" }, hint: { text: "For example, 1 in 1000" } do %>
-      <%= f.govuk_number_field :probability_frequency, label: { text: "Enter the probability as a frequency number." }, width: 4, prefix_text: "1 in" %>
+      <%= f.govuk_number_field :probability_frequency, label: { text: "Enter the probability as a frequency number." }, width: 4, prefix_text: "1 in", class: %w[opss-step-probability-frequency] %>
     <% end %>
   <% end %>
   <%= govuk_details(summary_text: "Help with defining probability of harm") do %>

--- a/prism/app/views/prism/tasks/add_a_harm_scenario_and_probability_of_harm.html.erb
+++ b/prism/app/views/prism/tasks/add_a_harm_scenario_and_probability_of_harm.html.erb
@@ -32,7 +32,7 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <p class="govuk-body"><a href="#" class="govuk-link govuk-link--no-visited-state" data-action="nested-form#add">Add another step</a></p>
       <h2 class="govuk-heading-m govuk-!-padding-top-4">Overall probability of harm</h2>
-      <p class="govuk-body-l"><%= overall_probability_of_harm[:probability_human] %></p>
+      <p class="govuk-body-l" id="overall-probability-of-harm"><%= overall_probability_of_harm.probability_human %></p>
       <%= f.govuk_submit "Save and continue" do %>
         <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
       <% end %>

--- a/prism/app/views/prism/tasks/add_uncertainty_and_sensitivity_analysis.html.erb
+++ b/prism/app/views/prism/tasks/add_uncertainty_and_sensitivity_analysis.html.erb
@@ -16,7 +16,7 @@
         <p class="govuk-body">Placeholder product</p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
-        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm[:probability_human] %></p>
+        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm.probability_human %></p>
         <p class="govuk-body">Severity of harm: <%= severity_of_harm %>, multiple casualties: <%= @harm_scenario.multiple_casualties ? "yes" : "no" %></p>
         <p class="govuk-body">Risk level: <%= overall_risk_level_tag %></p>
       <% end %>

--- a/prism/app/views/prism/tasks/determine_severity_of_harm.html.erb
+++ b/prism/app/views/prism/tasks/determine_severity_of_harm.html.erb
@@ -16,7 +16,7 @@
         <p class="govuk-body">Placeholder product</p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
-        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm[:probability_human] %></p>
+        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm.probability_human %></p>
       <% end %>
       <p class="govuk-body">Choose the level of severity of harm most appropriate for the product.</p>
       <%= f.govuk_collection_radio_buttons :severity, severity_radios, :id, :name, :description, legend: nil, bold_labels: false %>

--- a/prism/app/views/prism/tasks/determine_severity_of_harm_casualties.html.erb
+++ b/prism/app/views/prism/tasks/determine_severity_of_harm_casualties.html.erb
@@ -16,7 +16,7 @@
         <p class="govuk-body">Placeholder product</p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
-        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm[:probability_human] %></p>
+        <p class="govuk-body">Overall probability of harm: <%= overall_probability_of_harm.probability_human %></p>
         <p class="govuk-body">Severity of harm: <%= severity_of_harm %></p>
       <% end %>
       <%=

--- a/prism/config/routes.rb
+++ b/prism/config/routes.rb
@@ -27,4 +27,8 @@ Prism::Engine.routes.draw do
       end
     end
   end
+
+  scope "/api" do
+    get "overall-probability-of-harm", to: "api#overall_probability_of_harm"
+  end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1658

## Description

Changes the overall probability of harm on the harm scenarios page to update dynamically as the user changes intermediate probabilities.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
