### PR TITLE
PSD-1599 - Blank product country of origin is labelled as unknown

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -95,8 +95,8 @@ module ProductsHelper
 
   def items_for_authenticity(product_form)
     items = [
-      { text: "Yes",    value: "counterfeit" },
-      { text: "No",     value: "genuine" }
+      { text: "Yes", value: "counterfeit" },
+      { text: "No", value: "genuine" }
     ]
 
     return items if product_form.authenticity.blank?
@@ -106,8 +106,8 @@ module ProductsHelper
 
   def items_for_before_2021_radio(product_form)
     items = [
-      { text: "Yes",    value: "before_2021" },
-      { text: "No",     value: "on_or_after_2021" },
+      { text: "Yes", value: "before_2021" },
+      { text: "No", value: "on_or_after_2021" },
       { text: "Unable to ascertain", value: "unknown_date" }
     ]
     return items if product_form.when_placed_on_market.blank?
@@ -116,12 +116,14 @@ module ProductsHelper
   end
 
   def options_for_country_of_origin(countries, product_form)
-    countries.map do |country|
+    options = [{ text: "Unknown", value: nil }]
+    options << countries.map do |country|
       text = country[0]
       option = { text:, value: country[1] }
       option[:selected] = true if product_form.country_of_origin == text
       option
     end
+    options.flatten
   end
 
 private

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -107,7 +107,6 @@
   form: form,
   key: :country_of_origin,
   items: options_for_country_of_origin(countries, product_form),
-  include_blank: true,
   label: { text: "Country of origin", classes: label_class },
   hint: { text: "Where the product was manufactured" }
 ) %>

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -6,10 +6,12 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
   end
 
-  scenario "Adding a product" do
+  before do
     sign_in user
     visit "/products/new"
+  end
 
+  scenario "Adding a product" do
     fill_in "Barcode number (GTIN, EAN or UPC)", with: "invalid"
 
     click_button "Save"
@@ -85,5 +87,41 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     expect(page).to have_summary_item(key: "Country of origin", value: attributes[:country])
     expect(page).to have_summary_item(key: "Description", value: attributes[:description])
     expect(page).to have_summary_item(key: "Market date", value: "#{I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key)} Placed on the market")
+  end
+
+  scenario "Adding a product with unknown origin" do
+    select attributes[:category], from: "Product category"
+    fill_in "Product subcategory", with: attributes[:subcategory]
+    fill_in "Manufacturer's brand name", with: attributes[:brand]
+    fill_in "Product name", with: attributes[:name]
+    fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
+    fill_in "Other product identifiers", with: attributes[:product_code]
+    fill_in "Webpage", with: attributes[:webpage]
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
+    within_fieldset("Is the product counterfeit?") do
+      choose counterfeit_answer(attributes[:authenticity])
+    end
+
+    within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
+      page.find("input[value='#{attributes[:has_markings]}']").choose
+    end
+
+    within_fieldset("Select product marking") do
+      attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
+    end
+
+    fill_in "Description of product", with: attributes[:description]
+    click_on "Save"
+
+    expect(page).to have_current_path("/products")
+    expect(page).not_to have_error_messages
+    expect(page).to have_selector("h1", text: "Product record created")
+
+    click_on "View the product record"
+    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
   end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1599

## Description
Changes the blank 'country of origin' in the product form to 'Unknown', is the form default so not selecting any country will now be consistently worded 

## Screen-shots or screen-capture of UI changes

<img width="517" alt="CleanShot 2023-08-23 at 12 31 04@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/d0542180-4443-49cd-ab62-6765706e392f">
<img width="429" alt="CleanShot 2023-08-23 at 12 30 57@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/aba40b84-d9f7-45e7-9115-0f34b3c46231">
