### PR TITLE
HOTFIX - Whitelist businessandtrade.gov.uk email domain

### DIFF
--- a/config/constants/whitelisted_emails.yml
+++ b/config/constants/whitelisted_emails.yml
@@ -25,6 +25,7 @@ email_domains:
   - "bristol.gov.uk"
   - "bromley.gov.uk"
   - "bury.gov.uk"
+  - "businessandtrade.gov.uk"
   - "caerphilly.gov.uk"
   - "cambridgeshire.gov.uk"
   - "camden.gov.uk"


### PR DESCRIPTION
Adds `businessandtrade.gov.uk` to email domain whitelist

Ready for emails starting to transition early next week 