### PR TITLE
PRISM: change order of triage pages

### DIFF
--- a/prism/app/controllers/prism/triage_controller.rb
+++ b/prism/app/controllers/prism/triage_controller.rb
@@ -1,25 +1,9 @@
 module Prism
   class TriageController < ApplicationController
-    skip_before_action :authenticate_user!, only: %i[index full_risk_assessment_required full_risk_assessment_required_choose perform_risk_triage]
-    before_action :set_prism_risk_assessment, only: %i[serious_risk_rebuttable serious_risk_rebuttable_choose]
+    skip_before_action :authenticate_user!
+    before_action :prism_risk_assessment, except: %i[index serious_risk serious_risk_choose perform_risk_triage]
 
     def index; end
-
-    def full_risk_assessment_required
-      @form_model = Prism::Form::FullRiskAssessmentRequired.new
-    end
-
-    def full_risk_assessment_required_choose
-      @form_model = Prism::Form::FullRiskAssessmentRequired.new(full_risk_assessment_required_params)
-
-      return render :full_risk_assessment_required unless @form_model.valid?
-
-      if full_risk_assessment_required_params[:full_risk_assessment_required] == "false"
-        redirect_to perform_risk_triage_path
-      else
-        redirect_to serious_risk_path
-      end
-    end
 
     def serious_risk
       @prism_risk_assessment = Prism::RiskAssessment.new
@@ -27,13 +11,12 @@ module Prism
 
     def serious_risk_choose
       @prism_risk_assessment = Prism::RiskAssessment.new(serious_risk_params)
-      @prism_risk_assessment.created_by_user_id = current_user.id
 
       if @prism_risk_assessment.save(context: :serious_risk)
         if @prism_risk_assessment.serious_risk?
           redirect_to serious_risk_rebuttable_path(@prism_risk_assessment)
         else
-          redirect_to risk_assessment_tasks_path(@prism_risk_assessment)
+          redirect_to full_risk_assessment_required_path(@prism_risk_assessment)
         end
       else
         render :serious_risk
@@ -46,9 +29,29 @@ module Prism
       @prism_risk_assessment.assign_attributes(serious_risk_rebuttable_params)
 
       if @prism_risk_assessment.save(context: :serious_risk_rebuttable)
-        redirect_to risk_assessment_tasks_path(@prism_risk_assessment)
+        if @prism_risk_assessment.less_than_serious_risk?
+          redirect_to full_risk_assessment_required_path(@prism_risk_assessment)
+        else
+          redirect_to risk_assessment_tasks_path(@prism_risk_assessment)
+        end
       else
         render :serious_risk_rebuttable
+      end
+    end
+
+    def full_risk_assessment_required
+      @form_model = Prism::Form::FullRiskAssessmentRequired.new
+    end
+
+    def full_risk_assessment_required_choose
+      @form_model = Prism::Form::FullRiskAssessmentRequired.new(full_risk_assessment_required_params)
+
+      return render :full_risk_assessment_required unless @form_model.valid?
+
+      if full_risk_assessment_required_params[:full_risk_assessment_required] == "false"
+        redirect_to perform_risk_triage_path(@prism_risk_assessment)
+      else
+        redirect_to risk_assessment_tasks_path(@prism_risk_assessment)
       end
     end
 
@@ -56,12 +59,11 @@ module Prism
 
   private
 
-    def set_prism_risk_assessment
-      @prism_risk_assessment = Prism::RiskAssessment.find_by!(id: params[:id], created_by_user_id: current_user.id)
-    end
-
-    def full_risk_assessment_required_params
-      params.require(:form_full_risk_assessment_required).permit(:full_risk_assessment_required)
+    def prism_risk_assessment
+      # We can't set the user ID until the tasks list page since that's the first point at which
+      # authentication is enforced. We explicitly search for risk assessments without a user ID so
+      # triage cannot be re-entered once completed.
+      @prism_risk_assessment ||= Prism::RiskAssessment.find_by!(id: params[:id], created_by_user_id: nil)
     end
 
     def serious_risk_params
@@ -70,6 +72,10 @@ module Prism
 
     def serious_risk_rebuttable_params
       params.require(:risk_assessment).permit(:less_than_serious_risk, :serious_risk_rebuttable_factors)
+    end
+
+    def full_risk_assessment_required_params
+      params.require(:form_full_risk_assessment_required).permit(:full_risk_assessment_required)
     end
   end
 end

--- a/prism/app/views/prism/triage/full_risk_assessment_required.html.erb
+++ b/prism/app/views/prism/triage/full_risk_assessment_required.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Does the product require a full risk assessment?" %>
-<% @back_link_href = root_path %>
+<% @back_link_href = @prism_risk_assessment.less_than_serious_risk.present? ? serious_risk_rebuttable_path(@prism_risk_assessment) : serious_risk_path(@prism_risk_assessment) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/prism/app/views/prism/triage/index.html.erb
+++ b/prism/app/views/prism/triage/index.html.erb
@@ -8,7 +8,7 @@
     <p class="govuk-body">You can find the <abbr title="Product Safety Risk Assessment Methodology">PRISM</abbr> guide, case studies and statistical data sets to support your risk assessments on the <a href="https://www.gov.uk/guidance/product-safety-risk-assessment-methodology-prism" class="govuk-link" target="_blank" rel="noreferrer noopener">guidance page<span class="govuk-visually-hidden"> (opens in new tab)</span></a>. The explanation of <abbr title="Office for Product Safety and Standards">OPSS</abbr> terminology concerned with risk and risk-related matters can be found on the <a href="https://www.gov.uk/guidance/opss-risk-lexicon" class="govuk-link" target="_blank" rel="noreferrer noopener"><abbr title="Office for Product Safety and Standards">OPSS</abbr> risk lexicon page<span class="govuk-visually-hidden"> (opens in new tab)</span></a>.</p>
     <p class="govuk-body">Use this service to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><a href="<%= perform_risk_triage_path(back_to: "start_page") %>" class="govuk-link">Risk triage</a> to determine whether the product needs a full safety risk assessment.</li>
+      <li><a href="<%= perform_risk_triage_path %>" class="govuk-link">Risk triage</a> to determine whether the product needs a full safety risk assessment.</li>
       <li>Search for products on the Product Safety Database (PSD).</li>
       <li>Assess and evaluate the risk level of the non-food consumer product.</li>
       <li>Save and submit assessment results to the <abbr title="Product Safety Database">PSD</abbr>.</li>
@@ -23,6 +23,6 @@
       <li>Research studies, statistical data sets or other evidence showing the average probability of product hazard occurring.</li>
       <li>Risk assessments that have been undertaken previously for the product or closely related products.</li>
     </ul>
-    <%= govuk_start_button(text: "Start now", href: full_risk_assessment_required_path) %>
+    <%= govuk_start_button(text: "Start now", href: serious_risk_path) %>
   </div>
 </div>

--- a/prism/app/views/prism/triage/perform_risk_triage.html.erb
+++ b/prism/app/views/prism/triage/perform_risk_triage.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Perform risk triage" %>
-<% @back_link_href = params[:back_to] == "start_page" ? root_path : full_risk_assessment_required_path %>
+<% @back_link_href = params[:id].present? ? full_risk_assessment_required_path(params[:id]) : root_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/prism/app/views/prism/triage/serious_risk.html.erb
+++ b/prism/app/views/prism/triage/serious_risk.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Is the product likely to pose a serious risk that would justify exemption from a full risk assessment?" %>
-<% @back_link_href = full_risk_assessment_required_path %>
+<% @back_link_href = root_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/prism/config/routes.rb
+++ b/prism/config/routes.rb
@@ -2,16 +2,16 @@ Prism::Engine.routes.draw do
   root "triage#index"
 
   scope "/triage" do
-    get "full-risk-assessment-required", to: "triage#full_risk_assessment_required"
-    patch "full-risk-assessment-required", to: "triage#full_risk_assessment_required_choose"
-    put "full-risk-assessment-required", to: "triage#full_risk_assessment_required_choose"
     get "serious-risk", to: "triage#serious_risk"
     patch "serious-risk", to: "triage#serious_risk_choose"
     put "serious-risk", to: "triage#serious_risk_choose"
     get "serious-risk-rebuttable/:id", to: "triage#serious_risk_rebuttable", as: "serious_risk_rebuttable"
     patch "serious-risk-rebuttable/:id", to: "triage#serious_risk_rebuttable_choose"
     put "serious-risk-rebuttable/:id", to: "triage#serious_risk_rebuttable_choose"
-    get "perform-risk-triage", to: "triage#perform_risk_triage"
+    get "full-risk-assessment-required/:id", to: "triage#full_risk_assessment_required", as: "full_risk_assessment_required"
+    patch "full-risk-assessment-required/:id", to: "triage#full_risk_assessment_required_choose"
+    put "full-risk-assessment-required/:id", to: "triage#full_risk_assessment_required_choose"
+    get "perform-risk-triage(/:id)", to: "triage#perform_risk_triage", as: "perform_risk_triage"
   end
 
   resources :risk_assessment, path: "risk-assessment", only: [] do

--- a/spec/features/prism/tasks_spec.rb
+++ b/spec/features/prism/tasks_spec.rb
@@ -147,4 +147,20 @@ RSpec.feature "PRISM tasks", type: :feature do
       expect(page).to have_selector("#task-list-0-1-status", text: "Cannot start yet")
     end
   end
+
+  context "when signed in as a user without the PRISM role" do
+    let(:non_prism_user) { create(:user, :activated) }
+    let(:prism_risk_assessment) { create(:prism_risk_assessment, created_by_user_id: nil) }
+
+    before do
+      sign_out
+      sign_in non_prism_user
+    end
+
+    scenario "visiting the task list" do
+      visit prism.risk_assessment_tasks_path(prism_risk_assessment)
+
+      expect(page).to have_current_path("/403")
+    end
+  end
 end

--- a/spec/features/prism/triage_spec.rb
+++ b/spec/features/prism/triage_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "PRISM triage", type: :feature do
-  let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, created_by_user_id: user&.id) }
+  let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk) }
 
   scenario "visiting the start page" do
     visit prism.root_path
@@ -12,10 +12,65 @@ RSpec.feature "PRISM triage", type: :feature do
     expect(page).not_to have_link("Sign out")
   end
 
-  scenario "selecting the product requires a full risk assessment" do
-    visit prism.root_path
+  scenario "selecting that a product poses a serious risk" do
+    visit prism.serious_risk_path
 
-    click_link "Start now"
+    expect(page).to have_text("Is the product likely to pose a serious risk that would justify exemption from a full risk assessment?")
+
+    click_button "Continue"
+
+    expect(page).to have_text("Select whether the product poses a serious risk")
+
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
+  end
+
+  scenario "selecting that a product does not pose a serious risk" do
+    visit prism.serious_risk_path
+
+    expect(page).to have_text("Is the product likely to pose a serious risk that would justify exemption from a full risk assessment?")
+
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_text("Does the product require a full risk assessment?")
+  end
+
+  scenario "selecting that a product does have rebuttable factors to posing a serious risk" do
+    visit prism.serious_risk_rebuttable_path(prism_risk_assessment)
+
+    expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
+
+    click_button "Continue"
+
+    expect(page).to have_text("Select whether there are any factors")
+
+    choose "Yes"
+    click_button "Continue"
+
+    expect(page).to have_text("Enter a description")
+
+    fill_in "risk_assessment[serious_risk_rebuttable_factors]", with: "Lorem ipsum"
+    click_button "Continue"
+
+    expect(page).to have_text("Does the product require a full risk assessment?")
+  end
+
+  scenario "selecting that a product does not have rebuttable factors to posing a serious risk" do
+    visit prism.serious_risk_rebuttable_path(prism_risk_assessment)
+
+    expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
+
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_text("Sign in")
+  end
+
+  scenario "selecting the product requires a full risk assessment" do
+    visit prism.full_risk_assessment_required_path(prism_risk_assessment)
 
     expect(page).to have_text("Does the product require a full risk assessment?")
 
@@ -30,91 +85,11 @@ RSpec.feature "PRISM triage", type: :feature do
   end
 
   scenario "selecting the product may not require a full risk assessment" do
-    visit prism.root_path
+    visit prism.full_risk_assessment_required_path(prism_risk_assessment)
 
-    click_link "Start now"
     choose "Not clear"
     click_button "Continue"
 
     expect(page).to have_text("Perform risk triage")
-  end
-
-  context "when signed in as a user with the PRISM role" do
-    let(:user) { create(:user, :activated, roles: %w[prism]) }
-
-    before do
-      sign_in user
-    end
-
-    scenario "selecting that a product poses a serious risk" do
-      visit prism.serious_risk_path
-
-      expect(page).to have_text("Is the product likely to pose a serious risk that would justify exemption from a full risk assessment?")
-
-      click_button "Continue"
-
-      expect(page).to have_text("Select whether the product poses a serious risk")
-
-      choose "Yes"
-      click_button "Continue"
-
-      expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
-    end
-
-    scenario "selecting that a product does not post a serious risk" do
-      visit prism.serious_risk_path
-
-      expect(page).to have_text("Is the product likely to pose a serious risk that would justify exemption from a full risk assessment?")
-
-      choose "No"
-      click_button "Continue"
-
-      expect(page).to have_text("Determine and evaluate the level of product risk")
-    end
-
-    scenario "selecting that a product does have rebuttable factors to posing a serious risk" do
-      visit prism.serious_risk_rebuttable_path(prism_risk_assessment)
-
-      expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
-
-      click_button "Continue"
-
-      expect(page).to have_text("Select whether there are any factors")
-
-      choose "Yes"
-      click_button "Continue"
-
-      expect(page).to have_text("Enter a description")
-
-      fill_in "risk_assessment[serious_risk_rebuttable_factors]", with: "Lorem ipsum"
-      click_button "Continue"
-
-      expect(page).to have_text("Evaluate the product deemed serious risk")
-    end
-
-    scenario "selecting that a product does not have rebuttable factors to posing a serious risk" do
-      visit prism.serious_risk_rebuttable_path(prism_risk_assessment)
-
-      expect(page).to have_text("Are there any factors to indicate the product risk to be less than serious?")
-
-      choose "No"
-      click_button "Continue"
-
-      expect(page).to have_text("Evaluate the product deemed serious risk")
-    end
-  end
-
-  context "when signed in as a user without the PRISM role" do
-    let(:user) { create(:user, :activated) }
-
-    before do
-      sign_in user
-    end
-
-    scenario "visiting the start page" do
-      visit prism.root_path
-
-      expect(page).to have_current_path("/403")
-    end
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1846

## Description

Changes the ordering of the triage pages and only enforces authentication once the user reaches the task list.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
