### PR TITLE
PRISM: PSD integration scenario 3

### DIFF
--- a/app/controllers/investigations/prism_risk_assessments_controller.rb
+++ b/app/controllers/investigations/prism_risk_assessments_controller.rb
@@ -1,0 +1,53 @@
+module Investigations
+  class PrismRiskAssessmentsController < Investigations::BaseController
+    before_action :set_investigation
+    before_action :authorize_investigation_updates
+    before_action :set_investigation_breadcrumbs
+    before_action :ensure_one_product, except: %i[choose_product]
+    before_action :product, except: %i[choose_product]
+
+    def new
+      # Find all submitted PRISM risk assessments that are associated with the chosen product
+      # either directly or via a case that is not the current case.
+      @related_prism_risk_assessments = PrismRiskAssessment
+        .left_joins(:prism_associated_products, prism_associated_investigations: :prism_associated_investigation_products)
+        .submitted
+        .where(prism_associated_products: { product_id: @product.id })
+        .or(PrismRiskAssessment.where.not(prism_associated_investigations: { investigation_id: @investigation.id }).where(prism_associated_investigations: { prism_associated_investigation_products: { product_id: @product.id } }))
+        .order(updated_at: :desc)
+    end
+
+    def create
+      return render :new if params[:prism_risk_assessment_id].blank?
+
+      prism_risk_assessment = PrismRiskAssessment.find(params[:prism_risk_assessment_id])
+      ActiveRecord::Base.transaction do
+        # When a PRISM risk assessment is associated with a case, any direct product associations are deleted
+        prism_risk_assessment.prism_associated_products.destroy_all
+        # rubocop:disable Rails/SaveBang
+        if prism_risk_assessment.prism_associated_investigations.create(investigation_id: @investigation.id, prism_associated_investigation_products_attributes: [{ product_id: params[:product_id] }])
+          redirect_to investigation_path(@investigation), flash: { success: "The risk assessment has been added to the case." }
+        else
+          render :new
+        end
+        # rubocop:enable Rails/SaveBang
+      end
+    end
+
+    def choose_product
+      @products = @investigation.products
+    end
+
+  private
+
+    def ensure_one_product
+      return if @investigation.products.size == 1
+
+      redirect_to choose_product_investigation_prism_risk_assessments_path unless params[:product_id].present? && @investigation.products.find_by(id: params[:product_id])
+    end
+
+    def product
+      @product ||= params[:product_id].present? ? @investigation.products.find(params[:product_id]) : @investigation.products.first!
+    end
+  end
+end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -76,6 +76,8 @@ class Investigation < ApplicationRecord
   has_one :owner_user, through: :owner_user_collaboration, dependent: :destroy, source_type: "User", source: :collaborator
 
   has_many :risk_assessments
+  has_many :prism_associated_investigations
+  has_many :prism_risk_assessments, through: :prism_associated_investigations
   has_many :accidents
   has_many :incidents
   has_many :unexpected_events

--- a/app/models/prism_associated_investigation.rb
+++ b/app/models/prism_associated_investigation.rb
@@ -1,10 +1,6 @@
 class PrismAssociatedInvestigation < ApplicationRecord
-  # This model is only used for the PRISM risk assessment
-  # dashboard inside PSD and cannot be used to assign new
-  # associated investigations.
-  def readonly?
-    true
-  end
-
+  belongs_to :prism_risk_assessment, foreign_key: "risk_assessment_id"
   has_many :prism_associated_investigation_products, foreign_key: "associated_investigation_id"
+
+  accepts_nested_attributes_for :prism_associated_investigation_products, reject_if: :all_blank
 end

--- a/app/models/prism_associated_investigation_product.rb
+++ b/app/models/prism_associated_investigation_product.rb
@@ -1,10 +1,4 @@
 class PrismAssociatedInvestigationProduct < ApplicationRecord
-  # This model is only used for the PRISM risk assessment
-  # dashboard inside PSD and cannot be used to assign new
-  # associated investigation products.
-  def readonly?
-    true
-  end
-
+  belongs_to :prism_associated_investigation, foreign_key: "associated_investigation_id"
   belongs_to :product
 end

--- a/app/models/prism_associated_product.rb
+++ b/app/models/prism_associated_product.rb
@@ -1,10 +1,4 @@
 class PrismAssociatedProduct < ApplicationRecord
-  # This model is only used for the PRISM risk assessment
-  # dashboard inside PSD and cannot be used to assign new
-  # associated products.
-  def readonly?
-    true
-  end
-
+  belongs_to :prism_risk_assessment, foreign_key: "risk_assessment_id"
   belongs_to :product
 end

--- a/app/models/prism_risk_assessment.rb
+++ b/app/models/prism_risk_assessment.rb
@@ -25,4 +25,9 @@ class PrismRiskAssessment < ApplicationRecord
       "Unknown product"
     end
   end
+
+  def user_and_organisation
+    user = User.find(created_by_user_id)
+    [user.name, user.organisation.name]
+  end
 end

--- a/app/views/investigations/_actions.html.erb
+++ b/app/views/investigations/_actions.html.erb
@@ -36,9 +36,9 @@
       <% end %>
     </div>
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Risk assessment&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.risk_assessments.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <dt class="govuk-summary-list__key">Risk assessment&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.risk_assessments.size + @investigation.prism_risk_assessments.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
       <% if policy(@investigation).update? %>
-        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_risk_assessment_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a risk assessment</span></a></dd>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_prism_risk_assessment_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a risk assessment</span></a></dd>
       <% end %>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/investigations/prism_risk_assessments/choose_product.html.erb
+++ b/app/views/investigations/prism_risk_assessments/choose_product.html.erb
@@ -1,0 +1,22 @@
+<% page_heading = "Select a product for risk assessment" %>
+<%= page_title page_heading %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= form_with url: new_investigation_prism_risk_assessment_path, method: :get, builder: ApplicationFormBuilder, html: { novalidate: true } do |form| %>
+      <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
+      <%= govukRadios(
+        form: form,
+        key: :product_id,
+        items: @products.map do |product|
+          {
+            id: "product_#{product.id}",
+            text: product.name,
+            value: product.id
+          }
+        end,
+        fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } }
+      ) %>
+      <%= govukButton(text: "Continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/investigations/prism_risk_assessments/new.html.erb
+++ b/app/views/investigations/prism_risk_assessments/new.html.erb
@@ -1,0 +1,70 @@
+<% page_heading = "Add risk assessment" %>
+<%= page_title page_heading %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= form_with url: investigation_prism_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: { novalidate: true } do |form| %>
+      <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
+      <h1 class="govuk-heading-l"><%= page_heading %></h1>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">For</p>
+        <p class="govuk-body-l"><%= @product.name %></p>
+      </div>
+      <h2 class="govuk-heading-m">Related risk assessments</h2>
+      <% if @related_prism_risk_assessments.size.positive? %>
+        <p class="govuk-body">Select a related risk assessment to add to the case. If you find that the assessment doesn't fit your case, you have the choice to either start a new assessment or attach one you've previously created.</p>
+        <table class="govuk-table opss-table-items opss-table-items--first-col-33 opss-table--borders">
+          <caption class="govuk-table__caption govuk-visually-hidden">PRISM risk assessments: a simple data table.</caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Hazard description</th>
+              <th scope="col" class="govuk-table__header">Created by</th>
+              <th scope="col" class="govuk-table__header">Last updated</th>
+              <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View assessment</span></th>
+              <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Add assessment to case</span></th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% @related_prism_risk_assessments.each do |prism_risk_assessment| %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  <%= prism_risk_assessment.prism_harm_scenarios&.first&.description || "None" %>
+                </th>
+                <td class="govuk-table__cell">
+                  <%= prism_risk_assessment.user_and_organisation.join("<br>").html_safe %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= date_or_recent_time_ago prism_risk_assessment.updated_at %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%# TODO(ruben): Add link to view submitted assessment %>
+                  <a href="#" class="govuk-link">View<span class="govuk-visually-hidden"> assessment</span></a>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= govukButton(text: "Add", name: "prism_risk_assessment_id", value: prism_risk_assessment.id) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+          <% if @related_prism_risk_assessments.size > 11 %>
+            <tfoot class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Hazard description</th>
+                <th scope="col" class="govuk-table__header">Created by</th>
+                <th scope="col" class="govuk-table__header">Last updated</th>
+                <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View assessment</span></th>
+                <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Add assessment to case</span></th>
+              </tr>
+            </tfoot>
+          <% end %>
+        </table>
+        <%= form.hidden_field :product_id, value: @product.id %>
+      <% else %>
+        <p class="govuk-body">There are no risk assessments for <%= @product.name %>. You can start a new assessment.</p>
+      <% end %>
+      <%= govukButton(text: "Start a new risk assessment", href: prism.serious_risk_path(investigation_id: @investigation.id, product_ids: [@product.id]), classes: "govuk-button--secondary") %>
+    <% end %>
+    <p class="govuk-body">
+      <a href="<%= new_investigation_risk_assessment_path %>" class="govuk-link">Attach existing risk assessment</a>
+    </p>
+  </div>
+</div>

--- a/app/views/investigations/risk_assessments/new.html.erb
+++ b/app/views/investigations/risk_assessments/new.html.erb
@@ -1,4 +1,4 @@
-<% page_heading = "Add risk assessment" %>
+<% page_heading = "Attach existing risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -7,7 +7,7 @@
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <%= render "form_fields", risk_assessment_form: @risk_assessment_form, investigation: @investigation, page_heading: page_heading, form: form %>
-      <%= govukButton(text: "Add risk assessment") %>
+      <%= govukButton(text: "Attach risk assessment") %>
     <% end %>
   </div>
 </div>

--- a/app/views/investigations/risk_assessments/no_products.html.erb
+++ b/app/views/investigations/risk_assessments/no_products.html.erb
@@ -1,4 +1,4 @@
-<% page_heading = "Add risk assessment" %>
+<% page_heading = "Attach existing risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/prism_risk_assessments/_table.html.erb
+++ b/app/views/prism_risk_assessments/_table.html.erb
@@ -1,5 +1,5 @@
 <table class="govuk-table opss-table-items opss-table-items--first-col-33 opss-table--borders">
-  <caption class="govuk-table__caption govuk-visually-hidden">Risk assessments: a simple data table.</caption>
+  <caption class="govuk-table__caption govuk-visually-hidden">PRISM risk assessments: a simple data table.</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Product name</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,12 @@ Rails.application.routes.draw do
       resource :comment, only: %i[create new]
     end
 
+    resources :prism_risk_assessments, controller: "investigations/prism_risk_assessments", path: "prism-risk-assessments", only: %i[new create] do
+      collection do
+        get :choose_product
+      end
+    end
+
     resources :risk_assessments, controller: "investigations/risk_assessments", path: "risk-assessments", only: %i[new create show edit update] do
       resource :update_case_risk_level, only: %i[show update], path: "update-case-risk-level", controller: "investigations/update_case_risk_level_from_risk_assessment"
     end

--- a/db/migrate/20230915145123_add_name_to_prism_risk_assessments.prism.rb
+++ b/db/migrate/20230915145123_add_name_to_prism_risk_assessments.prism.rb
@@ -1,0 +1,6 @@
+# This migration comes from prism (originally 20230915145048)
+class AddNameToPrismRiskAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prism_risk_assessments, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_141145) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_145123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -407,6 +407,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_141145) do
     t.string "assessor_name"
     t.datetime "created_at", null: false
     t.uuid "created_by_user_id"
+    t.string "name"
     t.string "overall_product_risk_level"
     t.string "overall_product_risk_methodology"
     t.string "overall_product_risk_plus_label"

--- a/prism/app/models/prism/associated_investigation.rb
+++ b/prism/app/models/prism/associated_investigation.rb
@@ -3,5 +3,7 @@ module Prism
     belongs_to :risk_assessment
     belongs_to :investigation, class_name: "::Investigation"
     has_many :associated_investigation_products
+
+    accepts_nested_attributes_for :associated_investigation_products, reject_if: :all_blank
   end
 end

--- a/prism/db/migrate/20230915145048_add_name_to_prism_risk_assessments.rb
+++ b/prism/db/migrate/20230915145048_add_name_to_prism_risk_assessments.rb
@@ -1,0 +1,5 @@
+class AddNameToPrismRiskAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prism_risk_assessments, :name, :string
+  end
+end

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -44,6 +44,9 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
     expect_to_be_on_case_page(case_id: investigation.pretty_id)
 
     click_link "Add a risk assessment"
+    choose product1.name
+    click_button "Continue"
+    click_link "Attach existing risk assessment"
 
     expect_to_be_on_add_risk_assessment_for_a_case_page(case_id: investigation.pretty_id)
     expect_to_have_case_breadcrumbs
@@ -56,7 +59,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
                                 options: ["", "MyBrand Distributors", "MyBrand Inc"],
                                 selected: [""])
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     errors_list = page.find(".govuk-error-summary__list").all("li")
     expect(errors_list[0].text).to eq "Enter the date of the assessment"
@@ -67,7 +70,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
 
     attach_file "Upload the risk assessment", risk_assessment_file
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     expect(page).to have_css("#current-attachment-details a", text: risk_assessment_file.basename.to_s)
     expect(page).not_to have_text("You must upload the risk assessment")
@@ -92,7 +95,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
 
     fill_in("Further details (optional)", with: "Products risk-assessed in response to incident.")
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Skip the 'Case risk level' page as it is automatically updated to match
 
@@ -154,14 +157,14 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
       check "MyBrand washing machine model X"
     end
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     expect(page).to have_text("Select business related to the case")
     select "MyBrand Inc", from: "Choose business"
 
     attach_file "Upload the risk assessment", risk_assessment_file
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Skip the 'Case risk level' page as it is automatically updated to match
 
@@ -200,24 +203,24 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
       check "MyBrand washing machine model X"
     end
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     within_fieldset("What was the risk level?") do
       choose "Serious risk"
     end
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     expect(page).to have_text("Enter organisation name")
     fill_in "Organisation name", with: "RiskAssessmentsRUs"
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Check that field retains value when there's a validation error
     expect(page).to have_field("Organisation name", with: "RiskAssessmentsRUs")
 
     attach_file "Upload the risk assessment", risk_assessment_file
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Skip the 'Case risk level' page as it is automatically updated to match
 
@@ -273,7 +276,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
 
     attach_file "Upload the risk assessment", risk_assessment_file
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Skip the 'Case risk level' page as it is automatically updated to match
 
@@ -307,7 +310,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
 
     attach_file "Upload the risk assessment", risk_assessment_file
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     # Skip the 'Case risk level' page as it already matches
 
@@ -337,7 +340,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_antivirus, :wi
 
     attach_file "Upload the risk assessment", risk_assessment_file
 
-    click_button "Add risk assessment"
+    click_button "Attach risk assessment"
 
     expect_to_be_on_update_case_risk_level_from_risk_assessment_page(case_id: investigation_with_not_conclusive_risk_level.pretty_id)
 

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Case actions", :with_stubbed_antivirus, :with_stubbed_mailer, typ
         expect(page).to have_link("Add an image", href: new_investigation_document_path(investigation_1))
         expect(page).to have_link("Add an accident or incident", href: new_investigation_accident_or_incidents_type_path(investigation_1))
         expect(page).to have_link("Add a corrective action", href: new_investigation_corrective_action_path(investigation_1))
-        expect(page).to have_link("Add a risk assessment", href: new_investigation_risk_assessment_path(investigation_1))
+        expect(page).to have_link("Add a risk assessment", href: new_investigation_prism_risk_assessment_path(investigation_1))
         expect(page).to have_link("Add a correspondence", href: new_investigation_correspondence_path(investigation_1))
         expect(page).to have_link("Add a test result", href: new_investigation_funding_source_path(investigation_1))
         expect(page).to have_link("Add a document or attachment", href: new_investigation_document_path(investigation_1))

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -674,7 +674,7 @@ module PageExpectations
 
   def expect_to_be_on_add_risk_assessment_for_a_case_page(case_id:)
     expect(page).to have_current_path("/cases/#{case_id}/risk-assessments/new")
-    expect_page_to_have_h1("Add risk assessment")
+    expect_page_to_have_h1("Attach existing risk assessment")
   end
 
   def expect_to_be_on_risk_assessement_for_a_case_page(case_id:, risk_assessment_id: nil)


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/PSD-1864, https://regulatorydelivery.atlassian.net/browse/PSD-1891

## Description

Adds functionality to assign an existing submitted PRISM risk assessment to a case where the risk assessment is already assigned to the product in question either directly or via another case.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-09-14 at 16 58 16](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/b34b37a9-14dd-4223-ab7f-8ad2ff1f5a9b)

![Screenshot 2023-09-14 at 16 58 26](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/b05752a1-2b3f-46a2-a894-381aeac7901c)

![Screenshot 2023-09-14 at 16 59 03](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/9c474b1d-532d-4f78-9ab0-f8dc86d7f17c)

![Screenshot 2023-09-14 at 20 07 03](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/b9447440-cfcf-432b-b0f0-9b873ec0cdd8)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
