### PR TITLE
Fix duplicate image tag - PSD-1737

### DIFF
--- a/app/views/products/duplicate_checks/show.html.erb
+++ b/app/views/products/duplicate_checks/show.html.erb
@@ -55,7 +55,7 @@
                       </span>
                     </summary>
                       <div class="govuk-details__text">
-                        <%= image_tag(@image.file_upload, alt: image.title, class: 'opss-details-img') %>
+                        <%= image_tag(@image.file_upload, alt: @image.title, class: 'opss-details-img') %>
                       </div>
                   </details>
                 <% end %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1737

## Description
[For this error in Sentry](https://beis.sentry.io/issues/4304941494/?environment=staging&query=is%3Aarchived&referrer=issue-stream&statsPeriod=24h&stream_index=0). 

A duplicate product without an image was never an issue - but when the product has a stored PSD image, it would throw an exception

To reproduce:

1. Add a product with a new barcode
2. Add a new case, add that product to the case
3. Edit the product, add an image
4. Try and add a new product, lookup with the same barcode
5. This new code works, on staging you currently get a 500 

## Screenshots
<img width="861" alt="CleanShot 2023-09-01 at 12 15 39@2x" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/e5b92424-781d-4e57-b0a7-0c3ba6b8f370">

https://psd-pr-2537.london.cloudapps.digital/products/11/duplicate-check
