### PR TITLE
PSD-1795 - Migrate cases to new "Electromagnetic disturbance" hazard

### DIFF
--- a/config/constants/hazard_constants.yml
+++ b/config/constants/hazard_constants.yml
@@ -7,10 +7,9 @@ hazard_type:
   - Cuts
   - Damage to hearing
   - Damage to sight
-  - Disturbance
   - Drowning
   - Electric shock
-  - Electromagnetic
+  - Electromagnetic disturbance
   - Energy consumption
   - Entrapment
   - Environment

--- a/db/migrate/20230731094750_migrate_electromagnetic_disturbance_hazards.rb
+++ b/db/migrate/20230731094750_migrate_electromagnetic_disturbance_hazards.rb
@@ -1,0 +1,6 @@
+class MigrateElectromagneticDisturbanceHazards < ActiveRecord::Migration[7.0]
+  def change
+    Investigation.where(hazard_type: "Electromagnetic").update_all(hazard_type: "Electromagnetic disturbance")
+    Investigation.where(hazard_type: "Disturbance").update_all(hazard_type: "Electromagnetic disturbance")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_144332) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_31_094750) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1795

## Description

- Migrates all cases with 'Electromagnetic' or 'Disturbance' to just 'Electromagnetic disturbance' 
- Remove the old two options & replaces with the newer one for future cases