### PR TITLE
Allow multiple image uploads for investigations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -135,6 +135,6 @@ private
 
   def highlight_cases?
     return true if params[:controller].match?(/investigations|searches|collaborators|comments/)
-    return true if params[:controller] == "documents" && params[:investigation_pretty_id]
+    return true if %w[documents image_uploads].include?(params[:controller]) && params[:investigation_pretty_id]
   end
 end

--- a/app/decorators/audit_activity/document_upload/base_decorator.rb
+++ b/app/decorators/audit_activity/document_upload/base_decorator.rb
@@ -1,0 +1,7 @@
+class AuditActivity::DocumentUpload::BaseDecorator < ApplicationDecorator
+  delegate_all
+
+  def protected_details_type
+    "attachments"
+  end
+end

--- a/app/decorators/audit_activity/image_upload/base_decorator.rb
+++ b/app/decorators/audit_activity/image_upload/base_decorator.rb
@@ -1,0 +1,7 @@
+class AuditActivity::ImageUpload::BaseDecorator < ApplicationDecorator
+  delegate_all
+
+  def protected_details_type
+    "images"
+  end
+end

--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -34,7 +34,7 @@ module Investigations::DisplayTextHelper
       {
         href: investigation_images_path(investigation),
         text: "Images",
-        count: " (#{investigation.images.size})",
+        count: " (#{investigation.images.size + investigation.image_uploads.size})",
         active: is_current_tab.images?
       },
       {

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -20,7 +20,7 @@ module UrlHelper
 
   def attachments_tab_path(parent, file = nil)
     if parent.is_a?(Investigation)
-      path_for_model(parent) + (file&.image? ? "/images" : "/supporting-information")
+      path_for_model(parent) + (file.is_a?(ImageUpload) || file&.image? ? "/images" : "/supporting-information")
     else
       "#{path_for_model(parent)}#attachments"
     end

--- a/app/models/audit_activity/document_upload/add.rb
+++ b/app/models/audit_activity/document_upload/add.rb
@@ -1,0 +1,41 @@
+class AuditActivity::DocumentUpload::Add < AuditActivity::DocumentUpload::Base
+  has_one_attached :file_upload
+
+  def self.build_metadata(blob)
+    blob.metadata.merge(blob_id: blob.id)
+  end
+
+  def metadata
+    migrate_metadata_structure
+  end
+
+  def title(_user)
+    metadata["title"]
+  end
+
+  def description
+    metadata["description"]
+  end
+
+  def restricted_title(_user)
+    "Document added"
+  end
+
+private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if metadata
+
+    new_metadata = self.class.build_metadata(file_upload.blob)
+    new_metadata["title"] = self[:title]
+    new_metadata["description"] = self[:body]
+
+    JSON.parse(new_metadata.to_json)
+  end
+
+  def subtitle_slug
+    "#{attachment_type} added"
+  end
+end

--- a/app/models/audit_activity/document_upload/base.rb
+++ b/app/models/audit_activity/document_upload/base.rb
@@ -1,0 +1,19 @@
+class AuditActivity::DocumentUpload::Base < AuditActivity::Base
+  def has_attachment?
+    true
+  end
+
+  def attachment_type
+    attached_image? ? "Image" : "Document"
+  end
+
+  def attached_image?
+    file_upload.image?
+  end
+
+  def restricted_title(_user); end
+
+  def can_display_all_data?(user)
+    attached_image? || Pundit.policy(user, investigation).view_protected_details?
+  end
+end

--- a/app/models/audit_activity/document_upload/destroy.rb
+++ b/app/models/audit_activity/document_upload/destroy.rb
@@ -1,0 +1,33 @@
+class AuditActivity::DocumentUpload::Destroy < AuditActivity::DocumentUpload::Base
+  has_one_attached :file_upload
+
+  def self.build_metadata(blob)
+    blob.metadata.merge(blob_id: blob.id)
+  end
+
+  def metadata
+    migrate_metadata_structure
+  end
+
+  def title(_user)
+    "Deleted: #{metadata['title']}"
+  end
+
+  def restricted_title(_user)
+    "Document deleted"
+  end
+
+private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if metadata
+
+    JSON.parse(self.class.build_metadata(file_upload.blob).to_json)
+  end
+
+  def subtitle_slug
+    "#{attachment_type} deleted"
+  end
+end

--- a/app/models/audit_activity/document_upload/update.rb
+++ b/app/models/audit_activity/document_upload/update.rb
@@ -1,0 +1,87 @@
+class AuditActivity::DocumentUpload::Update < AuditActivity::DocumentUpload::Base
+  has_one_attached :file_upload
+
+  def self.build_metadata(blob)
+    {
+      blob_id: blob.id,
+      updates: blob.previous_changes.slice(:metadata)
+    }
+  end
+
+  def metadata
+    migrate_metadata_structure
+  end
+
+  def title(_user)
+    if title_changed?
+      "Updated: #{new_title || 'Untitled document'} (was: #{old_title || 'Untitled document'})"
+    elsif description_changed?
+      "Updated: Description for #{new_title}"
+    end
+  end
+
+  def new_description
+    metadata["updates"]["metadata"].last["description"]
+  end
+
+  def restricted_title(_user)
+    "Document updated"
+  end
+
+private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if metadata
+
+    title_matches = self[:title].match(/\AUpdated: (.*) \(was: (.*)\)\z/)
+    new_title = title_matches&.captures&.first
+    old_title = title_matches&.captures&.last
+
+    # We can't reconstruct the old description for comparison so we will need to compare the new description with nil
+    description_changed = self[:title].start_with?("Updated: Description for")
+
+    new_metadata = {
+      blob_id: file_upload.blob.id,
+      updates: {
+        metadata: [
+          {
+            title: old_title,
+            description: nil
+          },
+          {
+            title: new_title,
+            description: (description_changed ? self[:body] : nil)
+          }
+        ]
+      }
+    }
+
+    JSON.parse(new_metadata.to_json)
+  end
+
+  def subtitle_slug
+    "#{attachment_type} details updated"
+  end
+
+  def title_changed?
+    old_title != new_title
+  end
+
+  def description_changed?
+    old_description != new_description
+  end
+
+  def old_title
+    metadata["updates"]["metadata"].first["title"]
+  end
+
+  def new_title
+    metadata["updates"]["metadata"].last["title"]
+  end
+
+  def old_description
+    metadata["updates"]["metadata"].first["description"]
+  end
+end

--- a/app/models/audit_activity/image_upload/add.rb
+++ b/app/models/audit_activity/image_upload/add.rb
@@ -1,0 +1,35 @@
+class AuditActivity::ImageUpload::Add < AuditActivity::ImageUpload::Base
+  has_one_attached :file_upload
+
+  def self.build_metadata(blob)
+    blob.metadata.merge(blob_id: blob.id, blob_filename: blob.filename)
+  end
+
+  def metadata
+    migrate_metadata_structure
+  end
+
+  def title(_user)
+    "Added: #{metadata['blob_filename']}"
+  end
+
+  def restricted_title(_user)
+    "Image added"
+  end
+
+private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if metadata
+
+    new_metadata = self.class.build_metadata(attachment.blob)
+
+    JSON.parse(new_metadata.to_json)
+  end
+
+  def subtitle_slug
+    "Image added"
+  end
+end

--- a/app/models/audit_activity/image_upload/base.rb
+++ b/app/models/audit_activity/image_upload/base.rb
@@ -1,0 +1,11 @@
+class AuditActivity::ImageUpload::Base < AuditActivity::Base
+  def has_attachment?
+    true
+  end
+
+  def restricted_title(_user); end
+
+  def can_display_all_data?(_user)
+    true
+  end
+end

--- a/app/models/audit_activity/image_upload/destroy.rb
+++ b/app/models/audit_activity/image_upload/destroy.rb
@@ -1,0 +1,33 @@
+class AuditActivity::ImageUpload::Destroy < AuditActivity::ImageUpload::Base
+  has_one_attached :file_upload
+
+  def self.build_metadata(blob)
+    blob.metadata.merge(blob_id: blob.id, blob_filename: blob.filename)
+  end
+
+  def metadata
+    migrate_metadata_structure
+  end
+
+  def title(_user)
+    "Deleted: #{metadata['blob_filename']}"
+  end
+
+  def restricted_title(_user)
+    "Image deleted"
+  end
+
+private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if metadata
+
+    JSON.parse(self.class.build_metadata(attachment.blob).to_json)
+  end
+
+  def subtitle_slug
+    "Image deleted"
+  end
+end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -119,6 +119,7 @@ class Investigation < ApplicationRecord
     self
   end
 
+  # Legacy images that were uploaded as an attachment
   def images
     @images ||= documents
       .includes(:blob)
@@ -128,7 +129,7 @@ class Investigation < ApplicationRecord
   end
 
   def number_of_related_images
-    images.size + products.flat_map(&:virus_free_images).count
+    images.size + image_uploads.size + products.flat_map(&:virus_free_images).count
   end
 
   def generic_supporting_information_attachments
@@ -139,16 +140,15 @@ class Investigation < ApplicationRecord
       .where.not(record: [corrective_actions, correspondences, tests])
   end
 
-  def virus_free_images
-    images.joins(:blob).where("active_storage_blobs.metadata LIKE ?", '%"safe":true%')
-  end
-
-  def virus_free_non_image_attachments
-    generic_supporting_information_attachments.joins(:blob).where("active_storage_blobs.metadata LIKE ?", '%"safe":true%')
-  end
-
   def supporting_information
     @supporting_information ||= (corrective_actions + correspondences + test_results.includes(:investigation_product) + risk_assessments + prism_risk_assessments + accidents + incidents).sort_by(&:created_at).reverse
+  end
+
+  # Expose image uploads similarly to other model attributes while managing them as an
+  # array of IDs. This allows investigations to be versioned along with their associated image
+  # uploads as they were at the time of the versioned investigation.
+  def image_uploads
+    ImageUpload.where(id: image_upload_ids)
   end
 
   def enquiry?

--- a/app/views/image_uploads/_image_preview.html.erb
+++ b/app/views/image_uploads/_image_preview.html.erb
@@ -22,7 +22,7 @@
           <%= render("image_uploads/image_tag", image:, dimensions: dimensions) %>
           <span class="govuk-visually-hidden">(opens in new tab)</span>
         <% end %>
-        <%= link_to link_content, image, target: "_blank", rel: "noreferrer noopener" %>
+        <%= link_to link_content, rails_storage_proxy_path(image.file_upload), target: "_blank", rel: "noreferrer noopener" %>
       <% end %>
     </div>
   <% else %>

--- a/app/views/image_uploads/new.html.erb
+++ b/app/views/image_uploads/new.html.erb
@@ -1,4 +1,4 @@
-<% title = "Add attachment" %>
+<% title = "Add an image" %>
 <%= page_title title, errors: @image_upload.errors.any? %>
 <%= form_with model: @image_upload, local: true, builder: ApplicationFormBuilder, html: { novalidate: true }, url: associated_image_uploads_path(@parent) do |form| %>
   <div class="govuk-grid-row">
@@ -8,13 +8,61 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
 
       <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
-        <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the case images page." : "Image files will be saved to the product images." %>
-        <div class="govuk-hint govuk-!-margin-bottom-8"><%= hint_text %></div>
+        <% hint_text = @parent.is_a?(Investigation) ? "To provide visual evidence of the product hazard or incident/accident, you can upload either a single image or multiple images to the case." : "Image files will be saved to the product images." %>
+        <div class="govuk-hint"><%= hint_text %></div>
+        <div class="govuk-hint">Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF. Maximum file size: 100MB.</div>
       <% end %>
 
-      <%= render "upload_file_component", form: form, old_file: nil, field_name: :file_upload, legend: "Upload a file", label: "Upload a file" %>
+      <%= render "upload_file_component", form: form, old_file: nil, field_name: :file_upload, label: nil %>
 
-      <%= govukButton text: "Save attachment" %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <% if @parent.is_a?(Investigation) && params[:image_upload_id].present? %>
+        <% params[:image_upload_id].each do |image_upload_id| %>
+          <input type="hidden" name="image_upload_id[]" value="<%= image_upload_id %>">
+        <% end %>
+        <table class="govuk-table">
+          <caption class="govuk-visually-hidden">
+            A table of images already uploaded for this case during the current session.
+          </caption>
+          <thead class="govuk-table__head govuk-visually-hidden">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">File name</th>
+              <th scope="col" class="govuk-table__header opss-text-align-right">Remove file</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body" data-cy-case-id="<%= @parent.pretty_id %>">
+            <% params[:image_upload_id].each do |image_upload_id| %>
+              <%
+                image_upload = @parent.image_uploads.find_by(id: image_upload_id)
+                next unless image_upload
+              %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  <a href="<%= url_for(image_upload.file_upload) %>" class="govuk-link" rel="noreferrer noopener" target="_blank"><%= image_upload.file_upload.filename %></a>
+                </td>
+                <td class="govuk-table__cell opss-text-align-right">
+                  <a href="<%= remove_investigation_image_upload_path(@parent, image_upload, multiple: true, image_upload_id: (params[:image_upload_id] - [image_upload_id])) %>" class="govuk-link">Remove</a>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+          <% if params[:image_upload_id].size > 11 %>
+            <tfoot class="govuk-table__head govuk-visually-hidden">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">File name</th>
+                <th scope="col" class="govuk-table__header opss-text-align-right">Remove file</th>
+              </tr>
+            </tfoot>
+          <% end %>
+        </table>
+      <% end %>
+
+      <%= govukButton text: "Upload" %>
+
+      <% if @parent.is_a?(Investigation) %>
+        <p class="govuk-body"><a href="<%= investigation_images_path(@parent) %>" class="govuk-link">Finish uploading images</a></p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/image_uploads/remove.html.erb
+++ b/app/views/image_uploads/remove.html.erb
@@ -1,9 +1,9 @@
-<%= page_title "Remove attachment" %>
+<%= page_title "Remove image" %>
 <% content_for :after_header do %>
   <%= link_to "Back", attachments_tab_path(@parent, @image_upload), class: "govuk-back-link" %>
 <% end %>
 
-<%= render "page_heading", title: "Remove attachment" %>
+<%= render "page_heading", title: "Remove image" %>
 
 <%= render "image_uploads/image_preview", image: @image_upload, dimensions: [480, 320] %>
 
@@ -31,5 +31,11 @@
 </div>
 
 <%= form_with url: associated_image_upload_path(@parent, @image_upload), method: :delete, local: true do |form| %>
-  <%= form.submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
+  <% if params[:multiple] %>
+    <input type="hidden" name="multiple" value="true">
+    <% (params[:image_upload_id] || []).each do |image_upload_id| %>
+      <input type="hidden" name="image_upload_id[]" value="<%= image_upload_id %>">
+    <% end %>
+  <% end %>
+  <%= form.submit "Delete image", class: "govuk-button govuk-button--warning" %>
 <% end %>

--- a/app/views/image_uploads/show.html.erb
+++ b/app/views/image_uploads/show.html.erb
@@ -39,7 +39,7 @@
     <%= govukSummaryList(rows: rows) %>
 
     <% if imageable_policy(@parent).remove? %>
-      <p class="govuk-body"><%= link_to "Remove attachment", remove_associated_image_upload_path(@parent, @image_upload), class: "govuk-link" %></p>
+      <p class="govuk-body"><%= link_to "Remove image", remove_associated_image_upload_path(@parent, @image_upload), class: "govuk-link" %></p>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/investigations/_actions.html.erb
+++ b/app/views/investigations/_actions.html.erb
@@ -20,7 +20,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Image&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.number_of_related_images %><span class="govuk-visually-hidden"> added</span>)</span></dt>
       <% if policy(@investigation).update? %>
-        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_document_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> an image</span></a></dd>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_image_upload_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> an image</span></a></dd>
       <% end %>
     </div>
     <div class="govuk-summary-list__row">

--- a/app/views/investigations/activities/document_upload/_add.html.erb
+++ b/app/views/investigations/activities/document_upload/_add.html.erb
@@ -1,0 +1,16 @@
+<% if activity.description %>
+  <p><%= markdown simple_format(activity.description) %></p>
+<% end %>
+
+<% if activity.file_upload.image? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%= render "document_uploads/document_preview",
+               document: activity.file_upload,
+               dimensions: [100, 100],
+               class_name: "product-image" %>
+    </div>
+  </div>
+<% else %>
+  <%= link_to "View document upload (opens in new tab)", activity.file_upload, class: "psd-block-link govuk-link--no-visited-state", target: "_blank", rel: "noreferrer noopener" %>
+<% end %>

--- a/app/views/investigations/activities/document_upload/_destroy.html.erb
+++ b/app/views/investigations/activities/document_upload/_destroy.html.erb
@@ -1,0 +1,12 @@
+<% if activity.file_upload.image? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%= render "document_uploads/document_preview",
+               document: activity.file_upload,
+               dimensions: [100, 100],
+               class_name: "product-image" %>
+    </div>
+  </div>
+<% else %>
+  <%= link_to "View document upload (opens in new tab)", activity.file_upload, class: "psd-block-link govuk-link--no-visited-state", target: "_blank", rel: "noreferrer noopener" %>
+<% end %>

--- a/app/views/investigations/activities/document_upload/_update.html.erb
+++ b/app/views/investigations/activities/document_upload/_update.html.erb
@@ -1,0 +1,16 @@
+<% if activity.new_description %>
+  <p><%= markdown simple_format(activity.new_description) %></p>
+<% end %>
+
+<% if activity.file_upload.image? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <%= render "document_uploads/document_preview",
+               document: activity.file_upload,
+               dimensions: [100, 100],
+               class_name: "product-image" %>
+    </div>
+  </div>
+<% else %>
+  <%= link_to "View document upload (opens in new tab)", activity.file_upload, class: "psd-block-link govuk-link--no-visited-state", target: "_blank", rel: "noreferrer noopener" %>
+<% end %>

--- a/app/views/investigations/activities/image_upload/_add.html.erb
+++ b/app/views/investigations/activities/image_upload/_add.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "image_uploads/image_preview",
+             image: activity,
+             dimensions: [100, 100],
+             class_name: "product-image" %>
+  </div>
+</div>

--- a/app/views/investigations/activities/image_upload/_destroy.html.erb
+++ b/app/views/investigations/activities/image_upload/_destroy.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "image_uploads/image_preview",
+             image: activity,
+             dimensions: [100, 100],
+             class_name: "product-image" %>
+  </div>
+</div>

--- a/app/views/investigations/images/index.html.erb
+++ b/app/views/investigations/images/index.html.erb
@@ -2,7 +2,7 @@
                                                 current_tab: "images",
                                                 case_page_heading: "Images",
                                                 secondary_text: "These are the case evidence images showing damage, incidents, injuries or other case evidence.",
-                                                href: new_investigation_document_path(@investigation),
+                                                href: new_investigation_image_upload_path(@investigation),
                                                 link_text: "Add a case image" do %>
   <%= render "investigations/tabs/images" %>
 <% end %>

--- a/app/views/investigations/tabs/_images.html.erb
+++ b/app/views/investigations/tabs/_images.html.erb
@@ -1,6 +1,6 @@
 <%= page_title "Images - #{@investigation.pretty_id}" %>
 
-<% if @investigation.images.none? %>
+<% if @investigation.images.none? && @investigation.image_uploads.none? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <p class="govuk-body opss-text-align-center">This case does not have any case evidence images.</p>
@@ -74,6 +74,64 @@
       <% if policy(@investigation).update? %>
         <%= link_to(remove_associated_document_path(@investigation, image), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset") do %>
           Remove this image<span class="govuk-visually-hidden">: <%= image_title %></span>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<%
+  @investigation.image_uploads.each.with_index(@investigation.images.size + 1) do |image_upload, image_number|
+    image = image_upload.file_upload
+    analyzed = image.metadata["analyzed"]
+    safe = image.metadata["safe"]
+    metadata_ok_for_display = safe || !analyzed
+%>
+  <section class="govuk-!-margin-bottom-9">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h3 class="govuk-heading-m">Case image <%= image_number %></h3>
+      </div>
+    </div>
+    <dl class="govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--image">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Image</dt>
+        <dd class="govuk-summary-list__value">
+          <% if analyzed && safe %>
+            <figure>
+              <%= link_to image, class: "govuk-link govuk-link--no-visited-state", rel: "noreferrer noopener", target: "_blank", title: "Opens in a new tab" do %>
+                <%= render("image_uploads/image_tag", image: image_upload, dimensions: [300, 200], class_name: "") %>
+              <% end %>
+            </figure>
+          <% else %>
+            <figure>
+              <a target="_blank" rel="noreferrer noopener" href="#">
+                <%= image_tag "img-icon.png", alt: "Blank image", class: "opss-blank-img" %>
+              </a>
+              <% if !analyzed %>
+                <figcaption class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-0 opss-warning-text--s">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                      <span class="govuk-warning-text__assistive">Warning</span>
+                      The image file has not finished uploading – this may take several minutes or more. Refresh the page to confirm it has finished.
+                  </strong>
+                </figcaption>
+              <% end %>
+            </figure>
+          <% end %>
+        </dd>
+      </div>
+      <% if metadata_ok_for_display %>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Updated</dt>
+            <dd class="govuk-summary-list__value"><%= file_updated_date_in_govuk_format image %></dd>
+        </div>
+      <% end %>
+    </dl>
+    <div class="opss-text-align-right opss-margin-bottom-1-desktop">
+      <% if policy(@investigation).update? %>
+        <%= link_to(remove_associated_image_upload_path(@investigation, image_upload), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset") do %>
+          Remove this image
         <% end %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,14 +453,12 @@ en:
             authorised_representative_choice:
               blank: Select an authorised representative region
               inclusion: Select an authorised representative region
-
         remove_business_form:
           attributes:
             remove:
               inclusion: "Select yes if you want to remove the business from the case"
             reason:
               blank: "Enter the reason for removing the business from the case"
-
         accident_or_incident_form:
           attributes:
             is_date_known:
@@ -545,7 +543,6 @@ en:
               blank: "Select the product marking(s)"
             when_placed_on_market:
               blank: "Select yes if the product was placed on the market before 1 January 2021"
-
         risk_assessment_form:
           attributes:
             assessed_on:
@@ -790,6 +787,10 @@ en:
           attributes:
             correspondence_date:
               invalid: "Enter a real correspondence date"
+        image_upload:
+          attributes:
+            file_upload:
+              blank: "Select a file"
         investigation:
           attributes:
             product_category:
@@ -881,7 +882,7 @@ en:
   file_added: "The file was added"
   file_updated: "File has been updated"
   file_removed: "File was successfully removed"
-  image_added: "The image was added"
+  image_added: "The image was uploaded"
   image_updated: "The image was updated"
   image_removed: "The image was successfully removed"
   otp_code:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Rails.application.routes.draw do
               path: "cases",
               only: %i[show index destroy],
               param: :pretty_id,
-              concerns: %i[document_attachable] do
+              concerns: %i[document_attachable image_uploadable] do
       member do
         get :created
         get :cannot_close

--- a/db/migrate/20231009105855_add_image_upload_ids_to_investigations.rb
+++ b/db/migrate/20231009105855_add_image_upload_ids_to_investigations.rb
@@ -1,0 +1,5 @@
+class AddImageUploadIdsToInvestigations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :investigations, :image_upload_ids, :bigint, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,6 +249,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_141513) do
     t.text "description"
     t.text "hazard_description"
     t.string "hazard_type"
+    t.bigint "image_upload_ids", default: [], array: true
     t.boolean "is_closed", default: false
     t.boolean "is_from_overseas_regulator"
     t.boolean "is_private", default: false, null: false

--- a/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
+++ b/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
@@ -14,16 +14,16 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
     click_link "Add an image"
     expect_to_be_on_add_attachment_to_a_product_page(product_id: product.id)
 
-    click_button "Save attachment"
+    click_button "Upload"
 
-    expect(page).to have_error_summary("File upload cannot be blank")
+    expect(page).to have_error_summary("Select a file")
 
     attach_file "image_upload[file_upload]", image
 
-    click_button "Save attachment"
+    click_button "Upload"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect_confirmation_banner("The image was added")
+    expect_confirmation_banner("The image was uploaded")
 
     change_attachment_to_have_simulated_virus(product.reload)
 
@@ -43,15 +43,15 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
 
     attach_file "image_upload[file_upload]", image
 
-    click_button "Save attachment"
+    click_button "Upload"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect_confirmation_banner("The image was added")
+    expect_confirmation_banner("The image was uploaded")
 
     click_link "Remove this image"
     expect_to_be_on_delete_attachment_for_a_product_page(product_id: product.id, image_upload_id: product.reload.virus_free_images.first.id)
 
-    click_button "Delete attachment"
+    click_button "Delete image"
 
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
     expect_confirmation_banner("The image was successfully removed")
@@ -67,15 +67,15 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
       click_link "Add an image"
       expect_to_be_on_add_attachment_to_a_product_page(product_id: product.id)
 
-      click_button "Save attachment"
+      click_button "Upload"
 
-      expect(page).to have_error_summary("File upload cannot be blank")
+      expect(page).to have_error_summary("Select a file")
 
       attach_file "image_upload[file_upload]", image
 
-      click_button "Save attachment"
+      click_button "Upload"
 
-      expect_warning_banner("The image did not finish uploading - you must refresh the image")
+      expect_warning_banner("File upload must be virus free")
     end
   end
 
@@ -93,7 +93,7 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
       expect { visit("/products/#{product.id}/document_uploads/new") }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not allow the user to edit or delete attachments" do
+    it "does not allow the user to edit or delete images" do
       sign_in owning_user
       visit "/products/#{product.id}"
 
@@ -103,10 +103,10 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
 
       attach_file "image_upload[file_upload]", image
 
-      click_button "Save attachment"
+      click_button "Upload"
 
       expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-      expect_confirmation_banner("The image was added")
+      expect_confirmation_banner("The image was uploaded")
 
       expect(page).to have_link("Remove this image")
 

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Case actions", :with_stubbed_antivirus, :with_stubbed_mailer, typ
       within("#page-content section dl.govuk-summary-list") do
         expect(page).to have_link("Add a product", href: new_investigation_product_path(investigation_1))
         expect(page).to have_link("Add a business", href: new_investigation_business_types_path(investigation_1))
-        expect(page).to have_link("Add an image", href: new_investigation_document_path(investigation_1))
+        expect(page).to have_link("Add an image", href: new_investigation_image_upload_path(investigation_1))
         expect(page).to have_link("Add an accident or incident", href: new_investigation_accident_or_incidents_type_path(investigation_1))
         expect(page).to have_link("Add a corrective action", href: new_investigation_corrective_action_path(investigation_1))
         expect(page).to have_link("Add a risk assessment", href: new_investigation_prism_risk_assessment_path(investigation_1))

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -40,9 +40,11 @@ module PageExpectations
     expect(page).to have_selector("h1", text: "Images")
   end
 
-  def expect_to_be_on_add_image_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new")
-    expect(page).to have_selector("h1", text: "Add attachment")
+  def expect_to_be_on_add_image_page(image_upload_id: nil)
+    # rubocop:disable Style/StringConcatenation
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/image_uploads/new#{image_upload_id.present? ? '?image_upload_id[]=' + image_upload_id.to_s : ''}")
+    # rubocop:enable Style/StringConcatenation
+    expect(page).to have_selector("h1", text: "Add an image")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Cases")
   end
 
@@ -204,6 +206,13 @@ module PageExpectations
     expect(page).to have_content "Image files will be saved to the case images page."
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new")
     expect(page).to have_h1("Add attachment")
+    expect(page).to have_css(".psd-header__navigation-item--active", text: "Cases")
+  end
+
+  def expect_to_be_on_add_image_to_a_case_page
+    expect(page).to have_content "To provide visual evidence of the product hazard or incident/accident, you can upload either a single image or multiple images to the case."
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/image_uploads/new")
+    expect(page).to have_h1("Add an image")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Cases")
   end
 
@@ -471,13 +480,13 @@ module PageExpectations
   def expect_to_be_on_add_attachment_to_a_product_page(product_id:)
     expect(page).to have_content "Image files will be saved to the product images"
     expect(page).to have_current_path("/products/#{product_id}/image_uploads/new")
-    expect(page).to have_h1("Add attachment")
+    expect(page).to have_h1("Add an image")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
   end
 
   def expect_to_be_on_delete_attachment_for_a_product_page(product_id:, image_upload_id:)
     expect(page).to have_current_path("/products/#{product_id}/image_uploads/#{image_upload_id}/remove")
-    expect(page).to have_h2("Remove attachment")
+    expect(page).to have_h2("Remove image")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1819

## Description

Allows users to upload multiple images for an investigation one after the other without having to return to the investigation page each time.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-10-09 at 14 22 32](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/3a57403e-a434-41c4-b495-b55b26d28beb)

![Screenshot 2023-10-09 at 14 22 46](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/d11a3426-765a-4953-ae13-cf205ffb011f)

## Review apps

https://psd-pr-2616.london.cloudapps.digital/
https://psd-pr-2616-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
