### PR TITLE
Add product image to product creation

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -147,8 +147,8 @@ private
   def sort_by_items
     items = [
       SortByHelper::SortByItem.new("Newly added", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Name A–Z", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_ASC),
-      SortByHelper::SortByItem.new("Name Z–A", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DESC)
+      SortByHelper::SortByItem.new("Name A-Z", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_ASC),
+      SortByHelper::SortByItem.new("Name Z-A", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DESC)
     ]
     items.unshift(SortByHelper::SortByItem.new("Relevance", SortByHelper::SORT_BY_RELEVANT, SortByHelper::SORT_DIRECTION_DEFAULT)) if params[:q].present?
     items

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -111,6 +111,22 @@ private
     @search = SearchParams.new(query_params.except(:page_name))
   end
 
+  def product_params
+    params.require(:product).permit(
+      :name, :brand, :category, :subcategory, :product_code,
+      :webpage, :description, :country_of_origin, :barcode,
+      :authenticity, :when_placed_on_market, :has_markings, markings: []
+    )
+  end
+
+  def product_params_for_update
+    params.require(:product).permit(
+      :subcategory, :product_code,
+      :webpage, :description, :country_of_origin, :barcode,
+      :when_placed_on_market, :has_markings, markings: []
+    )
+  end
+
   def query_params
     params.permit(:q, :sort_by, :sort_dir, :direction, :category, :retired_status, :page_name)
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -36,16 +36,19 @@ class ProductsController < ApplicationController
   end
 
   def create
-    @product_form = ProductForm.new product_params
+    @product_form = ProductForm.new(product_params)
 
     if @product_form.valid?
       context = CreateProduct.call!(
         @product_form.serializable_hash.merge(user: current_user)
       )
       @product = context.product
+      @product_form.cache_file!(current_user, @product)
+
       render :confirmation
     else
       set_countries
+      @product_form.cache_file!(current_user, nil)
       render :new
     end
   end
@@ -53,7 +56,7 @@ class ProductsController < ApplicationController
   def edit
     authorize @product, :update?
 
-    @product_form = ProductForm.from @product.object
+    @product_form = ProductForm.from(@product.object)
     breadcrumb breadcrumb_product_label, breadcrumb_product_path
     breadcrumb @product.name, product_path(@product)
   end
@@ -61,13 +64,13 @@ class ProductsController < ApplicationController
   def update
     authorize @product, :update?
 
-    @product_form = ProductForm.from @product.object
+    @product_form = ProductForm.from(@product.object)
     @product_form.attributes = product_params_for_update
 
     if @product_form.valid?
       UpdateProduct.call!(
         product: @product.object,
-        product_params: @product_form.serializable_hash,
+        product_params: @product_form.serializable_hash.except("image", "existing_image_file_id"),
         updating_team: current_user.team
       )
 
@@ -114,6 +117,7 @@ private
   def product_params
     params.require(:product).permit(
       :name, :brand, :category, :subcategory, :product_code,
+      :image, :existing_image_file_id,
       :webpage, :description, :country_of_origin, :barcode,
       :authenticity, :when_placed_on_market, :has_markings, markings: []
     )

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -24,6 +24,10 @@ class ProductForm
   attribute :document_upload_ids
   attribute :image_upload_ids
 
+  # Used when adding an image during product creation
+  attribute :image
+  attribute :existing_image_file_id
+
   before_validation { trim_line_endings(:description) }
   before_validation { trim_whitespace(:brand) }
   before_validation { nilify_blanks(:barcode, :brand) }
@@ -43,6 +47,31 @@ class ProductForm
 
   def self.from(product)
     new(product.serializable_hash(except: %i[owning_team_id updated_at retired_at]))
+  end
+
+  def initialize(*args)
+    super
+    self.image ||= ActiveStorage::Blob.find_signed!(existing_image_file_id) if existing_image_file_id.present?
+  end
+
+  def cache_file!(user, product)
+    if image.present? && !image.is_a?(ActiveStorage::Blob)
+      self.image = ActiveStorage::Blob.create_and_upload!(
+        io: image,
+        filename: image.original_filename,
+        content_type: image.content_type
+      )
+
+      image.analyze_later
+
+      self.existing_image_file_id = image.signed_id
+    elsif existing_image_file_id.present? && product.present?
+      image_upload = ImageUpload.new(upload_model: product, created_by: user.id, file_upload: ActiveStorage::Blob.find_signed!(existing_image_file_id))
+      image_upload.save!
+
+      product.image_upload_ids.push(image_upload.id)
+      product.save!
+    end
   end
 
   def authenticity_not_provided?

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,28 +1,4 @@
 module ProductsHelper
-  PARAMS_FOR_CREATE = [:brand,
-                       :name,
-                       :subcategory,
-                       :category,
-                       :product_code,
-                       :webpage,
-                       :description,
-                       :country_of_origin,
-                       :barcode,
-                       :authenticity,
-                       :when_placed_on_market,
-                       :has_markings,
-                       { markings: [] }].freeze
-  PARAMS_FOR_UPDATE = PARAMS_FOR_CREATE.without(:category, :authenticity,
-                                                :brand, :name)
-
-  def product_params
-    params.require(:product).permit(PARAMS_FOR_CREATE).with_defaults(markings: [])
-  end
-
-  def product_params_for_update
-    params.require(:product).permit(PARAMS_FOR_UPDATE).with_defaults(markings: [])
-  end
-
   def search_for_products(page_size = Product.count, user = current_user, ids_only: false)
     query = Product.includes(investigations: %i[owner_user owner_team])
 

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -73,6 +73,10 @@
   attributes: { disabled: local_assigns[:disable_permanent_fields] }
 ) %>
 
+<% if !local_assigns[:disable_image_upload] %>
+  <%= render "upload_file_component", form: form, old_file: nil, field_name: :image, legend: "Upload a product image", label: "Upload a product image" %>
+<% end %>
+
 <%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
 
 <%= govukInput(

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -19,7 +19,7 @@
   form: form,
   id: "subcategory",
   label: { text: "Product subcategory", classes: label_class },
-  hint: { text: "For example, ‘Face mask’ or ‘Washing machine’" }
+  hint: { text: "For example, 'Face mask' or 'Washing machine'" }
 ) %>
 
 <% if product_form.authenticity_unsure?  %>
@@ -100,7 +100,7 @@
   key: :webpage,
   form: form,
   label: { text: "Webpage", classes: label_class },
-  hint: { text: "The manufacturer’s page for the product, or a link to where it can be bought" }
+  hint: { text: "The manufacturer's page for the product, or a link to where it can be bought" }
 ) %>
 
 <%= govukSelect(
@@ -124,7 +124,7 @@
   form: form,
   attributes: { maxlength: 10_000 },
   label: { text: "Description of product", classes: label_class },
-  hint: { text: "Details about the product you haven’t included above. For example, colour, size, packaging description. Do not include details of damage or incidents" }
+  hint: { text: "Details about the product you haven't included above. For example, colour, size, packaging description. Do not include details of damage or incidents" }
 ) %>
 
 <%= form.submit local_assigns[:submit_text] || "Save", class: "govuk-button", data: { cy: "save" } %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= render "form", form: form, product_form: @product_form, countries: @countries, search: false, disable_permanent_fields: true %>
+      <%= render "form", form: form, product_form: @product_form, countries: @countries, search: false, disable_permanent_fields: true, disable_image_upload: true %>
     </div>
   </div>
 <% end %>

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -38,13 +38,13 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
     expect(page).to have_css("#item-3", text: chemical_product.name)
   end
 
-  scenario "selecting Name A–Z sorts ascending by name" do
+  scenario "selecting Name A-Z sorts ascending by name" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name A–Z"
+      click_on "Name A-Z"
     end
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
     expect(page).to have_current_path(/sort_dir=asc/, ignore_query: false)
-    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name A–Z")
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name A-Z")
 
     expect(page).to have_css("#item-0", text: another_drowning_product.name)
     expect(page).to have_css("#item-1", text: fire_product_8.name)
@@ -52,13 +52,13 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
     expect(page).to have_css("#item-3", text: fire_product_5.name)
   end
 
-  scenario "selecting Name Z–A sorts descending by name" do
+  scenario "selecting Name Z-A sorts descending by name" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name Z–A"
+      click_on "Name Z-A"
     end
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
     expect(page).to have_current_path(/sort_dir=desc/, ignore_query: false)
-    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name Z–A")
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name Z-A")
 
     expect(page).to have_css("#item-0", text: zebra_product.name)
     expect(page).to have_css("#item-1", text: fire_product_2.name)
@@ -68,14 +68,14 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
 
   scenario "selected sort order is persisted when filtering by category" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name A–Z"
+      click_on "Name A-Z"
     end
 
     select "Lifts", from: "Category"
     click_button "Apply"
 
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
-    expect(page).to have_css("form dl.govuk-list.opss-dl-select dd", text: "Active: Name A–Z")
+    expect(page).to have_css("form dl.govuk-list.opss-dl-select dd", text: "Active: Name A-Z")
   end
 
   scenario "filtering by keyword sorts by Relevance by default" do
@@ -93,7 +93,7 @@ RSpec.feature "Product sorting", :with_opensearch, :with_stubbed_mailer, type: :
 
   scenario "filtering by keyword persists a selected sort order" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name A–Z"
+      click_on "Name A-Z"
     end
 
     fill_in "Search", with: "hot product"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1822

## Description
 
Adds functionality to attach an image when creating a product.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2609.london.cloudapps.digital/
https://psd-pr-2609-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
