### PR TITLE
PSD-1799 - Whitelist new businessandtrade.gov.uk email domain

### DIFF
--- a/config/constants/whitelisted_emails.yml
+++ b/config/constants/whitelisted_emails.yml
@@ -25,6 +25,7 @@ email_domains:
   - "bristol.gov.uk"
   - "bromley.gov.uk"
   - "bury.gov.uk"
+  - "businessandtrade.gov.uk"
   - "caerphilly.gov.uk"
   - "cambridgeshire.gov.uk"
   - "camden.gov.uk"


### PR DESCRIPTION
Cherry-pick & merge hotfix into develop