### PR TITLE
PRISM: make evidence file optional

### DIFF
--- a/prism/app/assets/javascripts/prism/overall_probability_of_harm_and_risk_level.js
+++ b/prism/app/assets/javascripts/prism/overall_probability_of_harm_and_risk_level.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
       getOverallProbabilityOfHarmAndRiskLevel()
     })
   })
+
+  getOverallProbabilityOfHarmAndRiskLevel()
 })
 
 const getOverallProbabilityOfHarmAndRiskLevel = async () => {

--- a/prism/app/models/prism/harm_scenario_step.rb
+++ b/prism/app/models/prism/harm_scenario_step.rb
@@ -28,7 +28,6 @@ module Prism
     validates :probability_evidence, inclusion: %w[sole_judgement_or_estimation some_limited_empirical_evidence strong_empirical_evidence], on: :estimate_probability_of_harm
     validates :probability_evidence_description_limited, presence: true, if: -> { probability_evidence == "some_limited_empirical_evidence" }, on: :estimate_probability_of_harm
     validates :probability_evidence_description_strong, presence: true, if: -> { probability_evidence == "strong_empirical_evidence" }, on: :estimate_probability_of_harm
-    validates :harm_scenario_step_evidence, presence: true, if: -> { %w[some_limited_empirical_evidence strong_empirical_evidence].include?(probability_evidence) }, on: :estimate_probability_of_harm
 
     after_find :set_probability_evidence_description_virtual_attributes
     before_validation :set_probability_evidence_description

--- a/prism/config/locales/en.yml
+++ b/prism/config/locales/en.yml
@@ -122,8 +122,6 @@ en:
               blank: Enter a description of the evidence
             probability_evidence_description_strong:
               blank: Enter a description of the evidence
-            harm_scenario_step_evidence:
-              blank: Attach a document in support of your decision
         prism/harm_scenario_step_evidence:
           attributes:
             evidence_file:


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1916

## Description

Makes the harm scenario evidence file optional. Also fixes a bug where the probability and risk level disappear when the page is reloaded with an error.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
