### PR TITLE
PRISM: allow multiple associated products and/or investigations

### DIFF
--- a/app/controllers/prism_risk_assessments_controller.rb
+++ b/app/controllers/prism_risk_assessments_controller.rb
@@ -2,8 +2,8 @@ class PrismRiskAssessmentsController < ApplicationController
   def your_prism_risk_assessments
     authorize PrismRiskAssessment, :index?
 
-    @draft_prism_risk_assessments = PrismRiskAssessment.for_user(current_user).draft.page(params[:draft_page]).per(20)
-    @submitted_prism_risk_assessments = PrismRiskAssessment.for_user(current_user).submitted.page(params[:submitted_page]).per(20)
+    @draft_prism_risk_assessments = PrismRiskAssessment.for_user(current_user).draft.order(updated_at: :desc).page(params[:draft_page]).per(20)
+    @submitted_prism_risk_assessments = PrismRiskAssessment.for_user(current_user).submitted.order(updated_at: :desc).page(params[:submitted_page]).per(20)
     @page_name = "your_prism_risk_assessments"
 
     render "prism_risk_assessments/index"

--- a/app/models/prism_associated_investigation.rb
+++ b/app/models/prism_associated_investigation.rb
@@ -1,0 +1,10 @@
+class PrismAssociatedInvestigation < ApplicationRecord
+  # This model is only used for the PRISM risk assessment
+  # dashboard inside PSD and cannot be used to assign new
+  # associated investigations.
+  def readonly?
+    true
+  end
+
+  has_many :prism_associated_investigation_products, foreign_key: "associated_investigation_id"
+end

--- a/app/models/prism_associated_investigation_product.rb
+++ b/app/models/prism_associated_investigation_product.rb
@@ -1,0 +1,10 @@
+class PrismAssociatedInvestigationProduct < ApplicationRecord
+  # This model is only used for the PRISM risk assessment
+  # dashboard inside PSD and cannot be used to assign new
+  # associated investigation products.
+  def readonly?
+    true
+  end
+
+  belongs_to :product
+end

--- a/app/models/prism_associated_product.rb
+++ b/app/models/prism_associated_product.rb
@@ -1,0 +1,10 @@
+class PrismAssociatedProduct < ApplicationRecord
+  # This model is only used for the PRISM risk assessment
+  # dashboard inside PSD and cannot be used to assign new
+  # associated products.
+  def readonly?
+    true
+  end
+
+  belongs_to :product
+end

--- a/app/models/prism_risk_assessment.rb
+++ b/app/models/prism_risk_assessment.rb
@@ -8,12 +8,21 @@ class PrismRiskAssessment < ApplicationRecord
   end
 
   has_many :prism_harm_scenarios, foreign_key: "risk_assessment_id"
+  has_many :prism_associated_investigations, foreign_key: "risk_assessment_id"
+  has_many :prism_associated_products, foreign_key: "risk_assessment_id"
+  has_many :prism_associated_investigation_products, through: :prism_associated_investigations, foreign_key: "risk_assessment_id"
 
   scope :for_user, ->(user) { where(created_by_user_id: user.id) }
   scope :draft, -> { where.not(state: "submitted") }
   scope :submitted, -> { where(state: "submitted") }
 
   def product_name
-    Product.find(product_id)&.name if product_id.present?
+    if prism_associated_investigations.present? && prism_associated_investigation_products.present?
+      prism_associated_investigations.first.prism_associated_investigation_products.first.product.name
+    elsif prism_associated_products.present?
+      prism_associated_products.first.product.name
+    else
+      "Unknown product"
+    end
   end
 end

--- a/app/views/investigations/risk_assessments/edit.html.erb
+++ b/app/views/investigations/risk_assessments/edit.html.erb
@@ -1,19 +1,14 @@
-<% page_heading =  "Edit risk assessment" %>
+<% page_heading = "Edit risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-
-    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
-
+    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder, html: { novalidate: true }) do |form| %>
       <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level assessed_by investigation_product_ids risk_assessment_file])%>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
-
       <%= render "form_fields", form: form, risk_assessment_form: @risk_assessment_form, investigation: @investigation %>
-
       <%= govukButton(text: "Update risk assessment") %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/investigations/risk_assessments/new.html.erb
+++ b/app/views/investigations/risk_assessments/new.html.erb
@@ -1,13 +1,12 @@
-<% page_heading =  "Add risk assessment" %>
+<% page_heading = "Add risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
+    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: { novalidate: true }) do |form| %>
       <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level assessed_by investigation_product_ids risk_assessment_file]) %>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
-
-      <%= render 'investigations/risk_assessments/form_fields', risk_assessment_form: @risk_assessment_form, investigation: @investigation, page_heading: page_heading, form: form %>
+      <%= render "form_fields", risk_assessment_form: @risk_assessment_form, investigation: @investigation, page_heading: page_heading, form: form %>
       <%= govukButton(text: "Add risk assessment") %>
     <% end %>
   </div>

--- a/app/views/investigations/risk_assessments/no_products.html.erb
+++ b/app/views/investigations/risk_assessments/no_products.html.erb
@@ -1,4 +1,4 @@
-<% page_heading =  "Add risk assessment" %>
+<% page_heading = "Add risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/prism_risk_assessments/_table_row.html.erb
+++ b/app/views/prism_risk_assessments/_table_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <th scope="row" class="govuk-table__header">
-    <%= prism_risk_assessment.product_name || "Unknown" %>
+    <%= prism_risk_assessment.product_name %>
   </th>
   <td class="govuk-table__cell">
     <%= prism_risk_assessment.prism_harm_scenarios&.first&.description || "None" %>

--- a/db/migrate/20230913141142_create_prism_associated_products.prism.rb
+++ b/db/migrate/20230913141142_create_prism_associated_products.prism.rb
@@ -1,0 +1,12 @@
+# This migration comes from prism (originally 20230913132741)
+class CreatePrismAssociatedProducts < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_products, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :risk_assessment, type: :uuid
+        t.references :product
+        t.timestamps
+      end
+    end
+  end
+end

--- a/db/migrate/20230913141143_create_prism_associated_investigations.prism.rb
+++ b/db/migrate/20230913141143_create_prism_associated_investigations.prism.rb
@@ -1,0 +1,12 @@
+# This migration comes from prism (originally 20230913132756)
+class CreatePrismAssociatedInvestigations < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_investigations, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :risk_assessment, type: :uuid
+        t.references :investigation
+        t.timestamps
+      end
+    end
+  end
+end

--- a/db/migrate/20230913141144_create_prism_associated_investigation_products.prism.rb
+++ b/db/migrate/20230913141144_create_prism_associated_investigation_products.prism.rb
@@ -1,0 +1,12 @@
+# This migration comes from prism (originally 20230913133147)
+class CreatePrismAssociatedInvestigationProducts < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_investigation_products, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :associated_investigation, type: :uuid, index: { name: "index_prism_associated_products_on_associated_investigation_id" }
+        t.references :product
+        t.timestamps
+      end
+    end
+  end
+end

--- a/db/migrate/20230913141145_remove_product_id_from_prism_risk_assessments.prism.rb
+++ b/db/migrate/20230913141145_remove_product_id_from_prism_risk_assessments.prism.rb
@@ -1,0 +1,8 @@
+# This migration comes from prism (originally 20230913134225)
+class RemoveProductIdFromPrismRiskAssessments < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :prism_risk_assessments, :product_id, :bigint
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_101809) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_141145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -292,6 +292,33 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_101809) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "prism_associated_investigation_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "associated_investigation_id"
+    t.datetime "created_at", null: false
+    t.bigint "product_id"
+    t.datetime "updated_at", null: false
+    t.index ["associated_investigation_id"], name: "index_prism_associated_products_on_associated_investigation_id"
+    t.index ["product_id"], name: "index_prism_associated_investigation_products_on_product_id"
+  end
+
+  create_table "prism_associated_investigations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "investigation_id"
+    t.uuid "risk_assessment_id"
+    t.datetime "updated_at", null: false
+    t.index ["investigation_id"], name: "index_prism_associated_investigations_on_investigation_id"
+    t.index ["risk_assessment_id"], name: "index_prism_associated_investigations_on_risk_assessment_id"
+  end
+
+  create_table "prism_associated_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "product_id"
+    t.uuid "risk_assessment_id"
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_prism_associated_products_on_product_id"
+    t.index ["risk_assessment_id"], name: "index_prism_associated_products_on_risk_assessment_id"
+  end
+
   create_table "prism_evaluations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "aimed_at_vulnerable_users"
     t.string "comparable_risk_level"
@@ -383,7 +410,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_101809) do
     t.string "overall_product_risk_level"
     t.string "overall_product_risk_methodology"
     t.string "overall_product_risk_plus_label"
-    t.bigint "product_id"
     t.string "risk_type"
     t.jsonb "routing_questions"
     t.string "serious_risk_rebuttable_factors"

--- a/prism/app/controllers/prism/tasks/create_controller.rb
+++ b/prism/app/controllers/prism/tasks/create_controller.rb
@@ -76,7 +76,7 @@ module Prism
   private
 
     def prism_risk_assessment
-      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:harm_scenarios).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
+      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:associated_investigations, :associated_products, :harm_scenarios).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
     end
 
     def harm_scenario

--- a/prism/app/controllers/prism/tasks/define_controller.rb
+++ b/prism/app/controllers/prism/tasks/define_controller.rb
@@ -44,7 +44,7 @@ module Prism
   private
 
     def prism_risk_assessment
-      @prism_risk_assessment ||= Prism::RiskAssessment.find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
+      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:associated_investigations, :associated_products).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
     end
 
     def set_wizard_steps

--- a/prism/app/controllers/prism/tasks/evaluate_controller.rb
+++ b/prism/app/controllers/prism/tasks/evaluate_controller.rb
@@ -52,7 +52,7 @@ module Prism
   private
 
     def prism_risk_assessment
-      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:product_market_detail, :harm_scenarios, :evaluation).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
+      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:associated_investigations, :associated_products, :product_market_detail, :harm_scenarios, :evaluation).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
     end
 
     def harm_scenarios

--- a/prism/app/controllers/prism/tasks/identify_controller.rb
+++ b/prism/app/controllers/prism/tasks/identify_controller.rb
@@ -42,7 +42,7 @@ module Prism
   private
 
     def prism_risk_assessment
-      @prism_risk_assessment ||= Prism::RiskAssessment.find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
+      @prism_risk_assessment ||= Prism::RiskAssessment.includes(:associated_investigations, :associated_products).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
     end
 
     def set_wizard_steps

--- a/prism/app/models/prism/associated_investigation.rb
+++ b/prism/app/models/prism/associated_investigation.rb
@@ -1,0 +1,7 @@
+module Prism
+  class AssociatedInvestigation < ApplicationRecord
+    belongs_to :risk_assessment
+    belongs_to :investigation, class_name: "::Investigation"
+    has_many :associated_investigation_products
+  end
+end

--- a/prism/app/models/prism/associated_investigation_product.rb
+++ b/prism/app/models/prism/associated_investigation_product.rb
@@ -1,0 +1,6 @@
+module Prism
+  class AssociatedInvestigationProduct < ApplicationRecord
+    belongs_to :associated_investigation
+    belongs_to :product, class_name: "::Product"
+  end
+end

--- a/prism/app/models/prism/associated_product.rb
+++ b/prism/app/models/prism/associated_product.rb
@@ -1,0 +1,6 @@
+module Prism
+  class AssociatedProduct < ApplicationRecord
+    belongs_to :risk_assessment
+    belongs_to :product, class_name: "::Product"
+  end
+end

--- a/prism/app/models/prism/risk_assessment.rb
+++ b/prism/app/models/prism/risk_assessment.rb
@@ -9,6 +9,9 @@ module Prism
     has_one :product_hazard, autosave: true, dependent: :destroy
     has_many :harm_scenarios, autosave: true, dependent: :destroy
     has_one :evaluation, autosave: true, dependent: :destroy
+    has_many :associated_products, autosave: true, dependent: :destroy
+    has_many :associated_investigations, autosave: true, dependent: :destroy
+    has_many :associated_investigation_products, through: :associated_investigations, autosave: true, dependent: :destroy
 
     # This is used on the "Review the overall product risk level"
     # page in case there are no other fields to make strong params
@@ -89,8 +92,14 @@ module Prism
       end
     end
 
-    def product
-      Product.find(product_id) if product_id.present?
+    def product_name
+      if associated_investigations.present? && associated_investigation_products.present?
+        associated_investigations.first.associated_investigation_products.first.product.name
+      elsif associated_products.present?
+        associated_products.first.product.name
+      else
+        "Unknown product"
+      end
     end
 
   private

--- a/prism/app/views/prism/tasks/create/add_steps_to_harm.html.erb
+++ b/prism/app/views/prism/tasks/create/add_steps_to_harm.html.erb
@@ -12,7 +12,7 @@
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
         <p class="govuk-body-l"><%= hazard_type %></p>
-        <p class="govuk-body">Placeholder product</p>
+        <p class="govuk-body"><%= @prism_risk_assessment.product_name %></p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
       <% end %>

--- a/prism/app/views/prism/tasks/create/check_your_harm_scenario.html.erb
+++ b/prism/app/views/prism/tasks/create/check_your_harm_scenario.html.erb
@@ -8,7 +8,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
       <% end %>
       <h2 class="govuk-heading-m">
         Hazard details

--- a/prism/app/views/prism/tasks/create/choose_hazard_type.html.erb
+++ b/prism/app/views/prism/tasks/create/choose_hazard_type.html.erb
@@ -11,7 +11,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
       <% end %>
       <%= f.govuk_radio_buttons_fieldset :hazard_type, legend: { text: "What is the hazard type?", size: "m" } do %>
         <%= f.govuk_radio_button :hazard_type, "mechanical", label: { text: "Mechanical" }, hint: { text: "Sharp edges, trapping hazards, crushing hazards, impact hazards." }, link_errors: true %>

--- a/prism/app/views/prism/tasks/create/determine_severity_of_harm.html.erb
+++ b/prism/app/views/prism/tasks/create/determine_severity_of_harm.html.erb
@@ -12,7 +12,7 @@
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
         <p class="govuk-body-l"><%= hazard_type %></p>
-        <p class="govuk-body">Placeholder product</p>
+        <p class="govuk-body"><%= @prism_risk_assessment.product_name %></p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
       <% end %>

--- a/prism/app/views/prism/tasks/create/estimate_probability_of_harm.html.erb
+++ b/prism/app/views/prism/tasks/create/estimate_probability_of_harm.html.erb
@@ -12,7 +12,7 @@
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
         <p class="govuk-body-l"><%= hazard_type %></p>
-        <p class="govuk-body">Placeholder product</p>
+        <p class="govuk-body"><%= @prism_risk_assessment.product_name %></p>
         <p class="govuk-body"><%= @harm_scenario.description %></p>
         <p class="govuk-body">Affected users: <%= affected_users %></p>
         <p class="govuk-body">Severity of harm: <%= severity_of_harm %></p>

--- a/prism/app/views/prism/tasks/create/identify_who_might_be_harmed.html.erb
+++ b/prism/app/views/prism/tasks/create/identify_who_might_be_harmed.html.erb
@@ -11,7 +11,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
       <% end %>
       <%= f.govuk_radio_buttons_fieldset :product_aimed_at, legend: { text: "Who is the product aimed at?", size: "m" } do %>
         <%= f.govuk_radio_button :product_aimed_at, "particular_group_of_users", label: { text: "Particular group of users" }, hint: { text: "For example, children, men or women, the elderly, certain ethnic or cultural groups, etc." }, link_errors: true do %>

--- a/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
+++ b/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
@@ -11,7 +11,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
       <% end %>
       <%= f.govuk_text_field :selling_organisation, label: { text: "Name of the business that sold the product", size: "m" }, hint: { text: "This information is essential for product traceability." } %>
       <%= f.govuk_radio_buttons_fieldset :total_products_sold_estimatable, legend: { text: "Can the total number of products in use be estimated?", size: "m" } do %>

--- a/prism/app/views/prism/tasks/evaluate/confirm_overall_product_risk.html.erb
+++ b/prism/app/views/prism/tasks/evaluate/confirm_overall_product_risk.html.erb
@@ -11,7 +11,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
         <% if @prism_risk_assessment.product_market_detail&.total_products_sold.present? %><p class="govuk-body">Number of products in use: <%= @prism_risk_assessment.product_market_detail&.total_products_sold %></p><% end %>
       <% end %>
       <%= govuk_inset_text(text: "The overall risk level takes into account the total number of products in use, if available.") %>

--- a/prism/app/views/prism/tasks/identify/add_a_number_of_hazards.html.erb
+++ b/prism/app/views/prism/tasks/identify/add_a_number_of_hazards.html.erb
@@ -11,7 +11,7 @@
       </h1>
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
-        <p class="govuk-body-l">Placeholder product</p>
+        <p class="govuk-body-l"><%= @prism_risk_assessment.product_name %></p>
       <% end %>
       <%= f.govuk_collection_radio_buttons :number_of_hazards, number_of_hazards_radios, :id, :name, legend: { text: "Number of hazards identified" } %>
       <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>

--- a/prism/app/views/prism/triage/serious_risk.html.erb
+++ b/prism/app/views/prism/triage/serious_risk.html.erb
@@ -29,6 +29,14 @@
           <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1121889/prism-products-and-hazards-deemed-serious-risk-v01.pdf" class="govuk-link" target="_blank" rel="noreferrer noopener">Products and hazards deemed serious risk<span class="govuk-visually-hidden"> (opens in new tab)</span></a> (PDF, 105 KB, 2 pages)
         </p>
       <% end %>
+      <% if params[:investigation_id].present? %>
+        <%= f.hidden_field :investigation_id, value: params[:investigation_id] %>
+      <% end %>
+      <% if params[:product_ids].present? %>
+        <% params[:product_ids].each do |product_id| %>
+          <%= f.hidden_field :product_ids, value: product_id, multiple: true %>
+        <% end %>
+      <% end %>
       <% if params[:product_id].present? %>
         <%= f.hidden_field :product_id, value: params[:product_id] %>
       <% end %>

--- a/prism/db/migrate/20230913132741_create_prism_associated_products.rb
+++ b/prism/db/migrate/20230913132741_create_prism_associated_products.rb
@@ -1,0 +1,11 @@
+class CreatePrismAssociatedProducts < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_products, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :risk_assessment, type: :uuid
+        t.references :product
+        t.timestamps
+      end
+    end
+  end
+end

--- a/prism/db/migrate/20230913132756_create_prism_associated_investigations.rb
+++ b/prism/db/migrate/20230913132756_create_prism_associated_investigations.rb
@@ -1,0 +1,11 @@
+class CreatePrismAssociatedInvestigations < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_investigations, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :risk_assessment, type: :uuid
+        t.references :investigation
+        t.timestamps
+      end
+    end
+  end
+end

--- a/prism/db/migrate/20230913133147_create_prism_associated_investigation_products.rb
+++ b/prism/db/migrate/20230913133147_create_prism_associated_investigation_products.rb
@@ -1,0 +1,11 @@
+class CreatePrismAssociatedInvestigationProducts < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      create_table :prism_associated_investigation_products, id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.references :associated_investigation, type: :uuid, index: { name: "index_prism_associated_products_on_associated_investigation_id" }
+        t.references :product
+        t.timestamps
+      end
+    end
+  end
+end

--- a/prism/db/migrate/20230913134225_remove_product_id_from_prism_risk_assessments.rb
+++ b/prism/db/migrate/20230913134225_remove_product_id_from_prism_risk_assessments.rb
@@ -1,0 +1,7 @@
+class RemoveProductIdFromPrismRiskAssessments < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :prism_risk_assessments, :product_id, :bigint
+    end
+  end
+end

--- a/prism/test/fixtures/prism/associated_investigation_products.yml
+++ b/prism/test/fixtures/prism/associated_investigation_products.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/prism/test/fixtures/prism/associated_investigations.yml
+++ b/prism/test/fixtures/prism/associated_investigations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/prism/test/fixtures/prism/associated_products.yml
+++ b/prism/test/fixtures/prism/associated_products.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/prism/test/models/prism/associated_investigation_product_test.rb
+++ b/prism/test/models/prism/associated_investigation_product_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module Prism
+  class AssociatedInvestigationProductTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/prism/test/models/prism/associated_investigation_test.rb
+++ b/prism/test/models/prism/associated_investigation_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module Prism
+  class AssociatedInvestigationTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/prism/test/models/prism/associated_product_test.rb
+++ b/prism/test/models/prism/associated_product_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module Prism
+  class AssociatedProductTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/spec/factories/prism/associated_investigation.rb
+++ b/spec/factories/prism/associated_investigation.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :prism_associated_investigation, class: "Prism::AssociatedInvestigation" do
+    association :risk_assessment, factory: :prism_risk_assessment
+
+    associated_investigation_products { [association(:prism_associated_investigation_product)] }
+  end
+end

--- a/spec/factories/prism/associated_investigation_product.rb
+++ b/spec/factories/prism/associated_investigation_product.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :prism_associated_investigation_product, class: "Prism::AssociatedInvestigationProduct" do
+    association :associated_investigation, factory: :prism_associated_investigation
+
+    product { create(:product) }
+  end
+end

--- a/spec/factories/prism/associated_product.rb
+++ b/spec/factories/prism/associated_product.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :prism_associated_product, class: "Prism::AssociatedProduct" do
+    association :risk_assessment, factory: :prism_risk_assessment
+
+    product { create(:product) }
+  end
+end

--- a/spec/factories/prism/risk_assessment.rb
+++ b/spec/factories/prism/risk_assessment.rb
@@ -31,16 +31,12 @@ FactoryBot.define do
       state { "submitted" }
     end
 
+    trait :with_product do
+      associated_products { [association(:prism_associated_product)] }
+    end
+
     trait :with_harm_scenario do
       harm_scenarios { [association(:prism_harm_scenario)] }
-    end
-
-    transient do
-      product { create(:product) }
-    end
-
-    before(:create) do |prism_risk_assessment, evaluator|
-      prism_risk_assessment.product_id = evaluator.product.id
     end
   end
 end

--- a/spec/features/prism/risk_assessment_spec.rb
+++ b/spec/features/prism/risk_assessment_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "PRISM risk assessment", type: :feature do
   end
 
   context "with normal risk" do
-    let(:prism_risk_assessment) { create(:prism_risk_assessment, created_by_user_id: user.id) }
+    let(:prism_risk_assessment) { create(:prism_risk_assessment, :with_product, created_by_user_id: user.id) }
 
     scenario "risk assessment completion" do
       visit prism.risk_assessment_tasks_path(prism_risk_assessment)
@@ -50,7 +50,7 @@ RSpec.feature "PRISM risk assessment", type: :feature do
 
       click_button "Save and continue"
 
-      expect(page).to have_text("For\nElectrical\nPlaceholder product\nThis is a test description 1\nAffected users: Particular group of users")
+      expect(page).to have_text("For\nElectrical\n#{prism_risk_assessment.product_name}\nThis is a test description 1\nAffected users: Particular group of users")
 
       fill_in "Step description", with: "Test description for step 1"
 
@@ -61,7 +61,7 @@ RSpec.feature "PRISM risk assessment", type: :feature do
 
       click_button "Save and continue"
 
-      expect(page).to have_text("For\nElectrical\nPlaceholder product\nThis is a test description 1\nAffected users: Particular group of users\nSeverity of harm: Level 3\nMultiple casualties: yes")
+      expect(page).to have_text("For\nElectrical\n#{prism_risk_assessment.product_name}\nThis is a test description 1\nAffected users: Particular group of users\nSeverity of harm: Level 3\nMultiple casualties: yes")
 
       choose "Decimal number" # In what format would you like to express the probability of harm?
       fill_in "Enter the probability as a decimal number.", with: "0.25"
@@ -92,7 +92,7 @@ RSpec.feature "PRISM risk assessment", type: :feature do
 
       click_button "Save and continue"
 
-      expect(page).to have_text("For\nMechanical\nPlaceholder product\nThis is a test description 2\nAffected users: General population")
+      expect(page).to have_text("For\nMechanical\n#{prism_risk_assessment.product_name}\nThis is a test description 2\nAffected users: General population")
 
       fill_in "Step description", with: "Test description for step 1"
 

--- a/spec/features/prism/tasks_spec.rb
+++ b/spec/features/prism/tasks_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "PRISM tasks", type: :feature do
   end
 
   context "with normal risk" do
-    let(:prism_risk_assessment) { create(:prism_risk_assessment, created_by_user_id: user.id) }
+    let(:prism_risk_assessment) { create(:prism_risk_assessment, :with_product, created_by_user_id: user.id) }
 
     scenario "tasks page", :aggregate_failures do
       visit prism.risk_assessment_tasks_path(prism_risk_assessment)
@@ -126,7 +126,7 @@ RSpec.feature "PRISM tasks", type: :feature do
   end
 
   context "with serious risk" do
-    let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, created_by_user_id: user.id) }
+    let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, :with_product, created_by_user_id: user.id) }
 
     scenario "tasks page", :aggregate_failures do
       visit prism.risk_assessment_tasks_path(prism_risk_assessment)

--- a/spec/features/prism/triage_spec.rb
+++ b/spec/features/prism/triage_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "PRISM triage", type: :feature do
   let(:user) { create(:user, :activated, roles: %w[prism]) }
-  let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, created_by_user_id: user.id) }
+  let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, :with_product, created_by_user_id: user.id) }
 
   before do
     sign_in user

--- a/spec/features/prism_risk_assessment_spec.rb
+++ b/spec/features/prism_risk_assessment_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.feature "PRISM risk assessment dashboard", type: :feature do
   context "when the user has access to PRISM" do
     let(:user) { create(:user, :activated, roles: %w[prism]) }
-    let(:draft_prism_risk_assessment) { create(:prism_risk_assessment, :with_harm_scenario, created_by_user_id: user.id) }
-    let(:submitted_prism_risk_assessment) { create(:prism_risk_assessment, :submitted, :with_harm_scenario, created_by_user_id: user.id) }
+    let(:draft_prism_risk_assessment) { create(:prism_risk_assessment, :with_product, :with_harm_scenario, created_by_user_id: user.id) }
+    let(:submitted_prism_risk_assessment) { create(:prism_risk_assessment, :submitted, :with_product, :with_harm_scenario, created_by_user_id: user.id) }
 
     before do
       sign_in user
@@ -24,10 +24,10 @@ RSpec.feature "PRISM risk assessment dashboard", type: :feature do
         click_link "Risk assessments"
 
         expect(page).to have_text("Risk assessments")
-        expect(page).to have_text(draft_prism_risk_assessment.product.name)
+        expect(page).to have_text(draft_prism_risk_assessment.product_name)
         expect(page).to have_text(draft_prism_risk_assessment.harm_scenarios.first.description)
         expect(page).to have_link("Make changes")
-        expect(page).to have_text(submitted_prism_risk_assessment.product.name)
+        expect(page).to have_text(submitted_prism_risk_assessment.product_name)
         expect(page).to have_text(submitted_prism_risk_assessment.harm_scenarios.first.description)
         expect(page).to have_link("View assessment")
         expect(page).to have_link("Start a new risk assessment")
@@ -53,14 +53,16 @@ RSpec.feature "PRISM risk assessment dashboard", type: :feature do
 
       context "without an associated product" do
         before do
-          draft_prism_risk_assessment.product_id = nil
-          draft_prism_risk_assessment.save!
+          draft_prism_risk_assessment.associated_products.destroy_all
         end
 
         scenario "making changes to an existing PRISM risk assessment" do
           visit "/"
 
           click_link "Risk assessments"
+
+          expect(page).to have_text("Unknown product")
+
           click_link "Make changes"
 
           expect(page).to have_current_path("/products/all-products")


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1894

## Description

Lays the foundations to allow a PRISM risk assessment to be associated with multiple products and/or investigations (with associated products).

The frontend currently only allows association with a single product.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
