### PR TITLE
Add last_change search filters for case - PSD-1938

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,5 +107,6 @@ group :test do
   gem "simplecov-console", "~> 0.9"
   gem "simplecov-lcov"
   gem "super_diff"
+  gem "timecop", "~> 0.9"
   gem "webmock", "~> 3.19"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,6 +632,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     tilt (2.3.0)
+    timecop (0.9.6)
     timeout (0.4.0)
     ttfunk (1.7.0)
     tty-color (0.6.0)
@@ -682,6 +683,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
@@ -772,6 +774,7 @@ DEPENDENCIES
   strong_migrations (~> 1.4)
   super_diff
   support_portal!
+  timecop (~> 0.9)
   tty-table
   turbo-rails
   validate_email (~> 0.1)

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -85,6 +85,10 @@ module InvestigationsHelper
       end
     end
 
+    if @search.last_change.present?
+      wheres[:updated_at] = { gt: @search.last_change.at_midnight }
+    end
+
     Investigation.search(
       query,
       where: wheres,

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -195,7 +195,8 @@ module InvestigationsHelper
       :created_by,
       :created_by_other_id,
       :page_name,
-      :hazard_type
+      :hazard_type,
+      last_change: %i[day month year]
     )
   end
 
@@ -211,7 +212,8 @@ module InvestigationsHelper
       :teams_with_access_other_id,
       :created_by,
       :created_by_other_id,
-      :hazard_type
+      :hazard_type,
+      last_change: %i[day month year]
     )
   end
 

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -75,6 +75,7 @@ class SearchParams
 
   def uses_expanded_filter_options?
     teams_with_access != "all" || created_by != "all" ||
-      case_type != "all" || case_owner != "all"
+      case_type != "all" || case_owner != "all" ||
+      last_change.present?
   end
 end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -24,6 +24,7 @@ class SearchParams
   attribute :category
   attribute :page_name
   attribute :retired_status
+  attribute :last_change, :govuk_date
 
   def selected_sort_by
     if sort_by.blank?

--- a/app/serializers/investigation_serializer.rb
+++ b/app/serializers/investigation_serializer.rb
@@ -2,7 +2,7 @@ class InvestigationSerializer < ActiveModel::Serializer
   attributes :type, :owner_id, :creator_id, :hazard_type,
              :description, :product_category, :is_closed, :updated_at, :created_at,
              :pretty_id, :hazard_description, :non_compliant_reason,
-             :complainant_reference, :risk_level, :title
+             :complainant_reference, :risk_level, :title, :user_title
 
   attribute :creator_user do
     object.creator_user&.id

--- a/app/serializers/investigation_serializer.rb
+++ b/app/serializers/investigation_serializer.rb
@@ -4,6 +4,11 @@ class InvestigationSerializer < ActiveModel::Serializer
              :pretty_id, :hazard_description, :non_compliant_reason,
              :complainant_reference, :risk_level, :title, :user_title
 
+  attribute :last_change_at do
+    latest_activity_date = object.activities.pluck(:created_at).max
+    [latest_activity_date, object.updated_at, object.created_at].compact.max
+  end
+
   attribute :creator_user do
     object.creator_user&.id
   end

--- a/app/views/investigations/_case_change_date_filter.html.erb
+++ b/app/views/investigations/_case_change_date_filter.html.erb
@@ -1,0 +1,28 @@
+<%= govukDateInput(
+  id: "change_date_filter-fieldset",
+  fieldset: {
+    legend: {
+      text: "Last updated date"
+    }
+  },
+  items: [
+    {
+      classes: "govuk-input--width-2",
+      label: "Day",
+      name: "last_change[day]",
+      value: form.object.last_change&.day
+    },
+    {
+      classes: "govuk-input--width-2",
+      label: "Month",
+      name: "last_change[month]",
+      value: form.object.last_change&.month
+    },
+    {
+      classes: "govuk-input--width-2",
+      label: "Year",
+      name: "last_change[year]",
+      value: form.object.last_change&.year
+    }
+  ]
+) %>

--- a/app/views/investigations/_case_change_date_filter.html.erb
+++ b/app/views/investigations/_case_change_date_filter.html.erb
@@ -2,7 +2,7 @@
   id: "change_date_filter-fieldset",
   fieldset: {
     legend: {
-      text: "Last updated date"
+      text: "Updated after"
     }
   },
   items: [

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -20,6 +20,7 @@
       <%= render "investigations/case_creator_radios", form: form %>
       <%= render "investigations/case_type_radios", form: form %>
       <%= render "investigations/case_hazard_type_filter", form: form %>
+      <%= render "investigations/case_change_date_filter", form: form %>
     <% end %>
 
     <div class="govuk-button-group">

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -368,7 +368,9 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
     before do
       Timecop.freeze(time)
+      old_case.update_column(:created_at, three_months_ago)
       old_case.update_column(:updated_at, three_months_ago)
+      new_case.update_column(:created_at, one_day_ago)
       new_case.update_column(:updated_at, one_day_ago)
 
       Investigation.reindex
@@ -386,7 +388,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       it "shows both cases" do
         expect_to_be_on_cases_search_results_page
-        expect(page).to have_content "2 cases matching keyword(s) #{title}, using the current filters, were found."
+        expect(page).to have_content "2 cases matching keyword(s)"
 
         expect(page).to have_text(old_case.pretty_id)
         expect(page).to have_text(new_case.pretty_id)
@@ -410,10 +412,10 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       it "only shows the case that was last changed within the date range" do
         expect_to_be_on_cases_search_results_page
-        expect(page).to have_content "1 case matching keyword(s) #{title}, using the current filters, was found."
+        expect(page).to have_content "1 case matching keyword(s)"
 
-        expect(page).to have_text(old_case.pretty_id)
-        expect(page).not_to have_text(new_case.pretty_id)
+        expect(page).not_to have_text(old_case.pretty_id)
+        expect(page).to have_text(new_case.pretty_id)
       end
     end
   end

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -355,4 +355,30 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       end
     end
   end
+
+  describe "when filtering based on the date of last change" do
+    let!(:old_case) { create(:allegation, products: [product], user_title: title, updated_at: 3.months.ago) }
+    let!(:new_case) { create(:allegation, products: [mobile_phone], user_title: title, updated_at: 1.day.ago) }
+
+    let(:title) { "interesting case" }
+
+    before do
+      Investigation.reindex
+      sign_in(user)
+      visit "/cases"
+
+      fill_in "Search", with: title
+      click_button "Submit search"
+    end
+
+    context "with no date filters applied" do
+      it "shows both cases" do
+        expect_to_be_on_cases_search_results_page
+        expect(page).to have_content "2 cases matching keyword(s) #{title}, using the current filters, were found."
+
+        expect(page).to have_text(old_case.pretty_id)
+        expect(page).to have_text(new_case.pretty_id)
+      end
+    end
+  end
 end

--- a/spec/serializers/investigation_serializer_spec.rb
+++ b/spec/serializers/investigation_serializer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe InvestigationSerializer, :with_stubbed_mailer, :with_test_queue_a
       expect(hash[:type]).to eq(investigation.type)
       expect(hash[:hazard_type]).to eq(investigation.hazard_type)
       expect(hash[:user_title]).to eq(investigation.user_title)
+      expect(hash[:pretty_id]).to eq(investigation.pretty_id)
     end
   end
 end

--- a/spec/serializers/investigation_serializer_spec.rb
+++ b/spec/serializers/investigation_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe InvestigationSerializer, :with_stubbed_mailer, :with_test_queue_a
     it "serializes the investigation object", :aggregate_failures do
       expect(hash[:type]).to eq(investigation.type)
       expect(hash[:hazard_type]).to eq(investigation.hazard_type)
+      expect(hash[:user_title]).to eq(investigation.user_title)
     end
   end
 end

--- a/spec/serializers/investigation_serializer_spec.rb
+++ b/spec/serializers/investigation_serializer_spec.rb
@@ -3,16 +3,34 @@ require "rails_helper"
 RSpec.describe InvestigationSerializer, :with_stubbed_mailer, :with_test_queue_adapter, type: :serializers do
   subject { described_class.new(investigation) }
 
-  let(:investigation) { create(:allegation) }
+  let(:investigation) { build(:allegation) }
+  let(:hash) { subject.to_h }
 
-  context "with an investigation" do
-    let(:hash) { subject.to_h }
+  it "serializes an investigation object", :aggregate_failures do
+    expect(hash[:type]).to eq(investigation.type)
+    expect(hash[:hazard_type]).to eq(investigation.hazard_type)
+    expect(hash[:user_title]).to eq(investigation.user_title)
+    expect(hash[:pretty_id]).to eq(investigation.pretty_id)
+  end
 
-    it "serializes the investigation object", :aggregate_failures do
-      expect(hash[:type]).to eq(investigation.type)
-      expect(hash[:hazard_type]).to eq(investigation.hazard_type)
-      expect(hash[:user_title]).to eq(investigation.user_title)
-      expect(hash[:pretty_id]).to eq(investigation.pretty_id)
+  describe "#last_change_at" do
+    let(:time) { Time.zone.parse("16 Oct 2023 00:00") }
+    let(:investigation_last_change) { time - 7.days }
+    let(:investigation) { build(:allegation, updated_at: investigation_last_change, created_at: investigation_last_change) }
+
+    context "when an investigation has activities" do
+      let(:investigation) { create(:allegation) }
+      let(:test_result_activity) { create(:audit_activity_test_result, investigation:) }
+
+      it "returns the test_result_activity_created_at" do
+        expect(hash[:last_change_at].to_i).to eq(test_result_activity.created_at.to_i)
+      end
+    end
+
+    context "when an investigation has no activities" do
+      it "returns the investigation updated_at" do
+        expect(hash[:last_change_at].to_i).to eq(investigation_last_change.to_i)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a new field for 'last changed' to cases search & export. Returns all cases that have either been created, updated directly or have had an activity added to it (e.g. test result added, document added etc) after that date.

I expect the UI of this to change very soon as we redesign the new search pages

## Screen-shots or screen-capture of UI changes
![CleanShot 2023-10-16 at 14 52 37@2x](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/8b42bcb3-ae95-41bb-9cd2-a549eb570084)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
