### PR TITLE
Add product count to case index view - PSD-1855

### DIFF
--- a/app/views/investigations/_full_table_body.html.erb
+++ b/app/views/investigations/_full_table_body.html.erb
@@ -1,9 +1,9 @@
-<tbody class="govuk-table__body">
+<tbody class="govuk-table__body" data-cy-case-id="<%= investigation.pretty_id %>">
   <tr class="govuk-table__row">
     <th class="govuk-visually-hidden">
       Case title
     </th>
-    <th id="<%= dom_id investigation, :item %>" colspan="4" scope="colgroup" class="govuk-table__header">
+    <th id="<%= dom_id investigation, :item %>" colspan="5" scope="colgroup" class="govuk-table__header">
       <%= link_to investigation.title, investigation_path(investigation), class: "govuk-link govuk-link--no-visited-state" %>
     </th>
   </tr>
@@ -32,6 +32,9 @@
         <%= investigation.hazard_type %>
       </td>
     <% end %>
+    <td headers="product_count" class="govuk-table__cell">
+      <%= pluralize investigation.products.count, "product" %>
+    </td>
     <% if sorted_by == SortByHelper::SORT_BY_CREATED_AT %>
       <td headers="created <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
         <%= "#{time_ago_in_words(investigation.created_at)} ago" %>

--- a/app/views/investigations/_status_table_row.html.erb
+++ b/app/views/investigations/_status_table_row.html.erb
@@ -25,7 +25,7 @@
   <th headers="<%= dom_id investigation, :item %>" id="<%= dom_id investigation, :status %>" class="govuk-visually-hidden">
     Type
   </th>
-  <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="4" class="govuk-table__cell">
+  <td headers="<%= dom_id investigation, :item %> <%= dom_id investigation, :status %>" colspan="5" class="govuk-table__cell">
     <%= tag.span investigation.case_type.upcase_first, class: class_names("opss-tag", "opss-tag--std", investigation.is_closed? && "opss-cross-through") unless investigation.case_type.blank? %>
     <% if investigation.products.count.zero? && ["team_cases", "your_cases"].include?(@page_name) %>
       <span class="govuk-visually-hidden"> | </span>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -42,6 +42,9 @@
                   <% else %>
                     <th id="haztype" scope="col" class="govuk-table__header">Hazard type</th>
                   <% end %>
+
+                  <th scope="col" class="govuk-table__header">Product count</th>
+
                   <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && non_search_cases_page_names.exclude?(@page_name) %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
@@ -68,6 +71,8 @@
                     <% else %>
                       <th scope="col" class="govuk-table__header">Hazard type</th>
                     <% end %>
+
+                    <th scope="col" class="govuk-table__header">Product count</th>
 
                     <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && non_search_cases_page_names.exclude?(@page_name) %>
                       <th scope="col" class="govuk-table__header">Created</th>

--- a/spec/features/add_product_to_case_spec.rb
+++ b/spec/features/add_product_to_case_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Adding a product to a case", :with_stubbed_mailer, :with_stubbed_
   let(:other_user)    { create(:user, :activated) }
   let(:right_product) { create(:product) }
   let(:wrong_product) { create(:product) }
+  let(:new_product)   { create(:product) }
 
   scenario "Finding and linking an existing product" do
     sign_in user
@@ -105,7 +106,46 @@ RSpec.feature "Adding a product to a case", :with_stubbed_mailer, :with_stubbed_
     expect(page).to have_text("Product added by #{user.name}")
   end
 
-  scenario "Not being able to add a product to another team’s case" do
+  scenario "Adding a product changes the product count for case index page" do
+    sign_in user
+
+    parent_selector = ".govuk-table__body[data-cy-case-id='#{investigation.pretty_id}']"
+
+    visit "/cases/your-cases"
+    within parent_selector do
+      expect(page).to have_text("0 products")
+    end
+
+    visit "/cases/#{investigation.pretty_id}/products"
+
+    click_link "Add a product to the case"
+    fill_in "reference", with: right_product.id
+    click_button "Continue"
+    choose "Yes"
+    click_button "Save and continue"
+
+    visit "/cases/your-cases"
+
+    within parent_selector do
+      expect(page).to have_text("1 product")
+    end
+
+    visit "/cases/#{investigation.pretty_id}/products"
+
+    click_link "Add a product to the case"
+    fill_in "reference", with: new_product.id
+    click_button "Continue"
+    choose "Yes"
+    click_button "Save and continue"
+
+    visit "/cases/your-cases"
+
+    within parent_selector do
+      expect(page).to have_text("2 products")
+    end
+  end
+
+  scenario "Not being able to add a product to another team's case" do
     sign_in other_user
     visit "/cases/#{investigation.pretty_id}/products"
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1855

## Description
Adds a product count for each case index view

## Screen-shots or screen-capture of UI changes

### Before
<img width="773" alt="Screenshot 2023-09-11 at 11 58 15" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/ff990eb2-e57d-437e-99f5-24637105013d">

### After
<img width="763" alt="Screenshot 2023-09-11 at 11 58 06" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/67d174c9-99c8-41e3-82e5-8a967838f53b">


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
