### PR TITLE
PRISM: add your, team and all risk assessments

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -41,4 +41,16 @@ module BreadcrumbHelper
     setting = "all_products" if setting == "index"
     setting.to_s.to_sym
   end
+
+  def breadcrumb_prism_risk_assessment_label
+    setting = cookies.fetch(:last_prism_risk_assessment_view, "your_prism_risk_assessments")
+    setting = "all_prism_risk_assessments" if setting == "index"
+    "prism_risk_assessments.#{setting}".to_sym
+  end
+
+  def breadcrumb_prism_risk_assessment_path
+    setting = cookies.fetch(:last_prism_risk_assessment_view, "your_prism_risk_assessments")
+    setting = "all_prism_risk_assessments" if setting == "index"
+    setting.to_s.to_sym
+  end
 end

--- a/app/models/prism_risk_assessment.rb
+++ b/app/models/prism_risk_assessment.rb
@@ -13,6 +13,7 @@ class PrismRiskAssessment < ApplicationRecord
   has_many :prism_associated_investigation_products, through: :prism_associated_investigations, foreign_key: "risk_assessment_id"
 
   scope :for_user, ->(user) { where(created_by_user_id: user.id) }
+  scope :for_team, ->(team) { where(created_by_user_id: team.users.pluck(:id)) }
   scope :draft, -> { where.not(state: "submitted") }
   scope :submitted, -> { where(state: "submitted") }
 

--- a/app/views/prism_risk_assessments/_search_statement.html.erb
+++ b/app/views/prism_risk_assessments/_search_statement.html.erb
@@ -1,0 +1,9 @@
+<p class="govuk-body">
+  <% if keywords.blank? %>
+    There <%= count == 1 ? "is" : "are" %> currently <%= pluralize count, "risk assessment", plural: "risk assessments" %>.
+  <% else %>
+    <% if keywords.present? %>
+      <%= pluralize count, "risk assessment", plural: "risk assessments" %> matching keyword(s) <span class="govuk-!-font-weight-bold"><%= sanitize keywords %></span>, <%= count == 1 ? "was" : "were" %> found.
+    <% end %>
+  <% end %>
+</p>

--- a/app/views/prism_risk_assessments/_secondary_nav.html.erb
+++ b/app/views/prism_risk_assessments/_secondary_nav.html.erb
@@ -1,0 +1,28 @@
+<a href="#page-content" class="govuk-skip-link opss-skip-link">
+  Skip to the main content
+</a>
+<nav aria-label="Secondary">
+  <ul class="govuk-list opss-left-nav">
+    <% if @page_name == "your_prism_risk_assessments" %>
+      <li class="opss-left-nav__active">
+    <% else %>
+      <li>
+    <% end %>
+        <%= link_to "Your risk assessments", your_prism_risk_assessments_path, class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if @page_name == "your_prism_risk_assessments") %>
+      </li>
+    <% if @page_name == "team_prism_risk_assessments" %>
+      <li class="opss-left-nav__active">
+    <% else %>
+      <li>
+    <% end %>
+        <%= link_to "Team risk assessments", team_prism_risk_assessments_path, class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" if @page_name == "team_prism_risk_assessments") %>
+      </li>
+    <% unless ["team_prism_risk_assessments", "your_prism_risk_assessments"].include? @page_name %>
+      <li class="opss-left-nav__active">
+    <% else %>
+      <li>
+    <% end %>
+        <%= link_to "All risk assessments - Search", all_prism_risk_assessments_path, class: "govuk-link govuk-link--no-visited-state", 'aria-current':("page" unless ["team_prism_risk_assessments", "your_prism_risk_assessments"].include? @page_name) %>
+      </li>
+    </ul>
+  </nav>

--- a/app/views/prism_risk_assessments/heading/_all_prism_risk_assessments.html.erb
+++ b/app/views/prism_risk_assessments/heading/_all_prism_risk_assessments.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">All risk assessments – Search</h1>
+    <p class="govuk-body opss-secondary-text">Search all risk assessment records in the Product Safety Database (<%= psd_abbr title: false %>).</p>
+  </div>
+</div>

--- a/app/views/prism_risk_assessments/heading/_team_prism_risk_assessments.html.erb
+++ b/app/views/prism_risk_assessments/heading/_team_prism_risk_assessments.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Your risk assessments</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Team risk assessments</h1>
   </div>
 </div>

--- a/app/views/prism_risk_assessments/index.html.erb
+++ b/app/views/prism_risk_assessments/index.html.erb
@@ -2,32 +2,73 @@
 
 <%= render "prism_risk_assessments/heading/#{@page_name}" %>
 
-<% if @draft_prism_risk_assessments.any? %>
-<div class="govuk-grid-row">
-  <section class="govuk-grid-column-full" id="page-content">
-    <h2 class="govuk-heading-m">Draft risk assessments</h2>
-    <%= render "table", prism_risk_assessments: @draft_prism_risk_assessments, type: "draft" %>
-    <%= paginate @draft_prism_risk_assessments, param_name: :draft_page %>
-  </section>
-</div>
+<%= form_with(model: @search, scope: "", url: all_prism_risk_assessments_path, method: :get, local: true, html: { novalidate: true, role: "search" }) do |form| %>
+  <div class="govuk-grid-row opss-full-height">
+    <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
+      <%= render "prism_risk_assessments/secondary_nav" %>
+    </section>
+    <section class="govuk-grid-column-three-quarters" id="page-content">
+      <% if ["team_prism_risk_assessments", "your_prism_risk_assessments"].exclude?(@page_name) %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-form-group govuk-!-padding-bottom-2">
+              <%= form.label :q, "Search", class: "govuk-label" %>
+              <div class="govuk-input__wrapper opss-search__wrapper">
+                <%= form.hidden_field :sort_by, id: "sort_by_current", value: params[:sort_by] %>
+                <%= form.hidden_field :sort_dir, value: params[:sort_dir] %>
+                <%= form.search_field :q, class: "govuk-input govuk-!-width-full", data: { "opss-clear-on-reset" => "element" }, spellcheck: false, "aria-describedby" => "search-hint" %>
+                <button class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
+                  <span class="govuk-visually-hidden">Submit search</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <%= render_sort_by form, @sort_by_items, @selected_sort_by, @selected_sort_direction, "govuk-grid-column-one-third" if (@count > 11) %>
+        </div>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= render "search_statement", count: @count, keywords: params[:q] %>
+          </div>
+        </div>
+      <% elsif (@count > 11) %>
+        <div class="govuk-grid-row">
+          <%= render_sort_by form, @sort_by_items, @selected_sort_by, @selected_sort_direction, "govuk-grid-column-one-third opss-float-right-desktop" %>
+        </div>
+      <% end %>
+
+      <% if @page_name == "your_prism_risk_assessments" && @draft_prism_risk_assessments.any? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full" role="region" aria-label="Draft risk assessments">
+            <h2 class="govuk-heading-m">Draft risk assessments</h2>
+            <%= render "table", prism_risk_assessments: @draft_prism_risk_assessments, type: "draft" %>
+            <%= paginate @draft_prism_risk_assessments, param_name: :draft_page %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @submitted_prism_risk_assessments.any? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full" role="region" aria-label="Risk assessments">
+            <% if @page_name == "your_prism_risk_assessments" && @draft_prism_risk_assessments.any? %>
+              <h2 class="govuk-heading-m">Submitted risk assessments</h2>
+            <% end %>
+            <%= render "table", prism_risk_assessments: @submitted_prism_risk_assessments, type: "submitted" %>
+            <%= paginate @submitted_prism_risk_assessments, param_name: :submitted_page %>
+          </div>
+        </div>
+      <% elsif @page_name == "your_prism_risk_assessments" && @draft_prism_risk_assessments.blank? %>
+        <p class="govuk-body">You haven't added any risk assessments yet.</p>
+      <% elsif @page_name == "team_prism_risk_assessments" %>
+        <p class="govuk-body">There are no risk assessments created by members of your team.</p>
+      <% end %>
+
+    </section>
+  </div>
 <% end %>
 
-<% if @submitted_prism_risk_assessments.any? %>
 <div class="govuk-grid-row">
-  <section class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Submitted risk assessments</h2>
-    <%= render "table", prism_risk_assessments: @submitted_prism_risk_assessments, type: "submitted" %>
-    <%= paginate @submitted_prism_risk_assessments, param_name: :submitted_page %>
-  </section>
-</div>
-<% end %>
-
-<% if @draft_prism_risk_assessments.blank? && @submitted_prism_risk_assessments.blank? %>
-<p class="govuk-body">You haven't added any risk assessments yet.</p>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-one-quarter">&nbsp;</div>
+  <div class="govuk-grid-column-three-quarters">
     <%= govukButton(text: "Start a new risk assessment", href: all_products_path) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,9 @@ en:
         caption: "Report an unsafe or non-compliant product"
   prism_risk_assessments:
     titles:
-      your_prism_risk_assessments: Risk assessments
+      your_prism_risk_assessments: Your risk assessments
+      team_prism_risk_assessments: Team risk assessments
+      all_prism_risk_assessments: All risk assessments
   audit_activity:
     investigation:
       coronavirus_related: Case is related to the coronavirus outbreak.

--- a/config/locales/loaf.en.yml
+++ b/config/locales/loaf.en.yml
@@ -23,3 +23,8 @@ en:
         your_products: Your products
         team_products: Team products
         all_products: All products - Search
+      prism_risk_assessments:
+        label: Risk assessments
+        your_prism_risk_assessments: Your risk assessments
+        team_prism_risk_assessments: Team risk assessments
+        all_prism_risk_assessments: All risk assessments - Search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,6 +272,8 @@ Rails.application.routes.draw do
 
   resource :prism_risk_assessments, only: [], path: "prism-risk-assessments" do
     get "your-prism-risk-assessments", to: "prism_risk_assessments#your_prism_risk_assessments", as: "your"
+    get "team-prism-risk-assessments", to: "prism_risk_assessments#team_prism_risk_assessments", as: "team"
+    get "all-prism-risk-assessments", to: "prism_risk_assessments#index", as: "all"
     get "add-to-case", to: "prism_risk_assessments#add_to_case", as: "add_to_case"
     post "add-to-case", to: "prism_risk_assessments#add_to_case"
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1907

## Description

Adds “your”, “team” and “all” risk assessments to the dashboard to match other dashboards.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-09-25 at 14 02 06](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/cd5b771e-b381-43da-a87e-db36c4b147ad)

![Screenshot 2023-09-25 at 14 02 11](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/6ea0f0ee-2b92-46f1-9073-573bca7707e0)

![Screenshot 2023-09-25 at 14 02 16](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/d0569511-3f66-4453-9f7b-b97ddc280787)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
