### PR TITLE
Add OPSS IMT to case when adding a corrective action

### DIFF
--- a/spec/services/add_corrective_action_to_case_spec.rb
+++ b/spec/services/add_corrective_action_to_case_spec.rb
@@ -51,5 +51,38 @@ RSpec.describe AddCorrectiveActionToCase, :with_stubbed_mailer, :with_test_queue
     expect(audit.business).to eq(business)
   end
 
+  it "does not add OPSS IMT with edit permissions as a collaborator" do
+    expect(result.investigation.teams_with_edit_access).to eq([user.team])
+  end
+
   it_behaves_like "a service which notifies teams with access"
+
+  context "when the investigation risk level is serious" do
+    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
+
+    before do
+      opss_imt
+      investigation.risk_level = "serious"
+      investigation.save!
+    end
+
+    it "adds OPSS IMT with edit permissions as a collaborator" do
+      expect(result.investigation.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
+    end
+  end
+
+  context "when the corrective action indicates a recall" do
+    let(:action_key) { "recall_of_the_product_from_end_users" }
+    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
+
+    before do
+      opss_imt
+      investigation.risk_level = "low"
+      investigation.save!
+    end
+
+    it "adds OPSS IMT with edit permissions as a collaborator" do
+      expect(result.investigation.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
+    end
+  end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1528

## Description

Automatically adds OPSS IMT with edit permissions to a case when a corrective action is added if:

* The investigation risk level is serious or high, or
* The corrective action indicates a recall

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2622.london.cloudapps.digital/
https://psd-pr-2622-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
