### PR TITLE
Prevent users making products with a blank country origin - PSD-1599

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -33,6 +33,7 @@ class ProductForm
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :name, presence: true
+  validates :country_of_origin, presence: true
   validates :when_placed_on_market, presence: true
   validates :description, length: { maximum: 10_000 }
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -116,7 +116,7 @@ module ProductsHelper
   end
 
   def options_for_country_of_origin(countries, product_form)
-    options = [{ text: "Unknown", value: nil }]
+    options = [{ text: "Unknown", value: "Unknown" }]
     options << countries.map do |country|
       text = country[0]
       option = { text:, value: country[1] }

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -106,7 +106,9 @@
 <%= govukSelect(
   form: form,
   key: :country_of_origin,
+  id: "country_of_origin",
   items: options_for_country_of_origin(countries, product_form),
+  include_blank: true,
   label: { text: "Country of origin", classes: label_class },
   hint: { text: "Where the product was manufactured" }
 ) %>

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }
     when_placed_on_market { "before_2021" }
+    country_of_origin { "United Kingdom" }
 
     trait :with_versions do
       transient do

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     expect(errors_list[4].text).to eq "Name cannot be blank"
     expect(errors_list[5].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
     expect(errors_list[6].text).to eq "Enter a valid barcode number"
+    expect(errors_list[7].text).to eq "Country of origin cannot be blank"
 
     select attributes[:category], from: "Product category"
 
@@ -89,6 +90,50 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     expect(page).to have_summary_item(key: "Market date", value: "#{I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key)} Placed on the market")
   end
 
+  scenario "Adding a product with blank origin, it asserts validations" do
+    select attributes[:category], from: "Product category"
+    fill_in "Product subcategory", with: attributes[:subcategory]
+    fill_in "Manufacturer's brand name", with: attributes[:brand]
+    fill_in "Product name", with: attributes[:name]
+    fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
+    fill_in "Other product identifiers", with: attributes[:product_code]
+    fill_in "Webpage", with: attributes[:webpage]
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
+    within_fieldset("Is the product counterfeit?") do
+      choose counterfeit_answer(attributes[:authenticity])
+    end
+
+    within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
+      page.find("input[value='#{attributes[:has_markings]}']").choose
+    end
+
+    within_fieldset("Select product marking") do
+      attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
+    end
+
+    fill_in "Description of product", with: attributes[:description]
+    click_on "Save"
+
+    # Expected validation errors
+    expect(page).to have_error_messages
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Country of origin cannot be blank"
+
+    select attributes[:country_of_origin], from: "Country of origin"
+
+    click_on "Save"
+    expect(page).to have_current_path("/products")
+    expect(page).not_to have_error_messages
+    expect(page).to have_selector("h1", text: "Product record created")
+
+    click_on "View the product record"
+    expect(page).to have_summary_item(key: "Country of origin", value: attributes[:country])
+  end
+
   scenario "Adding a product with unknown origin" do
     select attributes[:category], from: "Product category"
     fill_in "Product subcategory", with: attributes[:subcategory]
@@ -113,6 +158,8 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_opensearch
     within_fieldset("Select product marking") do
       attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
     end
+
+    select "Unknown", from: "Country of origin"
 
     fill_in "Description of product", with: attributes[:description]
     click_on "Save"

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe ProductForm do
 
   let(:attributes) { attributes_for(:product) }
 
+  describe "country_of_origin validation" do
+    before { form.country_of_origin = "" }
+
+    it "is invalid", :aggregate_failures do
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages_for(:country_of_origin)).to eq ["Country of origin cannot be blank"]
+    end
+  end
+
   describe "brand validation" do
     context "when setting an empty string" do
       before { form.brand = " " }


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1599

## Description
Further work for this ticket - the blank option should have been asserted as invalid, forcing the user to choose a country of origin. This is because this field is now a requirement for the minimum data set for reporting & escalation.

'Unknown' is now the first option in the list, but not default 

## Screen-shots or screen-capture of UI changes

<img width="588" alt="CleanShot 2023-08-31 at 12 10 00@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/d03155d8-38ad-4200-b40a-eaf48e5c467e">
<img width="687" alt="CleanShot 2023-08-31 at 12 10 05@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/db6b6849-85c7-4945-a64e-4243ba2993cc">


