### PR TITLE
PRISM: add autocomplete component for product legislation

### DIFF
--- a/db/migrate/20230918155916_remove_other_safety_legislation_standard_from_prism_product_market_details.prism.rb
+++ b/db/migrate/20230918155916_remove_other_safety_legislation_standard_from_prism_product_market_details.prism.rb
@@ -1,0 +1,8 @@
+# This migration comes from prism (originally 20230918155754)
+class RemoveOtherSafetyLegislationStandardFromPrismProductMarketDetails < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :prism_product_market_details, :other_safety_legislation_standard, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_15_145123) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_155916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -392,7 +392,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_15_145123) do
 
   create_table "prism_product_market_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "other_safety_legislation_standard"
     t.uuid "risk_assessment_id"
     t.jsonb "routing_questions"
     t.string "safety_legislation_standards", default: [], array: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@hmcts/frontend": "^0.0.41-alpha",
     "@hotwired/stimulus": "^3.2.2",
-    "accessible-autocomplete": "2.0.4",
+    "accessible-autocomplete": "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main",
     "esbuild": "^0.19.2",
     "govuk-frontend": "4.6.0",
     "i18n-js": "^4.3.2",

--- a/prism/app/assets/stylesheets/prism/_autocomplete.scss
+++ b/prism/app/assets/stylesheets/prism/_autocomplete.scss
@@ -1,0 +1,155 @@
+// Apply GOVUK typography
+// See https://github.com/alphagov/accessible-autocomplete/issues/285
+.autocomplete__wrapper * {
+  @include govuk-typography-common;
+}
+
+// Fix invisible arrow when used as dropdown
+// See https://github.com/alphagov/accessible-autocomplete/issues/351
+.autocomplete__wrapper {
+  z-index: 0;
+}
+
+// Add a clear button.
+.autocomplete-select-with-clear {
+  width: calc(100% - 48px);
+  display: inline-block;
+
+  // Hide IE browser input clear button (that doesn't work anyway)
+  .autocomplete__input::-ms-clear,
+  .autocomplete__hint::-ms-clear {
+    display: none;
+  }
+}
+
+.autocomplete__clear-button {
+  background: transparent;
+  border-color: transparent;
+  cursor: pointer;
+  width: 44px;
+  margin: 2px;
+  display: inline-block;
+  vertical-align: top;
+  padding: 0;
+  float: right;
+}
+
+.autocomplete__clear-button:focus {
+  @include govuk-focused-text;
+}
+
+.autocomplete__clear-viewbox {
+  cursor: pointer;
+  width: 30px;
+  height: 30px; // Set explicitly as IE needs it
+}
+
+.autocomplete__clear-icon {
+  stroke: govuk-colour("black");
+  fill: transparent;
+  stroke-linecap: round;
+  stroke-width: 5;
+}
+
+@include govuk-media-query($from: tablet) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+  }
+
+  .autocomplete__hint,
+  .autocomplete__input {
+    line-height: 25px;
+  }
+
+  .autocomplete__wrapper input,
+  .autocomplete__wrapper li {
+    font-size: 19px;
+  }
+}
+
+// Apply error styling
+.govuk-form-group--error {
+  .autocomplete__input {
+    border: $govuk-border-width-form-element solid $govuk-error-colour;
+  }
+
+  // Remove error colour when focused
+  .autocomplete__input:focus,
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+    // Remove `box-shadow` inherited from `:focus` as `input--error`
+    // already has the thicker border.
+    box-shadow: none;
+  }
+
+  // Make sure hint has same border width as input
+  .autocomplete__hint {
+    border-width: $govuk-border-width-form-element;
+  }
+
+  // Reposition dropdown arrow to account for thicker border
+  .autocomplete__dropdown-arrow-down {
+    top: 12px;
+  }
+
+  // Reposition clear button
+  .autocomplete__clear-button {
+    margin-top: 4px;
+  }
+}
+
+// Set autocomplete widths
+
+// TODO: It would be better to add a wrapper to autocompletes instead.
+// Autocompletes need a wrapper width to be set rather than on
+// input directly because of our 'clear' button
+@mixin autocomplete-set-width($max-width) {
+
+  // Explicitly set font size on container so ex units work
+  // Assumes all autocompletes are default size.
+  // This matches govuk fixed width inputs which scale with
+  // font size.
+  @include govuk-font(19);
+
+  // Set on govuk-selects and autocompletes (clear and non-clear)
+  // There is no one selector currently we can target, so we target
+  // both, then unset where we don't need.
+  .govuk-select,
+  .autocomplete__wrapper,
+  .autocomplete-select-with-clear {
+    max-width: $max-width !important;
+  }
+
+  // Unset on autocompletes clear button is used
+  // Easier to unset than to have more complex selector above
+  .autocomplete-select-with-clear .autocomplete__wrapper {
+    max-width: inherit !important;
+  }
+}
+
+// Custom width overrides so inputs can be fixed width regardless of resolution.
+@include govuk-media-query($from: tablet) {
+
+  // These widths should match those set in helpers/field-widths.scss
+  .app-\!-autocomplete--max-width-three-quarters {
+    @include autocomplete-set-width(50ex);
+  }
+
+  .app-\!-autocomplete--max-width-two-thirds {
+    @include autocomplete-set-width(44ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-half {
+    @include autocomplete-set-width(33ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-third {
+    @include autocomplete-set-width(22ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-quarter {
+    @include autocomplete-set-width(17ex);
+  }
+}

--- a/prism/app/assets/stylesheets/prism/application.scss
+++ b/prism/app/assets/stylesheets/prism/application.scss
@@ -20,6 +20,8 @@ $govuk-fonts-path: "";
 $govuk-global-styles: true;
 
 @import "govuk-frontend/govuk/all";
+@import "accessible-autocomplete/src/autocomplete";
+@import "autocomplete";
 @import "task_list";
 
 .opss-nojs-hide {

--- a/prism/app/controllers/prism/tasks/define_controller.rb
+++ b/prism/app/controllers/prism/tasks/define_controller.rb
@@ -68,7 +68,7 @@ module Prism
     def add_details_about_products_in_use_and_safety_params
       allowed_params = params
         .require(:product_market_detail)
-        .permit(:selling_organisation, :total_products_sold_estimatable, :total_products_sold, :other_safety_legislation_standard, :final, safety_legislation_standards: [])
+        .permit(:selling_organisation, :total_products_sold_estimatable, :total_products_sold, :final, safety_legislation_standards: [])
       # The form builder inserts an empty hidden field that needs to be removed before validation and saving
       allowed_params[:safety_legislation_standards].reject!(&:blank?)
       allowed_params

--- a/prism/app/models/prism/product_market_detail.rb
+++ b/prism/app/models/prism/product_market_detail.rb
@@ -9,20 +9,14 @@ module Prism
     validates :selling_organisation, presence: true
     validates :total_products_sold_estimatable, inclusion: [true, false]
     validates :total_products_sold, presence: true, numericality: { only_integer: true }, if: -> { total_products_sold_estimatable }
-    validates :safety_legislation_standards, presence: true, array_intersection: { in: %w[regulation_4404 regulation_129 bs_en_17072_2018 bs_en_17022_2018 other] }
-    validates :other_safety_legislation_standard, presence: true, if: -> { safety_legislation_standards.include?("other") }
+    validates :safety_legislation_standards, presence: true, array_intersection: { in: Rails.application.config.legislation_constants["legislation"] }
 
     before_save :clear_total_products_sold
-    before_save :clear_other_safety_legislation_standard
 
   private
 
     def clear_total_products_sold
       self.total_products_sold = nil unless total_products_sold_estimatable
-    end
-
-    def clear_other_safety_legislation_standard
-      self.other_safety_legislation_standard = nil unless safety_legislation_standards.include?("other")
     end
   end
 end

--- a/prism/app/views/layouts/prism/application.html.erb
+++ b/prism/app/views/layouts/prism/application.html.erb
@@ -124,5 +124,6 @@
   <%= javascript_tag nonce: true do -%>
     window.GOVUKFrontend.initAll()
   <% end -%>
+  <%= yield :extra_javascript %>
 </body>
 </html>

--- a/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
+++ b/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
@@ -20,16 +20,20 @@
         <% end %>
         <%= f.govuk_radio_button :total_products_sold_estimatable, false, label: { text: "No" }, hint: { text: "Insufficient information available to make a reasonable estimate." } %>
       <% end %>
-      <%= f.govuk_check_boxes_fieldset :safety_legislation_standards, legend: { text: "Product safety legislation and standards", size: "m" }, hint: { text: "Review the provided legislations and standards and choose the ones that you feel are relevant to your product." } do %>
-        <%= f.govuk_check_box :safety_legislation_standards, :regulation_4404, label: { text: "Regulation No 44/04 UN ECE approval of restraining devices for child occupants (child restraint systems)" }, link_errors: true,checked: @product_market_detail.safety_legislation_standards.include?("regulation_4404") %>
-        <%= f.govuk_check_box :safety_legislation_standards, :regulation_129, label: { text: "Regulation No 129 UN ECE R129 approval of enhanced child restraint systems (i-size)" }, checked: @product_market_detail.safety_legislation_standards.include?("regulation_129") %>
-        <%= f.govuk_check_box :safety_legislation_standards, :bs_en_17072_2018, label: { text: "BS EN 17072:2018" }, checked: @product_market_detail.safety_legislation_standards.include?("bs_en_17072_2018") %>
-        <%= f.govuk_check_box :safety_legislation_standards, :bs_en_17022_2018, label: { text: "BS EN 17022:2018" }, checked: @product_market_detail.safety_legislation_standards.include?("bs_en_17022_2018") %>
-        <%= f.govuk_check_box :safety_legislation_standards, :other, label: { text: "Other" }, checked: @product_market_detail.safety_legislation_standards.include?("other") do %>
-          <%= f.govuk_text_field :other_safety_legislation_standard, label: { text: "Name of safety legislation or standard" } %>
-        <% end %>
-      <% end %>
+      <%= f.govuk_select(
+        :safety_legislation_standards,
+        options_for_select([""] + Rails.application.config.legislation_constants["legislation"], @product_market_detail.safety_legislation_standards),
+        label: { text: "Product safety legislation and standards", size: "m" },
+        hint: { text: "Search applicable safety legislation and standards and choose the ones you feel are relevant to your product." },
+        multiple: true
+      ) %>
       <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+      <% content_for :extra_javascript do %>
+        <%= javascript_tag nonce: true do -%>
+          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field")
+          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field-error")
+        <% end -%>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/prism/config/locales/en.yml
+++ b/prism/config/locales/en.yml
@@ -76,8 +76,6 @@ en:
             safety_legislation_standards:
               blank: Select the product safety legislation and standards that are relevant to your product
               inclusion: Select the product safety legislation and standards that are relevant to your product
-            other_safety_legislation_standard:
-              blank: Enter the name of the safety legislation or standard
         prism/product_hazard:
           attributes:
             number_of_hazards:

--- a/prism/db/migrate/20230918155754_remove_other_safety_legislation_standard_from_prism_product_market_details.rb
+++ b/prism/db/migrate/20230918155754_remove_other_safety_legislation_standard_from_prism_product_market_details.rb
@@ -1,0 +1,7 @@
+class RemoveOtherSafetyLegislationStandardFromPrismProductMarketDetails < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :prism_product_market_details, :other_safety_legislation_standard, :string
+    end
+  end
+end

--- a/spec/features/prism/risk_assessment_spec.rb
+++ b/spec/features/prism/risk_assessment_spec.rb
@@ -23,7 +23,8 @@ RSpec.feature "PRISM risk assessment", type: :feature do
       fill_in "Name of the business that sold the product", with: "Test company"
       choose "Yes" # Can the total number of products in use be estimated?
       fill_in "Estimated number of products in use", with: 1_000_000
-      check "BS EN 17072:2018" # Product safety legislation and standards
+      select "ATEX 2016" # Product safety legislation and standards
+      select "Fireworks Act 2003 / Fireworks Regulations 2004" # Product safety legislation and standards
 
       click_button "Save and complete tasks in this section"
 

--- a/spec/features/prism/tasks_spec.rb
+++ b/spec/features/prism/tasks_spec.rb
@@ -72,7 +72,8 @@ RSpec.feature "PRISM tasks", type: :feature do
 
         fill_in "Name of the business that sold the product", with: "Test organisation"
         choose "No" # Can the total number of products in use be estimated?
-        check "BS EN 17022:2018"
+        select "ATEX 2016"
+        select "Fireworks Act 2003 / Fireworks Regulations 2004"
 
         click_button "Save and complete tasks in this section"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,10 +245,9 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-accessible-autocomplete@2.0.4:
+"accessible-autocomplete@https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main":
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
-  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  resolved "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main#f043b72a5530664a47a1a8e451258920135b9303"
   dependencies:
     preact "^8.3.1"
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1906

## Description

Adds a multiple selection autocomplete component to select the relevant product legislation and standards.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-09-19 at 15 47 34](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/7c4180ed-6923-4869-96f3-e9a58e0c9672)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
