### PR TITLE
Move product images to separate model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,7 +130,7 @@ private
 
   def highlight_products?
     return true if params[:controller].start_with?("product")
-    return true if %w[documents document_uploads].include?(params[:controller]) && params[:product_id]
+    return true if %w[documents document_uploads image_uploads].include?(params[:controller]) && params[:product_id]
   end
 
   def highlight_cases?

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -1,0 +1,100 @@
+class ImageUploadsController < ApplicationController
+  include ImageUploadsHelper
+
+  before_action :set_and_authorise_parent
+
+  def new
+    @image_upload = ImageUpload.new(upload_model: @parent)
+    @parent = @parent.decorate
+  end
+
+  def create
+    if image_upload_params[:existing_file_upload_file_id].present? && image_upload_params[:file_upload].blank?
+      existing_file = existing_file_from_id(image_upload_params[:existing_file_upload_file_id])
+      @image_upload = ImageUpload.new(
+        image_upload_params.merge(
+          file_upload: existing_file, upload_model: @parent, created_by: current_user.id
+        )
+      )
+    elsif image_upload_params[:file_upload].present?
+      file = ActiveStorage::Blob.create_and_upload!(
+        io: image_upload_params[:file_upload],
+        filename: image_upload_params[:file_upload].original_filename,
+        content_type: image_upload_params[:file_upload].content_type
+      )
+      file.analyze_later
+      @image_upload = ImageUpload.new(
+        image_upload_params.merge(
+          file_upload: file, existing_file_upload_file_id: file.signed_id, upload_model: @parent, created_by: current_user.id
+        )
+      )
+    else
+      # The image upload won't be valid since there is no file
+      @image_upload = ImageUpload.new(image_upload_params.merge(upload_model: @parent, created_by: current_user.id))
+    end
+
+    # sleep to give the antivirus checks a chance to be completed before running document form validations
+    sleep 3
+
+    if @image_upload.valid?
+      @image_upload.save!
+      # Manually attach the image upload to its parent model's ID array
+      @parent.image_upload_ids.push(@image_upload.id)
+      @parent.save!
+    else
+      @parent = @parent.decorate
+      return render :new
+    end
+
+    # Reload the uploaded file to get the latest metadata
+    @image_upload.file_upload.try(:reload)
+
+    if @image_upload.file_upload.metadata["safe"] && @image_upload.file_upload.metadata["analyzed"]
+      flash[:success] = t(:image_added)
+    else
+      flash[:information] = "The image did not finish uploading - you must refresh the image"
+    end
+
+    redirect_to(product_path(@parent, anchor: "images"))
+  end
+
+  def remove
+    @image_upload = @parent.image_uploads.find(params[:id])
+  end
+
+  def destroy
+    # Destroying an image upload actually removes the association
+    # from the parent model. The parent model may implement versioning.
+    @image_upload = @parent.image_uploads.find(params[:id])
+    @parent.image_upload_ids.delete(@image_upload.id)
+    @parent.save!
+
+    flash[:success] = t(:image_removed)
+
+    redirect_to(@parent)
+  end
+
+  def show
+    @image_upload = @parent.image_uploads.find(params[:id]).decorate
+    @parent = @parent.decorate
+  end
+
+private
+
+  def set_and_authorise_parent
+    @parent = get_parent
+    authorize @parent, policy_class: ImageablePolicy
+  end
+
+  def get_parent
+    Product.find(params[:product_id])
+  end
+
+  def image_upload_params
+    params.require(:image_upload).permit(:file_upload, :existing_file_upload_file_id)
+  end
+
+  def existing_file_from_id(existing_file_id)
+    ActiveStorage::Blob.find_signed!(existing_file_id)
+  end
+end

--- a/app/decorators/image_upload_decorator.rb
+++ b/app/decorators/image_upload_decorator.rb
@@ -1,0 +1,31 @@
+class ImageUploadDecorator < ApplicationDecorator
+  delegate_all
+
+  def title
+    object.file_upload.filename.to_s
+  end
+
+  def supporting_information_title
+    object.file_upload.filename.to_s
+  end
+
+  def event_type
+    File.extname(object.file_upload.filename.to_s)&.remove(".")&.upcase
+  end
+
+  def date_of_activity
+    object.created_at.to_formatted_s(:govuk)
+  end
+
+  def date_added
+    object.created_at.to_formatted_s(:govuk)
+  end
+
+  def updated_at
+    object.updated_at.to_formatted_s(:govuk)
+  end
+
+  def show_path
+    h.investigation_document_path(Investigation.find_by(id: object.id), object)
+  end
+end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -22,6 +22,7 @@ class ProductForm
   attribute :added_by_user_id
   attribute :when_placed_on_market
   attribute :document_upload_ids
+  attribute :image_upload_ids
 
   before_validation { trim_line_endings(:description) }
   before_validation { trim_whitespace(:brand) }

--- a/app/forms/product_recall_form.rb
+++ b/app/forms/product_recall_form.rb
@@ -26,11 +26,11 @@ class ProductRecallForm
   def product_images(product)
     product.virus_free_images.map do |img|
       {
-        text: img.title,
+        text: img.file_upload.filename,
         value: img.id,
         disable_ghost: true,
         checked: product_image_ids.to_a.include?(img.id),
-        html: "#{img.title}<div class='govuk-hint govuk-checkboxes__hint govuk-!-font-size-16'>#{img.description}</div><code>#{img.file_upload.filename}</code><div class='opss-checkboxes-thumbnails_img' style='background-image: url(#{rails_storage_proxy_path(img.file_upload, only_path: true)})'></div>".html_safe
+        html: "<div class='opss-checkboxes-thumbnails_img' style='background-image: url(#{rails_storage_proxy_path(img.file_upload, only_path: true)})'></div>".html_safe
       }
     end
   end

--- a/app/helpers/image_uploads_helper.rb
+++ b/app/helpers/image_uploads_helper.rb
@@ -1,0 +1,46 @@
+module ImageUploadsHelper
+  def image_upload_placeholder(image)
+    render "image_uploads/placeholder", image:
+  end
+
+  def product_image_preview(image, dimensions)
+    render "products/image_preview", image:, dimensions:
+  end
+
+  def image_upload_file_extension(image)
+    File.extname(image.file_upload.filename.to_s)&.remove(".")&.upcase
+  end
+
+  def image_upload_path(image)
+    return investigation_image_upload_path(image.upload_model, image) if image.upload_model.is_a?(Investigation)
+
+    return product_image_upload_path(image.upload_model, image) if image.upload_model.is_a?(Product)
+
+    return business_image_upload_path(image.upload_model, image) if image.upload_model.is_a?(Business)
+
+    ""
+  end
+
+  def image_upload_filename_with_size(image)
+    "#{image.file_upload.filename} (#{number_to_human_size(image.file_upload.blob.byte_size)})"
+  end
+
+  def image_upload_pretty_type_description(*)
+    "image"
+  end
+
+  def formatted_image_upload_updated_date(image)
+    "Updated #{image_upload_updated_date_in_govuk_format image}"
+  end
+
+  def image_upload_updated_date_in_govuk_format(image)
+    image.updated_at.to_formatted_s(:govuk)
+  end
+
+  def imageable_policy(record)
+    # NOTE: record will be the parent record, not the document!
+    # NOTE: Pundit doesn't have a policy helper that allows the overriding
+    #   of policy_class, so this helper manually instantiates an instance
+    ImageablePolicy.new current_user, record
+  end
+end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -59,4 +59,17 @@ module UrlHelper
   def remove_associated_document_upload_path(parent, document_upload)
     "#{associated_document_upload_path(parent, document_upload)}/remove"
   end
+
+  # IMAGE UPLOADS
+  def associated_image_uploads_path(parent)
+    path_for_model(parent, :image_uploads)
+  end
+
+  def associated_image_upload_path(parent, image_upload)
+    "#{path_for_model(parent, :image_uploads)}/#{image_upload.id}"
+  end
+
+  def remove_associated_image_upload_path(parent, image_upload)
+    "#{associated_image_upload_path(parent, image_upload)}/remove"
+  end
 end

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -7,8 +7,8 @@ class DocumentUpload < ApplicationRecord
 
   attribute :existing_file_upload_file_id, :string
 
-  validates :file_upload, attached: true, size: { less_than: 100.megabytes, message: "must be smaller than 100MB" }
-  validates :file_upload, attached: true, size: { greater_than: 1.bytes, message: "must be larger than 0MB" }
+  validates :file_upload, attached: true, size: { less_than: 100.megabytes, message: "File must be smaller than 100MB" }
+  validates :file_upload, attached: true, size: { greater_than: 1.bytes, message: "File must be larger than 0MB" }
   validates :title, presence: true
   validates :description, length: { maximum: 10_000 }
   validate :file_is_free_of_viruses

--- a/app/models/image_upload.rb
+++ b/app/models/image_upload.rb
@@ -1,0 +1,26 @@
+class ImageUpload < ApplicationRecord
+  include SanitizationHelper
+
+  belongs_to :upload_model, polymorphic: true
+
+  has_one_attached :file_upload
+
+  attribute :existing_file_upload_file_id, :string
+
+  validates :file_upload, attached: true, size: { less_than: 100.megabytes, message: "Image must be smaller than 100MB" }
+  validates :file_upload, attached: true, size: { greater_than: 1.bytes, message: "Image must be larger than 0MB" }
+  # Allow standard GIF/JPEG/PNG files as well as WEBP (if downloaded from the web) or HEIC/HEIF (if taken by a smartphone)
+  validates :file_upload, attached: true, content_type: { in: ["image/gif", "image/jpeg", "image/png", "image/heic", "image/heif", "image/webp"], message: "Image must be a GIF, JPEG, PNG, WEBP or HEIC/HEIF file" }
+  validate :file_is_free_of_viruses
+
+private
+
+  def file_is_free_of_viruses
+    # Don't run this validation unless document has been analyzed by antivirus analyzer
+    return unless file_upload.metadata&.key?("safe")
+
+    return if file_upload.metadata["safe"] == true
+
+    errors.add(:base, :virus, message: "File upload must be virus free")
+  end
+end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -128,7 +128,7 @@ class Investigation < ApplicationRecord
   end
 
   def number_of_related_images
-    images.size + products.flat_map(&:images).count
+    images.size + products.flat_map(&:virus_free_images).count
   end
 
   def generic_supporting_information_attachments

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -81,15 +81,8 @@ class Product < ApplicationRecord
     tests + corrective_actions + unexpected_events + risk_assessments + prism_risk_assessments
   end
 
-  def images
-    document_uploads.select { |document_upload| document_upload.file_upload.content_type.starts_with?("image") }
-  end
-
   def virus_free_images
-    document_uploads.select do |document_upload|
-      file_upload = document_upload.file_upload
-      file_upload.content_type.starts_with?("image") && file_upload.metadata["safe"]
-    end
+    image_uploads.select { |image_upload| image_upload.file_upload.metadata["safe"] }
   end
 
   # Expose document uploads similarly to other model attributes while managing them as an
@@ -97,6 +90,13 @@ class Product < ApplicationRecord
   # uploads as they were at the time of the versioned product.
   def document_uploads
     DocumentUpload.where(id: document_upload_ids)
+  end
+
+  # Expose image uploads similarly to other model attributes while managing them as an
+  # array of IDs. This allows products to be versioned along with their associated image
+  # uploads as they were at the time of the versioned product.
+  def image_uploads
+    ImageUpload.where(id: image_upload_ids)
   end
 
   def psd_ref(timestamp: nil, investigation_was_closed: false)

--- a/app/policies/imageable_policy.rb
+++ b/app/policies/imageable_policy.rb
@@ -1,0 +1,36 @@
+class ImageablePolicy < ApplicationPolicy
+  # NOTE: record will be the parent record, not the image!
+
+  def show?
+    case record
+    when Investigation
+      # Users who can view protected details can see case attachments
+      Pundit.policy!(user, record).view_protected_details?
+    else
+      # Anyone can show other types of Imageable
+      true
+    end
+  end
+
+  def create?
+    case record
+    when Investigation
+      # Users who can update the case can attach to it
+      Pundit.policy!(user, record).update?
+    when Product
+      # Users who can update the product can attach to it
+      Pundit.policy!(user, record).update?
+    else
+      # Anyone can attach to a Business or other Imageable
+      true
+    end
+  end
+
+  def destroy?
+    create?
+  end
+
+  def remove?
+    destroy?
+  end
+end

--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -79,11 +79,11 @@ private
   end
 
   def image_cell(id)
-    document_upload = DocumentUpload.find_by(id:, upload_model: product)
+    image_upload = ImageUpload.find_by(id:, upload_model: product)
 
-    return if document_upload.blank?
+    return if image_upload.blank?
 
-    document_upload.file_upload.blob.open do |file|
+    image_upload.file_upload.blob.open do |file|
       { image: File.open(file.path), fit: [200, 200] }
     end
   end

--- a/app/views/image_uploads/_image_preview.html.erb
+++ b/app/views/image_uploads/_image_preview.html.erb
@@ -1,0 +1,38 @@
+<%
+  hide_link ||= false
+  class_name ||= ""
+  custom_image_classes ||= ""
+  analyzed = image.file_upload.metadata["analyzed"]
+  safe = image.file_upload.metadata["safe"]
+  image_class = if image.file_upload.variable?
+                  "app-document-preview__image"
+                else
+                  "app-document-preview__image-without-preview"
+                end
+  image_classes = class_names(image_class, custom_image_classes)
+%>
+
+<div class="app-document-preview <%= class_name %>">
+  <% if analyzed && safe %>
+    <div class="<%= image_classes %>">
+      <% if hide_link %>
+        <%= render("image_uploads/image_tag", image:, dimensions: dimensions) %>
+      <% else %>
+        <% link_content = capture do %>
+          <%= render("image_uploads/image_tag", image:, dimensions: dimensions) %>
+          <span class="govuk-visually-hidden">(opens in new tab)</span>
+        <% end %>
+        <%= link_to link_content, image, target: "_blank", rel: "noreferrer noopener" %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="app-document-preview">
+       <div class="app-document-preview__image">
+           <a target="_blank" rel="noreferrer noopener" href="#">
+             <%= image_tag "img-icon.png", alt: "" %>
+             <span class="govuk-visually-hidden">(opens in new tab)</span>
+           </a>
+       </div>
+     </div>
+  <% end %>
+</div>

--- a/app/views/image_uploads/_image_tag.html.erb
+++ b/app/views/image_uploads/_image_tag.html.erb
@@ -1,0 +1,6 @@
+<% if image.file_upload.variable? %>
+  <% class_name ||= 'app-image' %>
+  <%= image_tag image.file_upload.variant(resize_to_limit: dimensions), class: class_name, alt: image.file_upload.filename %>
+<% else %>
+  <span>Preview not available: <%= image.file_upload.filename %></span>
+<% end %>

--- a/app/views/image_uploads/_placeholder.html.erb
+++ b/app/views/image_uploads/_placeholder.html.erb
@@ -1,0 +1,6 @@
+<div class="app-document-preview__placeholder" aria-hidden="true">
+  <%= image_tag "document_placeholder_document.png", alt: "" %>
+  <span class="app-document-preview__filetype">
+    <%= image_upload_file_extension(image) %>
+  </span>
+</div>

--- a/app/views/image_uploads/new.html.erb
+++ b/app/views/image_uploads/new.html.erb
@@ -1,0 +1,20 @@
+<% title = "Add attachment" %>
+<%= page_title title, errors: @image_upload.errors.any? %>
+<%= form_with model: @image_upload, local: true, builder: ApplicationFormBuilder, html: { novalidate: true }, url: associated_image_uploads_path(@parent) do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= error_summary(@image_upload.errors, %i[file_upload])%>
+      <span class="govuk-caption-l"><%= @parent.pretty_description %></span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
+
+      <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
+        <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the case images page." : "Image files will be saved to the product images." %>
+        <div class="govuk-hint govuk-!-margin-bottom-8"><%= hint_text %></div>
+      <% end %>
+
+      <%= render "upload_file_component", form: form, old_file: nil, field_name: :file_upload, legend: "Upload a file", label: "Upload a file" %>
+
+      <%= govukButton text: "Save attachment" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/image_uploads/remove.html.erb
+++ b/app/views/image_uploads/remove.html.erb
@@ -1,0 +1,35 @@
+<%= page_title "Remove attachment" %>
+<% content_for :after_header do %>
+  <%= link_to "Back", attachments_tab_path(@parent, @image_upload), class: "govuk-back-link" %>
+<% end %>
+
+<%= render "page_heading", title: "Remove attachment" %>
+
+<%= render "image_uploads/image_preview", image: @image_upload, dimensions: [480, 320] %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Type</th>
+          <td class="govuk-table__cell">
+            <%= image_upload_pretty_type_description(@image_upload) %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">
+            URL
+          </th>
+          <td class="govuk-table__cell">
+            <%= @image_upload.file_upload.filename %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= form_with url: associated_image_upload_path(@parent, @image_upload), method: :delete, local: true do |form| %>
+  <%= form.submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
+<% end %>

--- a/app/views/image_uploads/show.html.erb
+++ b/app/views/image_uploads/show.html.erb
@@ -1,0 +1,51 @@
+<% page_heading = "Attachment" %>
+<%= page_title page_heading %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= page_heading %></h1>
+    <div class="app-meta-area">
+      <p class="govuk-body govuk-hint">
+        Added <%= @image_upload.created_at.to_formatted_s(:govuk) %>
+      </p>
+    </div>
+
+    <% rows = [
+        {
+          key: {
+            text: "Type"
+          },
+          value: {
+            text: @image_upload.event_type
+          }
+        },
+        {
+          key: {
+            text: "Event date"
+          },
+          value: {
+            text: @image_upload.created_at.to_formatted_s(:govuk)
+          }
+        },
+        {
+          key: {
+            text: "Added"
+          },
+          value: {
+            text: @image_upload.created_at.to_formatted_s(:govuk)
+
+          }
+        }
+      ] %>
+    <%= govukSummaryList(rows: rows) %>
+
+    <% if imageable_policy(@parent).remove? %>
+      <p class="govuk-body"><%= link_to "Remove attachment", remove_associated_image_upload_path(@parent, @image_upload), class: "govuk-link" %></p>
+    <% end %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Attachment</h2>
+    <p class="govuk-body"><%= link_to @image_upload.file_upload.filename, @image_upload.file_upload, class: "govuk-link" %></p>
+
+    <%= image_upload_placeholder(@image_upload) %>
+  </div>
+</div>

--- a/app/views/investigations/products/confirm.html.erb
+++ b/app/views/investigations/products/confirm.html.erb
@@ -43,8 +43,8 @@
                   <%= govukDetails(
                     summaryText: "Product image",
                     html: capture {
-                      render "document_uploads/document_preview",
-                        document: @product.virus_free_images.first,
+                      render "image_uploads/image_preview",
+                        image: @product.virus_free_images.first,
                         dimensions: [300, 500],
                         hide_link: true,
                         class_name: 'app-document-preview--small'

--- a/app/views/investigations/tabs/_products.html.erb
+++ b/app/views/investigations/tabs/_products.html.erb
@@ -37,7 +37,6 @@
             <% unless @product.virus_free_images.empty? %>
               <figure class="opss-margin-bottom-1-desktop">
                 <%= image_tag @product.virus_free_images.first.file_upload.variant(resize_to_limit: [300, 500]), class: "opss-details-img opss-details-img--thumbnail opss-float-right-desktop" %>
-                <figcaption class="govuk-visually-hidden"><%= @product.virus_free_images.first.title %></figcaption>
               </figure>
             <% end %>
           </div>

--- a/app/views/products/_image_preview.html.erb
+++ b/app/views/products/_image_preview.html.erb
@@ -1,6 +1,6 @@
 <figure>
   <a href="<%= url_for(image.file_upload) %>" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noreferrer noopener" title="Opens in a new tab">
-    <%= image_tag image.file_upload.variant(resize_to_limit: dimensions), alt: image.title %>
+    <%= image_tag image.file_upload.variant(resize_to_limit: dimensions), alt: image.file_upload.filename %>
   </a>
-  <figcaption><%= image.title %></figcaption>
+  <figcaption><%= image.file_upload.filename %></figcaption>
 </figure>

--- a/app/views/products/_images.html.erb
+++ b/app/views/products/_images.html.erb
@@ -8,10 +8,10 @@
       <% end %>
     </p>
   </div>
-  <% if documentable_policy(@product).create? %>
+  <% if imageable_policy(@product).create? %>
     <div class="govuk-grid-column-one-third">
       <div class="opss-text-align-right opss-margin-bottom-1-desktop">
-        <%= link_to "Add an image", new_product_document_upload_path(@product), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" %>
+        <%= link_to "Add an image", new_product_image_upload_path(@product), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" %>
       </div>
     </div>
   <% end %>
@@ -23,28 +23,19 @@
       <li>
         <%= govukSummaryList classes: "govuk-!-padding-bottom-9 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--image opss-summary-list-mixed--sm-font", rows: [
           {
-            key: { text: "Image and title" },
+            key: { text: "Image" },
             value: { text: product_image_preview(image, [400, 400]) },
           },
           {
-            key: { text: "Image description" },
-            value: { text: image.description },
-          },
-          {
             key: { text: "Updated" },
-            value: { text: document_upload_updated_date_in_govuk_format(image) },
+            value: { text: image_upload_updated_date_in_govuk_format(image) },
           }
         ] %>
         <div class="opss-text-align-right govuk-!-margin-bottom-8">
           <ul class="govuk-list">
-            <% if documentable_policy(@product).update? %>
+            <% if imageable_policy(@product).destroy? %>
               <li class="govuk-!-display-inline govuk-!-margin-left-2">
-                <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset" href="<%= edit_product_document_upload_path(@product, image) %>">Edit this image<span class="govuk-visually-hidden"><%= image.title %></span></a>
-              </li>
-            <% end %>
-            <% if documentable_policy(@product).destroy? %>
-              <li class="govuk-!-display-inline govuk-!-margin-left-2">
-                <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset" href="<%= remove_product_document_upload_path(@product, image) %>">Remove this image<span class="govuk-visually-hidden"><%= image.title %></span></a>
+                <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset" href="<%= remove_product_image_upload_path(@product, image) %>">Remove this image</a>
               </li>
             <% end %>
           </ul>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,8 +1,8 @@
 <li class="govuk-!-margin-bottom-3">
   <%= link_to product.name, product_path(product), class: "app-block-link govuk-link govuk-!-margin-bottom-2" %>
   <% if product.virus_free_images.any? %>
-    <%= render "document_uploads/document_preview",
-      document: product.virus_free_images.first,
+    <%= render "image_uploads/image_preview",
+      image: product.virus_free_images.first,
       dimensions: [300, 500],
       hide_link: true,
       class_name: 'app-document-preview--small' %>

--- a/app/views/products/case_product_info_tabs/_images.html.erb
+++ b/app/views/products/case_product_info_tabs/_images.html.erb
@@ -13,7 +13,7 @@
       <dl class="govuk-summary-list govuk-!-padding-bottom-9 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--image">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Image and title
+            Image
           </dt>
           <dd class="govuk-summary-list__value">
             <figure class="opss-margin-bottom-1-desktop">
@@ -22,16 +22,7 @@
                 <span class="govuk-visually-hidden">(opens in new tab)</span>
               <% end %>
               <%= link_to link_content, image.file_upload, target: "_blank", rel: "noreferrer noopener", title: "Opens in a new tab" %>
-              <figcaption><%= image.title %></figcaption>
             </figure>
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Image description
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= image.description %>
           </dd>
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/products/duplicate_checks/show.html.erb
+++ b/app/views/products/duplicate_checks/show.html.erb
@@ -55,7 +55,7 @@
                       </span>
                     </summary>
                       <div class="govuk-details__text">
-                        <%= image_tag(@image.file_upload, alt: @image.title, class: 'opss-details-img') %>
+                        <%= image_tag(@image.file_upload, alt: @image.file_upload.filename, class: 'opss-details-img') %>
                       </div>
                   </details>
                 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -54,7 +54,6 @@
         <div class="govuk-grid-column-one-third">
           <figure class="opss-margin-bottom-1-desktop">
             <%= image_tag @product.virus_free_images.first.file_upload.variant(resize_to_limit: [300, 500]), class: "opss-details-img opss-details-img--thumbnail opss-float-right-desktop" %>
-            <figcaption class="govuk-visually-hidden"><%= @product.virus_free_images.first.title %></figcaption>
           </figure>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,14 @@ Rails.application.routes.draw do
       end
     end
 
+    concern :image_uploadable do
+      resources :image_uploads, controller: "image_uploads", except: %i[edit update] do
+        member do
+          get :remove
+        end
+      end
+    end
+
     namespace :declaration do
       get :index, path: ""
       post :accept
@@ -232,7 +240,7 @@ Rails.application.routes.draw do
       get "all-products", to: "products#index", as: "all"
     end
 
-    resources :products, except: %i[destroy], concerns: %i[document_uploadable] do
+    resources :products, except: %i[destroy], concerns: %i[document_uploadable image_uploadable] do
       member do
         get :owner
       end

--- a/db/migrate/20231003134941_add_image_upload_ids_to_products.rb
+++ b/db/migrate/20231003134941_add_image_upload_ids_to_products.rb
@@ -1,0 +1,5 @@
+class AddImageUploadIdsToProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :products, :image_upload_ids, :bigint, array: true, default: []
+  end
+end

--- a/db/migrate/20231003135055_create_image_uploads.rb
+++ b/db/migrate/20231003135055_create_image_uploads.rb
@@ -1,0 +1,9 @@
+class CreateImageUploads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :image_uploads do |t|
+      t.uuid :created_by
+      t.references :upload_model, polymorphic: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231003141941_migrate_document_uploads_images_to_image_uploads_for_products.rb
+++ b/db/migrate/20231003141941_migrate_document_uploads_images_to_image_uploads_for_products.rb
@@ -1,0 +1,82 @@
+class MigrateDocumentUploadsImagesToImageUploadsForProducts < ActiveRecord::Migration[7.0]
+  # NOTE: Opensearch should be re-indexed manually after running this.
+  #
+  def up
+    attachments = ActiveStorage::Attachment.where(record_type: "DocumentUpload").includes(:blob, record: :upload_model)
+    images = attachments.select { |attachment| attachment.content_type.start_with?("image") }
+
+    Rails.logger.debug "Migrating #{images.count} images..."
+
+    images.each do |image|
+      Rails.logger.debug "Migrating image id=#{image.id}"
+
+      document_upload = image.record
+
+      # Create a new image upload and populate with details from the document upload
+      image_upload = ImageUpload.new(
+        upload_model: image.record.upload_model,
+        created_by: image.record.created_by,
+        created_at: image.record.created_at,
+        updated_at: image.record.updated_at
+      )
+      image_upload.save!(validate: false, touch: false) # The image upload won't be valid until we add the attachment
+
+      # Update the product to add the new image upload and remove the old document upload.
+      # Do not trigger callbacks which would create a new version and re-index
+      # Opensearch.
+      image.record.upload_model.update_columns(
+        image_upload_ids: (image.record.upload_model.image_upload_ids << image_upload.id),
+        document_upload_ids: (image.record.upload_model.document_upload_ids - [document_upload.id])
+      )
+
+      # Attach the existing blob to the image upload
+      image.update_columns(record_id: image_upload.id, record_type: "ImageUpload")
+
+      # Delete the document upload
+      document_upload.delete
+
+      Rails.logger.debug "Migrated image id=#{image.id}"
+    end
+  end
+
+  # NOTE: Opensearch should be re-indexed manually after running this.
+  #
+  def down
+    attachments = ActiveStorage::Attachment.where(record_type: "ImageUpload").includes(:blob, record: :upload_model)
+
+    Rails.logger.debug "Migrating #{attachments.count} images..."
+
+    attachments.each do |attachment|
+      Rails.logger.debug "Migrating image id=#{attachment.id}"
+
+      image_upload = attachment.record
+
+      # Create a new document upload and populate with details from the image upload
+      document_upload = DocumentUpload.new(
+        upload_model: attachment.record.upload_model,
+        title: "",
+        description: "",
+        created_by: attachment.record.created_by,
+        created_at: attachment.record.created_at,
+        updated_at: attachment.record.updated_at
+      )
+      document_upload.save!(validate: false, touch: false) # The document upload won't be valid until we add the attachment
+
+      # Update the product to add the new document upload and remove the old image upload.
+      # Do not trigger callbacks which would create a new version and re-index
+      # Opensearch.
+      attachment.record.upload_model.update_columns(
+        document_upload_ids: (image.record.upload_model.document_upload_ids << document_upload.id),
+        image_upload_ids: (image.record.upload_model.image_upload_ids - [image_upload.id])
+      )
+
+      # Attach the existing blob to the document upload
+      image.update_columns(record_id: document_upload.id, record_type: "DocumentUpload")
+
+      # Delete the image upload
+      image_upload.delete
+
+      Rails.logger.debug "Migrated image id=#{attachment.id}"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_155916) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_141941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -198,6 +198,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_155916) do
     t.bigint "upload_model_id"
     t.string "upload_model_type"
     t.index ["upload_model_type", "upload_model_id"], name: "index_document_uploads_on_upload_model"
+  end
+
+  create_table "image_uploads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "created_by"
+    t.datetime "updated_at", null: false
+    t.bigint "upload_model_id"
+    t.string "upload_model_type"
+    t.index ["upload_model_type", "upload_model_id"], name: "index_image_uploads_on_upload_model"
   end
 
   create_table "investigation_businesses", id: :serial, force: :cascade do |t|
@@ -437,6 +446,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_155916) do
     t.text "description"
     t.bigint "document_upload_ids", default: [], array: true
     t.enum "has_markings", enum_type: "has_markings_values"
+    t.bigint "image_upload_ids", default: [], array: true
     t.text "markings", array: true
     t.string "name"
     t.uuid "owning_team_id"

--- a/spec/factories/image_uploads.rb
+++ b/spec/factories/image_uploads.rb
@@ -1,0 +1,31 @@
+FactoryBot.define do
+  trait :with_image_upload_info do
+    transient do
+      document_file { Rails.root.join("test/fixtures/files/testImage.png") }
+    end
+  end
+
+  trait :with_antivirus_checked_image_upload do
+    with_image_upload_info
+
+    after :create do |model, evaluator|
+      file = ActiveSupportHelper.create_file(
+        model,
+        evaluator,
+        content_type: "image/png",
+        metadata: {
+          analyzed: true,
+          identified: true,
+          safe: true
+        }
+      )
+
+      image_upload = ImageUpload.create!(
+        upload_model: model,
+        file_upload: file
+      )
+
+      model.update!(image_upload_ids: [image_upload.id])
+    end
+  end
+end

--- a/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
+++ b/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
@@ -3,13 +3,7 @@ require "rails_helper"
 RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antivirus, type: :feature do
   let(:user)    { create(:user, :activated, has_viewed_introduction: true) }
   let(:product) { create(:product, owning_team: user.team) }
-
-  let(:image)                 { Rails.root.join "test/fixtures/files/testImage.png" }
-  let(:non_image_attachment)  { Rails.root.join "test/fixtures/files/attachment_filename.txt" }
-  let(:title)                 { Faker::Lorem.sentence }
-  let(:description)           { Faker::Lorem.paragraph }
-  let(:new_title)             { Faker::Lorem.sentence }
-  let(:new_description)       { Faker::Lorem.paragraph }
+  let(:image) { Rails.root.join "test/fixtures/files/testImage.png" }
 
   scenario "Adding an image", :with_stubbed_antivirus do
     sign_in user
@@ -22,64 +16,20 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
 
     click_button "Save attachment"
 
-    expect(page).to have_error_summary("File upload cannot be blank", "Title cannot be blank")
+    expect(page).to have_error_summary("File upload cannot be blank")
 
-    attach_file "document_upload[file_upload]", image
-    fill_in "Document title", with: title
-    fill_in "Description",    with: description
+    attach_file "image_upload[file_upload]", image
 
     click_button "Save attachment"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
     expect_confirmation_banner("The image was added")
-
-    expect(page).to have_selector("figcaption", text: title)
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: description)
 
     change_attachment_to_have_simulated_virus(product.reload)
 
     visit "/products/#{product.id}"
 
     click_link "Images (0)"
-
-    expect(page).not_to have_selector("figcaption", text: title)
-    expect(page).not_to have_selector("dd.govuk-summary-list__value", text: description)
-  end
-
-  scenario "Editing an image" do
-    sign_in user
-    visit "/products/#{product.id}"
-
-    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-
-    click_link "Add an image"
-    expect_to_be_on_add_attachment_to_a_product_page(product_id: product.id)
-
-    attach_file "document_upload[file_upload]", image
-    fill_in "Document title", with: title
-    fill_in "Description",    with: description
-
-    click_button "Save attachment"
-
-    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect_confirmation_banner("The image was added")
-
-    expect(page).to have_selector("figcaption", text: title)
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: description)
-
-    click_link "Edit this image"
-    expect_to_be_on_edit_attachment_for_a_product_page(product_id: product.id, document_upload_id: product.reload.virus_free_images.first.id)
-
-    fill_in "Document title", with: new_title
-    fill_in "Description",    with: new_description
-
-    click_button "Update attachment"
-
-    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect_confirmation_banner("The image was updated")
-
-    expect(page).to have_selector("figcaption", text: new_title)
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: new_description)
   end
 
   scenario "Deleting an image" do
@@ -91,31 +41,20 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
     click_link "Add an image"
     expect_to_be_on_add_attachment_to_a_product_page(product_id: product.id)
 
-    attach_file "document_upload[file_upload]", image
-    fill_in "Document title", with: title
-    fill_in "Description",    with: description
+    attach_file "image_upload[file_upload]", image
 
     click_button "Save attachment"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
     expect_confirmation_banner("The image was added")
 
-    expect(page).to have_selector("figcaption", text: title)
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: description)
-
     click_link "Remove this image"
-    expect_to_be_on_delete_attachment_for_a_product_page(product_id: product.id, document_upload_id: product.reload.virus_free_images.first.id)
-
-    expect(page).to have_selector("td.govuk-table__cell", text: title)
-    expect(page).to have_selector("td.govuk-table__cell", text: description)
+    expect_to_be_on_delete_attachment_for_a_product_page(product_id: product.id, image_upload_id: product.reload.virus_free_images.first.id)
 
     click_button "Delete attachment"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
     expect_confirmation_banner("The image was successfully removed")
-
-    expect(page).not_to have_selector("figcaption", text: title)
-    expect(page).not_to have_selector("dd.govuk-summary-list__value", text: description)
   end
 
   context "when an image fails the antivirus check", :with_stubbed_failing_antivirus do
@@ -130,15 +69,13 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
 
       click_button "Save attachment"
 
-      expect(page).to have_error_summary("File upload cannot be blank", "Title cannot be blank")
+      expect(page).to have_error_summary("File upload cannot be blank")
 
-      attach_file "document_upload[file_upload]", non_image_attachment
-      fill_in "Document title", with: title
-      fill_in "Description",    with: description
+      attach_file "image_upload[file_upload]", image
 
       click_button "Save attachment"
 
-      expect_warning_banner("The file did not finish uploading - you must refresh the file")
+      expect_warning_banner("The image did not finish uploading - you must refresh the image")
     end
   end
 
@@ -164,16 +101,13 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
 
       click_link "Add an image"
 
-      attach_file "document_upload[file_upload]", image
-      fill_in "Document title", with: title
-      fill_in "Description",    with: description
+      attach_file "image_upload[file_upload]", image
 
       click_button "Save attachment"
 
       expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
       expect_confirmation_banner("The image was added")
 
-      expect(page).to have_link("Edit this image")
       expect(page).to have_link("Remove this image")
 
       click_on "Sign out", match: :first
@@ -186,16 +120,14 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
       expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
 
       expect(page).not_to have_link("Add an image")
-      expect(page).not_to have_link("Edit image")
       expect(page).not_to have_link("Delete image")
 
-      expect { visit("/products/#{product.id}/document_uploads/#{product.virus_free_images.last.id}/edit") }.to raise_error(Pundit::NotAuthorizedError)
-      expect { visit("/products/#{product.id}/document_uploads/#{product.virus_free_images.last.id}/remove") }.to raise_error(Pundit::NotAuthorizedError)
+      expect { visit("/products/#{product.id}/image_uploads/#{product.virus_free_images.last.id}/remove") }.to raise_error(Pundit::NotAuthorizedError)
     end
   end
 
   def change_attachment_to_have_simulated_virus(product)
-    blob = product.document_uploads.first.file_upload.blob
+    blob = product.image_uploads.first.file_upload.blob
     blob.update!(metadata: blob.metadata.merge(safe: false))
   end
 end

--- a/spec/features/product_versioning_spec.rb
+++ b/spec/features/product_versioning_spec.rb
@@ -5,11 +5,9 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
   let(:initial_product_description) { "Widget" }
   let(:new_product_description) { "Sausage" }
   let(:creation_time) { 1.day.ago }
-  let(:product) { create(:product, :with_antivirus_checked_image_document_upload, description: initial_product_description, owning_team: user.team) }
+  let(:product) { create(:product, :with_antivirus_checked_image_upload, description: initial_product_description, owning_team: user.team) }
   let(:first_investigation) { create(:allegation, creator: user, products: [product]) }
   let(:second_investigation) { create(:allegation, creator: user) }
-  let(:initial_image_description) { product.virus_free_images.first.description }
-  let(:new_image_description) { "This is a new description for an existing image" }
 
   before do
     sign_in(user)
@@ -24,9 +22,6 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
     expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The PSD reference number for this product record")
     expect(page).to have_summary_item(key: "Description", value: initial_product_description)
     expect(page).to have_link("Images (1)")
-
-    click_link "Images (1)"
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: initial_image_description)
 
     # Close the case which has the product attached, to create a "timestamped" version
     visit "/cases/#{first_investigation.pretty_id}"
@@ -53,20 +48,11 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
     fill_in "Description of product", with: new_product_description
     click_button "Save"
 
-    # Edit the attached image
-    click_link "Images (1)"
-    click_link "Edit this image"
-    fill_in "Description", with: new_image_description
-    click_button "Update attachment"
-
     # Ensure product page shows latest version
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
     expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The PSD reference number for this product record")
     expect(page).to have_summary_item(key: "Description", value: new_product_description)
     expect(page).to have_link("Images (1)")
-
-    click_link "Images (1)"
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: new_image_description)
 
     # Old version should be accessible
     visit "/cases/#{first_investigation.pretty_id}/products"
@@ -76,9 +62,6 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
     expect(page).to have_selector("dd.govuk-summary-list__value", text: initial_product_description)
     expect(page).not_to have_link "Edit this product"
     expect(page).to have_link("Images (1)")
-
-    click_link "Images (1)"
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: initial_image_description)
 
     visit all_products_path
 

--- a/spec/support/active_support.rb
+++ b/spec/support/active_support.rb
@@ -1,11 +1,11 @@
 module ActiveSupportHelper
 module_function
 
-  def create_file(_model, evaluator, metadata: {})
+  def create_file(_model, evaluator, content_type: "text/plain", metadata: {})
     ActiveStorage::Blob.create_and_upload!(
       io: File.open(evaluator.document_file),
       filename: File.basename(evaluator.document_file),
-      content_type: "text/plain",
+      content_type:,
       metadata:
     )
   end

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -470,19 +470,13 @@ module PageExpectations
 
   def expect_to_be_on_add_attachment_to_a_product_page(product_id:)
     expect(page).to have_content "Image files will be saved to the product images"
-    expect(page).to have_current_path("/products/#{product_id}/document_uploads/new")
+    expect(page).to have_current_path("/products/#{product_id}/image_uploads/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
   end
 
-  def expect_to_be_on_edit_attachment_for_a_product_page(product_id:, document_upload_id:)
-    expect(page).to have_current_path("/products/#{product_id}/document_uploads/#{document_upload_id}/edit")
-    expect(page).to have_h2("Edit attachment")
-    expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
-  end
-
-  def expect_to_be_on_delete_attachment_for_a_product_page(product_id:, document_upload_id:)
-    expect(page).to have_current_path("/products/#{product_id}/document_uploads/#{document_upload_id}/remove")
+  def expect_to_be_on_delete_attachment_for_a_product_page(product_id:, image_upload_id:)
+    expect(page).to have_current_path("/products/#{product_id}/image_uploads/#{image_upload_id}/remove")
     expect(page).to have_h2("Remove attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1926

## Description

Creates a new `ImageUpload` model to house product image uploads separately from the generic `DocumentUpload` model.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2601.london.cloudapps.digital/
https://psd-pr-2601-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
