### PR TITLE
Case extract by created date: part II - PSD-2023

### DIFF
--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -173,10 +173,8 @@ module InvestigationsHelper
               end
     end
 
-    if @search.last_change.present?
-      query = query.joins(:activities)
-                   .where("investigations.updated_at >= ?", @search.last_change.at_midnight)
-                   .where("activities.created_at >= ?", @search.last_change.at_midnight)
+    if @search.created_from_date.present?
+      query = query.where("investigations.created_at >= ?", @search.created_from_date.at_midnight)
     end
 
     if ids_only

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -85,8 +85,12 @@ module InvestigationsHelper
       end
     end
 
-    if @search.created_from_date.present?
-      wheres[:created_at] = { gt: @search.created_from_date.at_midnight }
+    if @search.created_from_date.present? && @search.created_to_date.present?
+      wheres[:created_at] = { gte: @search.created_from_date.at_midnight, lte: @search.created_to_date.at_end_of_day }
+    elsif @search.created_from_date.present?
+      wheres[:created_at] = { gte: @search.created_from_date.at_midnight }
+    elsif @search.created_to_date.present?
+      wheres[:created_at] = { lte: @search.created_to_date.at_midnight }
     end
 
     Investigation.search(
@@ -204,7 +208,8 @@ module InvestigationsHelper
       :created_by_other_id,
       :page_name,
       :hazard_type,
-      created_from_date: %i[day month year]
+      created_from_date: %i[day month year],
+      created_to_date: %i[day month year]
     )
   end
 
@@ -221,7 +226,8 @@ module InvestigationsHelper
       :created_by,
       :created_by_other_id,
       :hazard_type,
-      created_from_date: %i[day month year]
+      created_from_date: %i[day month year],
+      created_to_date: %i[day month year]
     )
   end
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -85,8 +85,8 @@ module InvestigationsHelper
       end
     end
 
-    if @search.last_change.present?
-      wheres[:updated_at] = { gt: @search.last_change.at_midnight }
+    if @search.created_from_date.present?
+      wheres[:created_at] = { gt: @search.created_from_date.at_midnight }
     end
 
     Investigation.search(

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -204,7 +204,7 @@ module InvestigationsHelper
       :created_by_other_id,
       :page_name,
       :hazard_type,
-      last_change: %i[day month year]
+      created_from_date: %i[day month year]
     )
   end
 
@@ -221,7 +221,7 @@ module InvestigationsHelper
       :created_by,
       :created_by_other_id,
       :hazard_type,
-      last_change: %i[day month year]
+      created_from_date: %i[day month year]
     )
   end
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -178,7 +178,10 @@ module InvestigationsHelper
     end
 
     if @search.created_from_date.present?
-      query = query.where("investigations.created_at >= ?", @search.created_from_date.at_midnight)
+      query = query.where("investigations.created_at >= ?", @search.created_from_date.at_beginning_of_day)
+    end
+    if @search.created_to_date.present?
+      query = query.where("investigations.created_at <= ?", @search.created_to_date.at_end_of_day)
     end
 
     if ids_only

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -25,6 +25,7 @@ class SearchParams
   attribute :page_name
   attribute :retired_status
   attribute :created_from_date, :govuk_date
+  attribute :created_to_date, :govuk_date
 
   def selected_sort_by
     if sort_by.blank?
@@ -76,6 +77,6 @@ class SearchParams
   def uses_expanded_filter_options?
     teams_with_access != "all" || created_by != "all" ||
       case_type != "all" || case_owner != "all" ||
-      created_from_date.present?
+      created_from_date.present? || created_to_date.present?
   end
 end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -24,7 +24,7 @@ class SearchParams
   attribute :category
   attribute :page_name
   attribute :retired_status
-  attribute :last_change, :govuk_date
+  attribute :created_from_date, :govuk_date
 
   def selected_sort_by
     if sort_by.blank?
@@ -76,6 +76,6 @@ class SearchParams
   def uses_expanded_filter_options?
     teams_with_access != "all" || created_by != "all" ||
       case_type != "all" || case_owner != "all" ||
-      last_change.present?
+      created_from_date.present?
   end
 end

--- a/app/serializers/investigation_serializer.rb
+++ b/app/serializers/investigation_serializer.rb
@@ -4,11 +4,6 @@ class InvestigationSerializer < ActiveModel::Serializer
              :pretty_id, :hazard_description, :non_compliant_reason,
              :complainant_reference, :risk_level, :title, :user_title
 
-  attribute :last_change_at do
-    latest_activity_date = object.activities.pluck(:created_at).max
-    [latest_activity_date, object.updated_at, object.created_at].compact.max
-  end
-
   attribute :creator_user do
     object.creator_user&.id
   end

--- a/app/views/investigations/_case_change_date_filter.html.erb
+++ b/app/views/investigations/_case_change_date_filter.html.erb
@@ -26,3 +26,31 @@
     }
   ]
 ) %>
+<%= govukDateInput(
+  id: "change_date_filter-fieldset",
+  fieldset: {
+    legend: {
+      text: "Created up to"
+    }
+  },
+  items: [
+    {
+      classes: "govuk-input--width-2",
+      label: "Day",
+      name: "created_to_date[day]",
+      value: form.object.created_to_date&.day
+    },
+    {
+      classes: "govuk-input--width-2",
+      label: "Month",
+      name: "created_to_date[month]",
+      value: form.object.created_to_date&.month
+    },
+    {
+      classes: "govuk-input--width-2",
+      label: "Year",
+      name: "created_to_date[year]",
+      value: form.object.created_to_date&.year
+    }
+  ]
+) %>

--- a/app/views/investigations/_case_change_date_filter.html.erb
+++ b/app/views/investigations/_case_change_date_filter.html.erb
@@ -2,27 +2,27 @@
   id: "change_date_filter-fieldset",
   fieldset: {
     legend: {
-      text: "Updated after"
+      text: "Created from"
     }
   },
   items: [
     {
       classes: "govuk-input--width-2",
       label: "Day",
-      name: "last_change[day]",
-      value: form.object.last_change&.day
+      name: "created_from_date[day]",
+      value: form.object.created_from_date&.day
     },
     {
       classes: "govuk-input--width-2",
       label: "Month",
-      name: "last_change[month]",
-      value: form.object.last_change&.month
+      name: "created_from_date[month]",
+      value: form.object.created_from_date&.month
     },
     {
       classes: "govuk-input--width-2",
       label: "Year",
-      name: "last_change[year]",
-      value: form.object.last_change&.year
+      name: "created_from_date[year]",
+      value: form.object.created_from_date&.year
     }
   ]
 ) %>

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -356,7 +356,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
     end
   end
 
-  describe "when filtering based on the date of last change" do
+  describe "when filtering based on the created_at datre" do
     let!(:old_case) { create(:allegation, products: [product], user_title: title) }
     let!(:new_case) { create(:allegation, products: [mobile_phone], user_title: title) }
 
@@ -393,7 +393,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
       end
     end
 
-    context "with a date filter applied" do
+    context "with a from date filter applied" do
       before do
         fill_in "Search", with: title
         find("details#filter-details").click
@@ -414,6 +414,30 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
         expect(page).not_to have_text(old_case.pretty_id)
         expect(page).to have_text(new_case.pretty_id)
+      end
+    end
+
+    context "with a to date filter applied" do
+      before do
+        fill_in "Search", with: title
+        find("details#filter-details").click
+
+        within_fieldset "Created up to" do
+          fill_in "change_date_filter-fieldset-created_to_date[day]", with: "14"
+          fill_in "change_date_filter-fieldset-created_to_date[month]", with: "10"
+          fill_in "change_date_filter-fieldset-created_to_date[year]", with: "2023"
+        end
+
+        click_button "Apply"
+        click_button "Submit search"
+      end
+
+      it "only shows the case that was last changed within the date range" do
+        expect_to_be_on_cases_search_results_page
+        expect(page).to have_content "1 case matching keyword(s)"
+
+        expect(page).to have_text(old_case.pretty_id)
+        expect(page).not_to have_text(new_case.pretty_id)
       end
     end
   end

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -369,9 +369,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
     before do
       Timecop.freeze(time)
       old_case.update_column(:created_at, three_months_ago)
-      old_case.update_column(:updated_at, three_months_ago)
       new_case.update_column(:created_at, one_day_ago)
-      new_case.update_column(:updated_at, one_day_ago)
 
       Investigation.reindex
       sign_in(user)
@@ -400,10 +398,10 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         fill_in "Search", with: title
         find("details#filter-details").click
 
-        within_fieldset "Updated after" do
-          fill_in "change_date_filter-fieldset-last_change[day]", with: "14"
-          fill_in "change_date_filter-fieldset-last_change[month]", with: "10"
-          fill_in "change_date_filter-fieldset-last_change[year]", with: "2023"
+        within_fieldset "Created from" do
+          fill_in "change_date_filter-fieldset-created_from_date[day]", with: "14"
+          fill_in "change_date_filter-fieldset-created_from_date[month]", with: "10"
+          fill_in "change_date_filter-fieldset-created_from_date[year]", with: "2023"
         end
 
         click_button "Apply"

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -199,21 +199,21 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
       expect(sheet.cell(3, 33)).to eq other_team_investigation.non_compliant_reason
     end
 
-    context "when a last_change search parameter is provided" do
-      let(:last_change) { 1.day.ago }
-      let(:params) { { case_type: "all", created_by: "all", case_status: "open", teams_with_access: "all", last_change: } }
+    context "when a created_from_date search parameter is provided" do
+      let(:created_from_date) { 1.day.ago }
+      let(:params) { { case_type: "all", created_by: "all", case_status: "open", teams_with_access: "all", created_from_date: } }
 
       let!(:old_case) { create(:allegation, creator: other_user_other_team, is_private: true).decorate }
 
       before do
-        old_case.update!(updated_at: 2.days.ago, created_at: 2.days.ago)
+        old_case.update!(created_at: 2.days.ago)
       end
 
       it "exports the case data", :aggregate_failures do
         expect(exported_data.sheets).to eq %w[Cases]
       end
 
-      it "only exports cases that have been updated since the last_change date", :aggregate_failures do
+      it "only exports cases that have been updated since the created_from_date date", :aggregate_failures do
         expect(sheet.cell(1, 1)).to eq "ID"
         expect(sheet.cell(2, 1)).to eq investigation.pretty_id
         expect(sheet.cell(3, 1)).to eq other_team_investigation.pretty_id

--- a/spec/serializers/investigation_serializer_spec.rb
+++ b/spec/serializers/investigation_serializer_spec.rb
@@ -12,25 +12,4 @@ RSpec.describe InvestigationSerializer, :with_stubbed_mailer, :with_test_queue_a
     expect(hash[:user_title]).to eq(investigation.user_title)
     expect(hash[:pretty_id]).to eq(investigation.pretty_id)
   end
-
-  describe "#last_change_at" do
-    let(:investigation_last_change) { time - 7.days }
-    let(:time) { Time.zone.parse("16 Oct 2023 00:00") }
-    let(:investigation) { build(:allegation, updated_at: investigation_last_change, created_at: investigation_last_change) }
-
-    xcontext "when an investigation has activities" do
-      let(:investigation) { create(:allegation, updated_at: investigation_last_change, created_at: investigation_last_change) }
-      let(:test_result_activity) { create(:audit_activity_test_result, investigation:) }
-
-      it "returns the test_result_activity_created_at" do
-        expect(hash[:last_change_at].to_i).to eq(test_result_activity.created_at.to_i)
-      end
-    end
-
-    context "when an investigation has no activities" do
-      it "returns the investigation updated_at" do
-        expect(hash[:last_change_at].to_i).to eq(investigation_last_change.to_i)
-      end
-    end
-  end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2023

## Description
Based on feedback from Monika - the case date filter should be...
- Just searching the case `created_at` time
- and allow you to search both from and up to a certain date

## Screen-shots or screen-capture of UI changes

![CleanShot 2023-10-19 at 11 48 45@2x](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/a16aaf9a-aa37-4ab5-890b-65e4da064c5b)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2632.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
