### PR TITLE
Only return relevant investigations when searching by ID

### DIFF
--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -93,7 +93,7 @@ module InvestigationsHelper
       query,
       where: wheres,
       order: @search.sorting_params,
-      misspellings: { edit_distance: 2 },
+      misspellings: { edit_distance: searching_for_investigation_pretty_id?(query) ? 0 : 2 },
       page: page_number,
       per_page: page_size
     )
@@ -245,6 +245,10 @@ module InvestigationsHelper
 
   def page_number
     params[:page].to_i > 500 ? "500" : params[:page]
+  end
+
+  def searching_for_investigation_pretty_id?(query)
+    query.match(/\d{4}-\d{4}/)
   end
 
   def safety_and_compliance_rows(investigation)

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -18,13 +18,15 @@
           <div class="govuk-grid-column-full" role="region" aria-label="Cases">
             <table id="results" class="govuk-table opss-table-items opss-table-items--sm">
               <caption class="govuk-visually-hidden">
-                Cases data: 4 columns with each case described across rows within each table body.
+                Cases data: 5 columns with each case described across rows within each table body.
               </caption>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th class="govuk-visually-hidden">&nbsp;</th>
                   <th id="case" scope="col" class="govuk-table__header">Case number</th>
                   <th id="caseowner" scope="col" class="govuk-table__header">Case owner</th>
+                  <th id="haztype" scope="col" class="govuk-table__header">Hazard type</th>
+                  <th scope="col" class="govuk-table__header">Product count</th>
                   <% if @search.sort_by == SortByHelper::SORT_BY_CREATED_AT %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
@@ -50,6 +52,8 @@
                     <th class="govuk-visually-hidden">&nbsp;</th>
                     <th scope="col" class="govuk-table__header">Case number</th>
                     <th scope="col" class="govuk-table__header">Case owner</th>
+                    <th scope="col" class="govuk-table__header">Hazard type</th>
+                    <th scope="col" class="govuk-table__header">Product count</th>
                     <% if @search.sort_by == SortByHelper::SORT_BY_CREATED_AT %>
                       <th scope="col" class="govuk-table__header">Created</th>
                     <% else %>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1895

## Description

Detects searching for investigations by pretty ID and disables edit distance so only relevant results are returned.

Also fixes the display of investigation search results in the table.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-10-18 at 11 18 27](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/8e65d80f-9ee6-482f-84b8-989a2a7e9e19)

## Review apps

https://psd-pr-2625.london.cloudapps.digital/
https://psd-pr-2625-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
