### PR TITLE
Rename case to notification - PSD-1947

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -58,10 +58,10 @@ class Investigations::TsInvestigationsController < ApplicationController
       return render_wizard unless @reason_for_creating_form.valid?
 
       if @reason_for_creating_form.case_is_safe == "yes"
-        session[:investigation] = Investigation::Case.new(reported_reason: "safe_and_compliant")
+        session[:investigation] = Investigation::Notification.new(reported_reason: "safe_and_compliant")
         skip_step
       else
-        session[:investigation] = Investigation::Case.new
+        session[:investigation] = Investigation::Notification.new
       end
       session[:form_answers] = reason_for_creating_params
     when :reason_for_concern
@@ -69,7 +69,7 @@ class Investigations::TsInvestigationsController < ApplicationController
       @edit_why_reporting_form = EditWhyReportingForm.new(reason_for_concern_params.merge(reported_reason:))
       return render_wizard unless @edit_why_reporting_form.valid?
 
-      session[:investigation] = Investigation::Case.new(reported_reason:, hazard_description: @edit_why_reporting_form.hazard_description,
+      session[:investigation] = Investigation::Notification.new(reported_reason:, hazard_description: @edit_why_reporting_form.hazard_description,
                                                         hazard_type: @edit_why_reporting_form.hazard_type, non_compliant_reason: @edit_why_reporting_form.non_compliant_reason)
       session[:form_answers].merge!(reason_for_creating_params)
     when :reference_number

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -70,7 +70,7 @@ class Investigations::TsInvestigationsController < ApplicationController
       return render_wizard unless @edit_why_reporting_form.valid?
 
       session[:investigation] = Investigation::Notification.new(reported_reason:, hazard_description: @edit_why_reporting_form.hazard_description,
-                                                        hazard_type: @edit_why_reporting_form.hazard_type, non_compliant_reason: @edit_why_reporting_form.non_compliant_reason)
+                                                                hazard_type: @edit_why_reporting_form.hazard_type, non_compliant_reason: @edit_why_reporting_form.non_compliant_reason)
       session[:form_answers].merge!(reason_for_creating_params)
     when :reference_number
       @reference_number_form = ReferenceNumberForm.new(reference_number_params)

--- a/app/models/investigation/case.rb
+++ b/app/models/investigation/case.rb
@@ -6,6 +6,10 @@ class Investigation < ApplicationRecord
             inverse_of: :investigation,
             dependent: :destroy
 
+    def case_type
+      "notification"
+    end
+
     def case_created_audit_activity_class
       AuditActivity::Investigation::AddCase
     end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -1,5 +1,5 @@
 class Investigation < ApplicationRecord
-  class Case < Investigation
+  class Notification < Investigation
     has_one :add_audit_activity,
             class_name: "AuditActivity::Investigation::AddCase",
             foreign_key: :investigation_id,

--- a/db/migrate/20231012141513_change_all_cases_to_notifications.rb
+++ b/db/migrate/20231012141513_change_all_cases_to_notifications.rb
@@ -1,0 +1,9 @@
+class ChangeAllCasesToNotifications < ActiveRecord::Migration[7.0]
+  def self.up
+    Investigation.where(type: "Investigation::Case").update_all(type: "Investigation::Notification")
+  end
+
+  def self.down
+    Investigation.where(type: "Investigation::Notification").update_all(type: "Investigation::Case")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_03_141941) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_12_141513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -258,20 +258,20 @@ RSpec.describe InvestigationDecorator, :with_stubbed_mailer do
   describe "#title" do
     context "with a user_title" do
       let(:user_title) { "user title" }
-      let(:investigation) { create(:case, user_title:, complainant_reference: nil) }
+      let(:investigation) { create(:notification, user_title:, complainant_reference: nil) }
 
       it { expect(decorated_investigation.title).to eq(user_title) }
     end
 
     context "without a user_title but with a complainant_reference" do
       let(:complainant_reference) { "complainant reference" }
-      let(:investigation) { create(:case, user_title: nil, complainant_reference:) }
+      let(:investigation) { create(:notification, user_title: nil, complainant_reference:) }
 
       it { expect(decorated_investigation.title).to eq(complainant_reference) }
     end
 
     context "without a user_title or a complainant_reference" do
-      let(:investigation) { create(:case, user_title: nil, complainant_reference: nil) }
+      let(:investigation) { create(:notification, user_title: nil, complainant_reference: nil) }
 
       it "uses the pretty_id" do
         expect(decorated_investigation.title).to eq(investigation.pretty_id)

--- a/spec/factories/investigations.rb
+++ b/spec/factories/investigations.rb
@@ -36,9 +36,9 @@ FactoryBot.define do
       user_title { "test project title" }
     end
 
-    factory :case, class: "Investigation::Case" do
-      description { "test case" }
-      user_title { "test case title" }
+    factory :notification, class: "Investigation::Notification" do
+      description { "test notification" }
+      user_title { "test notification title" }
     end
 
     trait :with_complainant do

--- a/spec/forms/notifying_country_form_spec.rb
+++ b/spec/forms/notifying_country_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe NotifyingCountryForm do
   subject(:form) { described_class.from(investigation) }
 
-  let(:investigation) { build(:case, notifying_country:) }
+  let(:investigation) { build(:notification, notifying_country:) }
   let(:notifying_country) { "country:GB" }
 
   describe ".from" do

--- a/spec/models/audit_activity/investigation/add_case_spec.rb
+++ b/spec/models/audit_activity/investigation/add_case_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AuditActivity::Investigation::AddCase, :with_stubbed_mailer do
-  let(:factory) { :case }
+  let(:factory) { :notification }
 
   it_behaves_like "an audit activity for investigation added"
 end

--- a/spec/models/investigation/case_spec.rb
+++ b/spec/models/investigation/case_spec.rb
@@ -1,9 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Investigation::Case do
-  subject(:case) { build(:case, date_received:).build_owner_collaborations_from(create(:user)) }
+  subject(:case_object) { build(:case) }
+
+  describe "#case_type" do
+    it "returns 'notification'" do
+      expect(case_object.case_type).to eq("notification")
+    end
+  end
 
   describe "#valid?" do
+    subject(:case) { build(:case, date_received:).build_owner_collaborations_from(create(:user)) }
+
     context "with valid date_received" do
       let(:date_received) { 1.day.ago }
 

--- a/spec/models/investigation/enquiry_spec.rb
+++ b/spec/models/investigation/enquiry_spec.rb
@@ -1,9 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Investigation::Enquiry do
-  subject(:enquiry) { build(:enquiry, date_received:).build_owner_collaborations_from(create(:user)) }
+  subject(:enquiry) { build(:enquiry) }
+
+  describe "#case_type" do
+    it "returns 'notification'" do
+      expect(enquiry.case_type).to eq("enquiry")
+    end
+  end
 
   describe "#valid?" do
+    subject(:enquiry) { build(:enquiry, date_received:).build_owner_collaborations_from(create(:user)) }
+
     context "with valid date_received" do
       let(:date_received) { 1.day.ago }
 

--- a/spec/models/investigation/notification_spec.rb
+++ b/spec/models/investigation/notification_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-RSpec.describe Investigation::Case do
-  subject(:case_object) { build(:case) }
+RSpec.describe Investigation::Notification do
+  subject(:notification) { build(:notification) }
 
   describe "#case_type" do
     it "returns 'notification'" do
-      expect(case_object.case_type).to eq("notification")
+      expect(notification.case_type).to eq("notification")
     end
   end
 
   describe "#valid?" do
-    subject(:case) { build(:case, date_received:).build_owner_collaborations_from(create(:user)) }
+    subject(:notification) { build(:notification, date_received:).build_owner_collaborations_from(create(:user)) }
 
     context "with valid date_received" do
       let(:date_received) { 1.day.ago }

--- a/spec/models/investigation/project_spec.rb
+++ b/spec/models/investigation/project_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Investigation::Project do
+  subject(:project) { build(:project) }
+
+  describe "#case_type" do
+    it "returns 'project'" do
+      expect(project.case_type).to eq("project")
+    end
+  end
+end

--- a/spec/services/find_closest_product_duplicate_spec.rb
+++ b/spec/services/find_closest_product_duplicate_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe FindClosestProductDuplicate, :with_stubbed_mailer do
 
     before do
       create_list(:product, 2, barcode:)
-      create(:investigation, products: [product_a])
+      create(:notification, products: [product_a])
     end
 
     it "returns the product with cases only" do
@@ -70,7 +70,7 @@ RSpec.describe FindClosestProductDuplicate, :with_stubbed_mailer do
 
     before do
       create_list(:product, 2, barcode:, authenticity: "genuine")
-      create(:investigation, products: [product_a])
+      create(:notification, products: [product_a])
     end
 
     it "returns the product with cases only" do

--- a/spec/services/find_closest_product_duplicate_spec.rb
+++ b/spec/services/find_closest_product_duplicate_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe FindClosestProductDuplicate, :with_stubbed_mailer do
 
     before do
       create_list(:product, 2, barcode:)
-      create(:case, products: [product_a])
+      create(:investigation, products: [product_a])
     end
 
     it "returns the product with cases only" do
@@ -70,7 +70,7 @@ RSpec.describe FindClosestProductDuplicate, :with_stubbed_mailer do
 
     before do
       create_list(:product, 2, barcode:, authenticity: "genuine")
-      create(:case, products: [product_a])
+      create(:investigation, products: [product_a])
     end
 
     it "returns the product with cases only" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-1947


## Description
Changes Case class to Notification for clarity, adds a `case_type=notification`for reports/exports and changes all current `Investigation::Case` objects to `Investigation::Notification`

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2618.london.cloudapps.digital/
https://psd-pr-2618-support.london.cloudapps.digital/
