### PR TITLE
Remove limits on data exports

### DIFF
--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -5,7 +5,7 @@ module BusinessesHelper
     business
   end
 
-  def search_for_businesses(page_size = Business.count, user = current_user)
+  def search_for_businesses(page_size = Business.count, user = current_user, ids_only: false)
     query = Business.includes(investigations: %i[owner_user owner_team])
 
     if @search.q
@@ -27,10 +27,14 @@ module BusinessesHelper
       query = query.where(users: { id: team.users.map(&:id) }, teams: { id: team.id })
     end
 
-    query
-      .order(sorting_params)
-      .page(page_number)
-      .per(page_size)
+    if ids_only
+      query.pluck(:id)
+    else
+      query
+        .order(sorting_params)
+        .page(page_number)
+        .per(page_size)
+    end
   end
 
   def business_export_params

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -95,10 +95,7 @@ module InvestigationsHelper
     )
   end
 
-  def search_for_investigations(page_size = Investigation.count, user = current_user)
-    # This method is not used for searching across all investigations
-    # (see `opensearch_for_investigations` above), but it implements all filters
-    # for potential future use.
+  def search_for_investigations(page_size = Investigation.count, user = current_user, ids_only: false)
     query = Investigation.not_deleted.includes(:owner_user, :owner_team, :creator_user, :creator_team, :collaboration_accesses)
 
     if @search.q
@@ -172,10 +169,14 @@ module InvestigationsHelper
               end
     end
 
-    query
-      .order(@search.sorting_params)
-      .page(page_number)
-      .per(page_size)
+    if ids_only
+      query.pluck(:id)
+    else
+      query
+        .order(@search.sorting_params)
+        .page(page_number)
+        .per(page_size)
+    end
   end
 
   def query_params

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -23,7 +23,7 @@ module ProductsHelper
     params.require(:product).permit(PARAMS_FOR_UPDATE).with_defaults(markings: [])
   end
 
-  def search_for_products(page_size = Product.count, user = current_user)
+  def search_for_products(page_size = Product.count, user = current_user, ids_only: false)
     query = Product.includes(investigations: %i[owner_user owner_team])
 
     if @search.q
@@ -56,10 +56,14 @@ module ProductsHelper
       query = query.where(users: { id: team.users.map(&:id) }, teams: { id: team.id })
     end
 
-    query
-      .order(sorting_params)
-      .page(page_number)
-      .per(page_size)
+    if ids_only
+      query.pluck(:id)
+    else
+      query
+        .order(sorting_params)
+        .page(page_number)
+        .per(page_size)
+    end
   end
 
   def product_export_params

--- a/app/models/business_export.rb
+++ b/app/models/business_export.rb
@@ -31,7 +31,7 @@ private
     return @business_ids if @business_ids
 
     @search = SearchParams.new(params)
-    search_for_businesses(nil, nil).pluck(:id).sort
+    search_for_businesses(nil, nil, ids_only: true).sort
   end
 
   def add_businesses_worksheet(business_ids, book)

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -46,7 +46,7 @@ private
     return @case_ids if @case_ids
 
     @search = SearchParams.new(params)
-    opensearch_for_investigations(nil, user).pluck(:id).sort
+    search_for_investigations(nil, user, ids_only: true).sort
   end
 
   def activity_counts

--- a/app/models/product_export.rb
+++ b/app/models/product_export.rb
@@ -38,7 +38,7 @@ private
     return @product_ids if @product_ids
 
     @search = SearchParams.new(params)
-    search_for_products(nil, user).pluck(:id).sort
+    search_for_products(nil, user, ids_only: true).sort
   end
 
   def find_products(ids)


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1932

## Description

Fixes a bug where data exports were limited to default page size limits in OpenSearch and Kaminari.

Moves all export activity away from OpenSearch into Postgres and optimises queries to return all IDs.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2611.london.cloudapps.digital/
https://psd-pr-2611-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
