### PR TITLE
Fix product name display when editing UCRs

### DIFF
--- a/app/views/investigation_products/ucr_numbers/edit.html.erb
+++ b/app/views/investigation_products/ucr_numbers/edit.html.erb
@@ -20,7 +20,7 @@
 
         <div class="govuk-hint govuk-!-margin-bottom-5" id="ucr-number-hint">
           <span class="govuk-!-display-block govuk-!-margin-bottom-2">
-            Add and edit <abbr>UCR</abbr> numbers for Asda washing up liquid.
+            Add and edit <abbr>UCR</abbr> numbers for <%= @investigation_product.name %>.
           </span>
 
           <span class="govuk-!-display-block govuk-!-font-size-16">


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1945

## Description

Fixes the UCR entry page to show the actual name of the relevant product.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
