### PR TITLE
Authorised representative businesses - PSD-1617

### DIFF
--- a/app/controllers/investigations/business_types_controller.rb
+++ b/app/controllers/investigations/business_types_controller.rb
@@ -26,6 +26,6 @@ private
   end
 
   def business_request_params
-    params.require(:set_business_type_on_case_form).permit(:type, :online_marketplace_id, :other_marketplace_name)
+    params.require(:set_business_type_on_case_form).permit(:type, :online_marketplace_id, :other_marketplace_name, :authorised_representative_choice)
   end
 end

--- a/app/controllers/investigations/businesses_controller.rb
+++ b/app/controllers/investigations/businesses_controller.rb
@@ -24,6 +24,7 @@ class Investigations::BusinessesController < Investigations::BaseController
         relationship: session[:business_type],
         online_marketplace_id: session[:online_marketplace_id],
         other_marketplace_name: session[:other_marketplace_name],
+        authorised_representative_choice: session[:authorised_representative_choice],
       )
     )
 
@@ -36,6 +37,7 @@ class Investigations::BusinessesController < Investigations::BaseController
           relationship: @business_form.relationship,
           online_marketplace: @business_form.online_marketplace,
           other_marketplace_name: @business_form.other_marketplace_name,
+          authorised_representative_choice: @business_form.authorised_representative_choice,
           investigation: @investigation,
           user: current_user
         )

--- a/app/decorators/investigation_business_decorator.rb
+++ b/app/decorators/investigation_business_decorator.rb
@@ -2,6 +2,6 @@ class InvestigationBusinessDecorator < ApplicationDecorator
   delegate_all
 
   def pretty_relationship
-    I18n.t(".business.type.#{relationship}", default: relationship.capitalize)
+    I18n.t(".business.type.#{relationship}", default: relationship.capitalize).humanize
   end
 end

--- a/app/decorators/investigation_business_decorator.rb
+++ b/app/decorators/investigation_business_decorator.rb
@@ -2,6 +2,18 @@ class InvestigationBusinessDecorator < ApplicationDecorator
   delegate_all
 
   def pretty_relationship
-    I18n.t(".business.type.#{relationship}", default: relationship.capitalize).humanize
+    return authorised_representative_relationship if relationship == "authorised_representative"
+
+    business_type_relationship
+  end
+
+private
+
+  def business_type_relationship
+    I18n.t("business.type.#{relationship}", default: relationship.capitalize)
+  end
+
+  def authorised_representative_relationship
+    I18n.t("business.type.authorised_reprsentative.#{authorised_representative_choice}", default: authorised_representative_choice.capitalize)
   end
 end

--- a/app/decorators/investigation_business_decorator.rb
+++ b/app/decorators/investigation_business_decorator.rb
@@ -14,6 +14,6 @@ private
   end
 
   def authorised_representative_relationship
-    I18n.t("business.type.authorised_reprsentative.#{authorised_representative_choice}", default: authorised_representative_choice.capitalize)
+    I18n.t("business.type.authorised_reprsentative.#{authorised_representative_choice}")
   end
 end

--- a/app/forms/add_business_to_case_form.rb
+++ b/app/forms/add_business_to_case_form.rb
@@ -11,6 +11,7 @@ class AddBusinessToCaseForm
   attribute :relationship, default: ""
   attribute :online_marketplace_id
   attribute :other_marketplace_name
+  attribute :authorised_representative_choice
 
   attribute :locations, default: []
   attribute :contacts, default: []

--- a/app/forms/set_business_type_on_case_form.rb
+++ b/app/forms/set_business_type_on_case_form.rb
@@ -6,13 +6,15 @@ class SetBusinessTypeOnCaseForm
   attribute :type
   attribute :online_marketplace_id
   attribute :other_marketplace_name
+  attribute :authorised_representative_choice
 
   BUSINESS_TYPES = %w[
-    retailer online_seller online_marketplace manufacturer exporter importer fulfillment_house distributor
+    retailer online_seller online_marketplace manufacturer exporter importer fulfillment_house distributor authorised_representative
   ].freeze
 
   validates_inclusion_of :type, in: BUSINESS_TYPES
   validates :online_marketplace_id, presence: true, if: -> { is_approved_online_marketplace? }
+  validates :authorised_representative_choice, presence: true, if: -> { is_authorised_representative? }
 
   def set_params_on_session(session)
     session[:business_type] = type
@@ -30,6 +32,10 @@ class SetBusinessTypeOnCaseForm
   end
 
 private
+
+  def is_authorised_representative?
+    type == "authorised_representative"
+  end
 
   def is_approved_online_marketplace?
     type == "online_marketplace" && other_marketplace_name.blank?

--- a/app/forms/set_business_type_on_case_form.rb
+++ b/app/forms/set_business_type_on_case_form.rb
@@ -22,6 +22,8 @@ class SetBusinessTypeOnCaseForm
       session[:online_marketplace_id] = online_marketplace_id
     elsif is_other_online_marketplace?
       session[:other_marketplace_name] = other_marketplace_name
+    elsif is_authorised_representative?
+      session[:authorised_representative_choice] = authorised_representative_choice
     end
   end
 
@@ -29,6 +31,7 @@ class SetBusinessTypeOnCaseForm
     session.delete(:business_type)
     session.delete(:online_marketplace_id)
     session.delete(:other_marketplace_name)
+    session.delete(:authorised_representative_choice)
   end
 
 private

--- a/app/services/add_business_to_case.rb
+++ b/app/services/add_business_to_case.rb
@@ -2,7 +2,7 @@ class AddBusinessToCase
   include Interactor
   include EntitiesToNotify
 
-  delegate :investigation, :user, :relationship, :business, :skip_email, :online_marketplace, :other_marketplace_name, to: :context
+  delegate :investigation, :user, :relationship, :business, :skip_email, :online_marketplace, :other_marketplace_name, :authorised_representative_choice, to: :context
 
   def call
     context.fail!(error: "No business supplied")      unless business.is_a?(Business)
@@ -13,7 +13,7 @@ class AddBusinessToCase
 
     Business.transaction do
       business.primary_location&.assign_attributes(name: "Registered office address", added_by_user: user)
-      investigation_business = business.investigation_businesses.build(investigation:, relationship:, online_marketplace:)
+      investigation_business = business.investigation_businesses.build(investigation:, relationship:, online_marketplace:, authorised_representative_choice:)
       business.save!
 
       send_notification_email(

--- a/app/views/investigations/business_types/new.html.erb
+++ b/app/views/investigations/business_types/new.html.erb
@@ -50,6 +50,25 @@
             <%= form.govuk_input :other_marketplace_name, label: t(".types.other.label"), classes: "js-input-handle-other" %>
           <% end %>
 
+          <% authorised_representative_radios = capture do %>
+            <div class="govuk-form-group <%= class_names("govuk-form-group--error") if @business_type_form&.errors[:authorised_representative_choice].present? %>">
+              <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                  <div class="govuk-radios govuk-radios--small">
+                    <div class="govuk-radios__item">
+                      <%= form.radio_button :authorised_representative_choice, t(".types.authorised_representative.uk.value"), class: "govuk-radios__input" %>
+                      <%= form.label :authorised_representative_choice, t(".types.authorised_representative.uk.label"), value: t(".types.authorised_representative.uk.value"), class: "govuk-label govuk-radios__label" %>
+                    </div>
+                    <div class="govuk-radios__item">
+                      <%= form.radio_button :authorised_representative_choice, t(".types.authorised_representative.eu.value"), class: "govuk-radios__input" %>
+                      <%= form.label :authorised_representative_choice, t(".types.authorised_representative.eu.label"), value: t(".types.authorised_representative.eu.value"), class: "govuk-label govuk-radios__label" %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
           <% radio_items = [
             { value: "retailer", text: t(".types.retailer.label"), hint: { text: t(".types.retailer.hint") } },
             { value: "online_seller", text: t(".types.online_seller.label"), hint: { text: t(".types.online_seller.hint") } },
@@ -58,9 +77,9 @@
             { value: "exporter", text: t(".types.exporter.label") },
             { value: "importer", text: t(".types.importer.label") },
             { value: "fulfillment_house", text: t(".types.fulfillment_house.label") },
-            { value: "distributor", text: t(".types.distributor.label") }
-
-            ] %>
+            { value: "distributor", text: t(".types.distributor.label") },
+            { value: "authorised_representative", text: t(".types.authorised_representative.label"), conditional: { html: authorised_representative_radios }},
+          ] %>
 
           <%= form.govuk_radios :type,
             legend: "",

--- a/app/views/investigations/tabs/_businesses.html.erb
+++ b/app/views/investigations/tabs/_businesses.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% @investigation.businesses.each_with_index do |business, index| %>
-  <% investigation_business = @investigation.investigation_businesses.find_by(business_id: business.id) %>
+  <% investigation_business = @investigation.investigation_businesses.find_by(business_id: business.id).decorate %>
 <section id="<%= business.trading_name.parameterize %>" class="govuk-!-margin-bottom-9">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
@@ -35,7 +35,7 @@
         Business type
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= investigation_business.relationship&.humanize %>
+        <%= investigation_business.pretty_relationship %>
       </dd>
     </div>
     <div class="govuk-summary-list__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,14 @@ en:
           online_marketplace:
             label: Online marketplace
             hint: Online platforms whose primary business is connecting traders and consumers and hosting third party sellers/sales.
+          authorised_representative:
+            label: Authorised representative
+            uk:
+              label: UK Authorised representative
+              value: uk_authorised_representative
+            eu:
+              label: EU Authorised representative
+              value: eu_authorised_representative
           manufacturer:
             label: Manufacturer
           exporter:
@@ -438,6 +446,9 @@ en:
             online_marketplace_id:
               blank: Select an online marketplace
               inclusion: Select an online marketplace
+            authorised_representative_choice:
+              blank: Select an authorised representative region
+              inclusion: Select an authorised representative region
 
         remove_business_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -908,3 +908,6 @@ en:
       fulfillment_house: "Fulfillment house"
       distributor: "Distributor"
       other: "Other"
+      authorised_reprsentative:
+        uk_authorised_representative: "UK Authorised representative"
+        eu_authorised_representative: "EU Authorised representative"

--- a/db/migrate/20230721141131_add_authorised_representative_choice_to_investigation_businesses.rb
+++ b/db/migrate/20230721141131_add_authorised_representative_choice_to_investigation_businesses.rb
@@ -1,0 +1,5 @@
+class AddAuthorisedRepresentativeChoiceToInvestigationBusinesses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :investigation_businesses, :authorised_representative_choice, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,6 +201,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_144332) do
   end
 
   create_table "investigation_businesses", id: :serial, force: :cascade do |t|
+    t.string "authorised_representative_choice"
     t.integer "business_id"
     t.datetime "created_at", precision: nil, null: false
     t.integer "investigation_id"

--- a/spec/decorators/investigation_business_decorator_spec.rb
+++ b/spec/decorators/investigation_business_decorator_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe InvestigationBusinessDecorator, :with_stubbed_opensearch, :with_stubbed_mailer do
+  subject(:decorated_object) { investigation_business.decorate }
+
+  let(:investigation) { create(:allegation, creator: user) }
+  let(:business) { create(:business) }
+  let(:investigation_business) { create(:investigation_business, investigation:, business:) }
+  let(:relationship) { "manufacturer" }
+  let(:user) { create(:user, :opss_user) }
+
+  before do
+    allow(helper).to receive(:current_user).and_return(user)
+  end
+
+  describe "#pretty_relationship" do
+    let(:investigation_business) { create(:investigation_business, investigation:, business:, relationship:) }
+
+    context "when the relationship is 'manufacturer'" do
+      let(:relationship) { "manufacturer" }
+
+      it "returns the pretty relationship" do
+        expect(decorated_object.pretty_relationship).to eq("Manufacturer")
+      end
+    end
+
+    context "when the relationship is 'distributor'" do
+      let(:relationship) { "distributor" }
+
+      it "returns the pretty relationship" do
+        expect(decorated_object.pretty_relationship).to eq("Distributor")
+      end
+    end
+
+    context "with relationship of authorised_represenative" do
+      let(:relationship) { "authorised_representative" }
+      let(:investigation_business) { create(:investigation_business, investigation:, business:, relationship:, authorised_representative_choice:) }
+
+      context 'when the authorised representative choice is "UK authorisation representative"' do
+        let(:authorised_representative_choice) { "uk_authorised_representative" }
+
+        it "returns the UK string" do
+          expect(decorated_object.pretty_relationship).to eq("UK Authorised representative")
+        end
+      end
+
+      context 'when the authorised representative choice is "EU authorisation representative"' do
+        let(:authorised_representative_choice) { "eu_authorised_representative" }
+
+        it "returns the EU string" do
+          expect(decorated_object.pretty_relationship).to eq("EU Authorised representative")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/add_business_to_a_case_spec.rb
+++ b/spec/features/add_business_to_a_case_spec.rb
@@ -233,15 +233,6 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
       expect(page.find("dt", text: "Trading name")).to have_sibling("dd", text: trading_name)
       expect(page.find("dt", text: "Business type")).to have_sibling("dd", text: "EU Authorised representative")
     end
-
-    # Check that adding  the business was recorded in the
-    # activity log for the investigation.
-    click_link "Activity"
-    expect(page).to have_text("Business added")
-    expect_to_have_case_breadcrumbs
-
-    expect(page.find("h3", text: "Business added"))
-      .to have_sibling(".govuk-body", text: "Role: eu_authorised_representative")
   end
 
   scenario "Adding an 'other' online marketplace business" do

--- a/spec/features/add_business_to_a_case_spec.rb
+++ b/spec/features/add_business_to_a_case_spec.rb
@@ -139,6 +139,7 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
     expect(page).to have_unchecked_field("Online marketplace")
     expect(page).to have_unchecked_field("Fulfillment house")
     expect(page).to have_unchecked_field("Distributor")
+    expect(page).to have_unchecked_field("Authorised representative")
 
     choose "Online marketplace"
     expect(page).to have_unchecked_field(marketplace_1.name)
@@ -178,6 +179,69 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
 
     expect(page.find("h3", text: "Business added"))
       .to have_sibling(".govuk-body", text: "Role: online_marketplace")
+  end
+
+  scenario "Adding a EU authorised rep business" do
+    sign_in user
+    visit "/cases/#{investigation.pretty_id}/businesses"
+
+    click_link "Add business"
+    expect_to_have_case_breadcrumbs
+
+    # Don't select a business type
+    click_on "Continue"
+
+    expect_to_be_on_investigation_add_business_type_page
+    expect_to_have_case_breadcrumbs
+    expect(page).to have_error_summary("Select a business type")
+
+    expect(page).to have_unchecked_field("Retailer")
+    expect(page).to have_unchecked_field("Manufacturer")
+    expect(page).to have_unchecked_field("Exporter")
+    expect(page).to have_unchecked_field("Importer")
+    expect(page).to have_unchecked_field("Online seller")
+    expect(page).to have_unchecked_field("Online marketplace")
+    expect(page).to have_unchecked_field("Fulfillment house")
+    expect(page).to have_unchecked_field("Distributor")
+    expect(page).to have_unchecked_field("Authorised representative")
+
+    choose "Authorised representative"
+    expect(page).to have_unchecked_field("UK Authorised representative")
+    expect(page).to have_unchecked_field("EU Authorised representative")
+    choose "EU Authorised representative"
+
+    click_on "Continue"
+
+    expect_to_be_on_investigation_add_business_details_page
+    expect_to_have_case_breadcrumbs
+
+    within_fieldset "Name and company number" do
+      fill_in "Trading name", with: trading_name
+    end
+
+    within_fieldset "Official address" do
+      select "France", from: "Country"
+    end
+
+    click_on "Save"
+
+    expect_to_be_on_investigation_businesses_page
+    expect(page).not_to have_error_messages
+    expect_to_have_case_breadcrumbs
+
+    within("section##{trading_name.parameterize}") do
+      expect(page.find("dt", text: "Trading name")).to have_sibling("dd", text: trading_name)
+      expect(page.find("dt", text: "Business type")).to have_sibling("dd", text: "EU Authorised representative")
+    end
+
+    # Check that adding  the business was recorded in the
+    # activity log for the investigation.
+    click_link "Activity"
+    expect(page).to have_text("Business added")
+    expect_to_have_case_breadcrumbs
+
+    expect(page.find("h3", text: "Business added"))
+      .to have_sibling(".govuk-body", text: "Role: eu_authorised_representative")
   end
 
   scenario "Adding an 'other' online marketplace business" do

--- a/spec/forms/set_business_type_on_case_form_spec.rb
+++ b/spec/forms/set_business_type_on_case_form_spec.rb
@@ -68,6 +68,30 @@ RSpec.describe SetBusinessTypeOnCaseForm, type: :model do
         end
       end
     end
+
+    context "when type is authorised_representative" do
+      let(:type) { "authorised_representative" }
+      let(:authorised_representative_choice) { "eu" }
+      let(:params) do
+        {
+          type:,
+          authorised_representative_choice:,
+        }
+      end
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      context "when authorised_representative_choice is missing" do
+        let(:authorised_representative_choice) { nil }
+
+        it "is invalid with an invalid authorised_representative_choice" do
+          expect(form).not_to be_valid
+          expect(form.errors[:authorised_representative_choice]).to include("Select an authorised representative region")
+        end
+      end
+    end
   end
 
   describe "#set_params_on_session" do

--- a/spec/services/add_business_to_case_spec.rb
+++ b/spec/services/add_business_to_case_spec.rb
@@ -105,7 +105,34 @@ RSpec.describe AddBusinessToCase, :with_stubbed_opensearch, :with_test_queue_ada
       expect(Business.last.investigation_businesses.find_by!(investigation:).online_marketplace).to eq(online_marketplace)
     end
 
-    it "creates and audit log", :aggregate_failures do
+    it "creates an audit log", :aggregate_failures do
+      result
+
+      business = Business.last
+      activity = investigation.reload.activities.find_by!(type: AuditActivity::Business::Add.name)
+      expect(activity).to have_attributes(title: nil, body: nil, business_id: business.id, metadata: { "business" => JSON.parse(business.attributes.to_json), "investigation_business" => JSON.parse(business.investigation_businesses.find_by!(investigation:).attributes.to_json) })
+      expect(activity.added_by_user).to eq(user)
+    end
+
+    it_behaves_like "a service which notifies the case owner"
+  end
+
+  context "with a choice for authorised_representative" do
+    subject(:result) { described_class.call(investigation:, business:, user:, authorised_representative_choice:) }
+
+    let(:authorised_representative_choice) { "EU Authorised representative" }
+
+    it "saves the the businesses" do
+      expect { result }.to change(investigation.businesses, :count).from(0).to(1)
+    end
+
+    it "sets the authorised_representative_choice on investigation_business" do
+      result
+
+      expect(Business.last.investigation_businesses.find_by!(investigation:).authorised_representative_choice).to eq("EU Authorised representative")
+    end
+
+    it "creates an audit log", :aggregate_failures do
       result
 
       business = Business.last


### PR DESCRIPTION

https://regulatorydelivery.atlassian.net/browse/PSD-1617


## Description
Adds new business type 'authorised representative', and provides UK & EU options.

## Screen-shots or screen-capture of UI changes

<img width="757" alt="CleanShot 2023-07-26 at 17 18 38@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/4eb1c57d-dadf-411d-a4e4-e9d6749657d0">
<img width="767" alt="CleanShot 2023-07-26 at 17 18 45@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/c87fcc72-0bd5-418c-b798-7a895b3abf36">
<img width="772" alt="CleanShot 2023-07-26 at 17 20 15@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/2dbb4550-a5fb-4596-8756-1a9608e6e70f">
