### PR TITLE
Add case creation for bulk product uploads

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -4,6 +4,7 @@ class BulkProductsController < ApplicationController
   include BreadcrumbHelper
 
   before_action :authorize_user
+  before_action :bulk_products_upload, except: %i[triage no_upload_unsafe no_upload_mixed]
 
   breadcrumb "products.label", :products_path
 
@@ -18,7 +19,13 @@ class BulkProductsController < ApplicationController
         when "mixed"
           redirect_to no_upload_mixed_bulk_upload_products_path
         when "non_compliant"
-          redirect_to create_case_bulk_upload_products_path
+          ActiveRecord::Base.transaction do
+            investigation = Investigation::Notification.new(reported_reason: "non_compliant", hazard_description: bulk_products_triage_params[:hazard_description])
+            CreateCase.call!(investigation:, user: current_user, bulk: true)
+            @bulk_products_upload = BulkProductsUpload.create!(investigation:, user: current_user)
+          end
+
+          redirect_to create_case_bulk_upload_products_path(@bulk_products_upload)
         end
       end
     else
@@ -30,7 +37,21 @@ class BulkProductsController < ApplicationController
 
   def no_upload_mixed; end
 
-  def create_case; end
+  def create_case
+    if request.put?
+      @bulk_products_create_case_form = BulkProductsCreateCaseForm.new(bulk_products_create_case_params)
+
+      if @bulk_products_create_case_form.valid?
+        @bulk_products_upload.investigation.update!(user_title: bulk_products_create_case_params[:name], complainant_reference: bulk_products_create_case_params[:reference_number])
+
+        redirect_to create_business_bulk_upload_products_path(@bulk_products_upload)
+      end
+    else
+      @bulk_products_create_case_form = BulkProductsCreateCaseForm.from(@bulk_products_upload)
+    end
+  end
+
+  def create_business; end
 
 private
 
@@ -38,7 +59,15 @@ private
     redirect_to "/403" if current_user && !current_user.can_bulk_upload_products?
   end
 
+  def bulk_products_upload
+    @bulk_products_upload ||= BulkProductsUpload.where(id: params[:bulk_products_upload_id], user: current_user).first!
+  end
+
   def bulk_products_triage_params
     params.require(:bulk_products_triage_form).permit(:compliance_and_safety, :hazard_description)
+  end
+
+  def bulk_products_create_case_params
+    params.require(:bulk_products_create_case_form).permit(:name, :reference_number, :reference_number_provided)
   end
 end

--- a/app/forms/bulk_products_create_case_form.rb
+++ b/app/forms/bulk_products_create_case_form.rb
@@ -1,0 +1,30 @@
+class BulkProductsCreateCaseForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name
+  attribute :reference_number
+  attribute :reference_number_provided, :boolean
+
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :reference_number, presence: true, if: -> { reference_number_provided }
+  validates :reference_number_provided, inclusion: { in: [true, false] }
+
+  def self.from(bulk_products_upload)
+    investigation = bulk_products_upload.investigation
+    new(
+      name: investigation.user_title,
+      reference_number: investigation.complainant_reference,
+      reference_number_provided: reference_number_provided?(investigation)
+    )
+  end
+
+  private_class_method def self.reference_number_provided?(investigation)
+    # Case name is mandatory, therefore if it is present then the user must
+    # have also made a choice about whether or not to provide a reference,
+    # as opposed to not making a choice at all.
+    return if investigation.user_title.blank? && investigation.complainant_reference.blank?
+
+    investigation.complainant_reference.present?
+  end
+end

--- a/app/forms/bulk_products_triage_form.rb
+++ b/app/forms/bulk_products_triage_form.rb
@@ -6,5 +6,5 @@ class BulkProductsTriageForm
   attribute :hazard_description
 
   validates :compliance_and_safety, inclusion: { in: %w[unsafe non_compliant mixed] }
-  validates :hazard_description, presence: true, if: -> { compliance_and_safety == "non_compliant" }
+  validates :hazard_description, presence: true, length: { maximum: 10_000 }, if: -> { compliance_and_safety == "non_compliant" }
 end

--- a/app/models/bulk_products_upload.rb
+++ b/app/models/bulk_products_upload.rb
@@ -1,0 +1,5 @@
+class BulkProductsUpload < ApplicationRecord
+  belongs_to :investigation
+  belongs_to :user
+  has_one_attached :products_file
+end

--- a/app/services/create_case.rb
+++ b/app/services/create_case.rb
@@ -1,12 +1,12 @@
 class CreateCase
   include Interactor
 
-  delegate :investigation, :user, :product, :prism_risk_assessment, to: :context
+  delegate :investigation, :user, :product, :prism_risk_assessment, :bulk, to: :context
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
-    context.fail!(error: "Product must be supplied for non opss users") if !user.is_opss? && !product.is_a?(Product)
+    context.fail!(error: "Product must be supplied for non opss users") if !bulk && !user.is_opss? && !product.is_a?(Product)
     team = user.team
 
     investigation.creator_user = user

--- a/app/views/bulk_products/create_case.html.erb
+++ b/app/views/bulk_products/create_case.html.erb
@@ -1,0 +1,60 @@
+<% page_heading = "Create a case for multiple products - Upload multiple products" %>
+<% page_title page_heading, errors: @bulk_products_create_case_form.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink(text: "Back", href: triage_bulk_upload_products_path) %>
+<% end %>
+<%= form_with model: @bulk_products_create_case_form, url: create_case_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= error_summary @bulk_products_create_case_form.errors %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Upload multiple products</span>
+        Create a case for multiple products
+      </h1>
+      <p class="govuk-body">All the products you upload will be grouped together in a single case.</p>
+      <%= govukInput(
+        form: form,
+        key: :name,
+        label: { text: "Case name", classes: "govuk-label--m" },
+        hint: { text: "Give the case a short descriptive title." },
+        value: @bulk_products_create_case_form.name,
+        id: "name"
+      ) %>
+      <%= govukRadios(
+        form: form,
+        key: :reference_number_provided,
+        fieldset: {
+          legend: {
+            text: "Do you want to add your own reference number to the case?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: { text: "This might be a number already created in a different internal system for your case, or a number you intend to use globally across different systems to reference your case." },
+        items: [
+          {
+            text: "Yes",
+            value: "true",
+            id: "reference_number_provided_true",
+            checked: @bulk_products_create_case_form.reference_number_provided,
+            conditional: {
+              html: govukInput(
+                form: form,
+                key: :reference_number,
+                label: { text: "Reference number" }
+              )
+            }
+          },
+          {
+            text: "No",
+            value: "false",
+            id: "reference_number_provided_false",
+            checked: @bulk_products_create_case_form.reference_number_provided == false # Can be `nil` if the user has not made a choice
+          }
+        ]
+      ) %>
+      <div class="govuk-button-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,6 +741,16 @@ en:
               inclusion: Select how you would describe the products in terms of their compliance and safety
             hazard_description:
               blank: Enter why the product is non-compliant
+              too_long: The reason why the product is non-compliant must be %{count} characters or less
+        bulk_products_create_case_form:
+          attributes:
+            name:
+              blank: Enter a name for the case
+              too_long: The case name must be %{count} characters or less
+            reference_number:
+              blank: Enter a reference number
+            reference_number_provided:
+              inclusion: Select yes if you want to add a reference number
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,11 +250,17 @@ Rails.application.routes.draw do
         post :duplicate_check, to: "products/duplicate_checks#create", path: "duplicate-check"
 
         scope "/bulk-upload" do
-          get :triage, to: "bulk_products#triage", as: "triage_bulk_upload"
-          put :triage, to: "bulk_products#triage"
-          get :no_upload_unsafe, to: "bulk_products#no_upload_unsafe", as: "no_upload_unsafe_bulk_upload", path: "no-upload-unsafe"
-          get :no_upload_mixed, to: "bulk_products#no_upload_mixed", as: "no_upload_mixed_bulk_upload", path: "no-upload-mixed"
-          get :create_case, to: "bulk_products#create_case", as: "create_case_bulk_upload", path: "create-case"
+          get "triage", to: "bulk_products#triage", as: "triage_bulk_upload"
+          put "triage", to: "bulk_products#triage"
+          get "no-upload-unsafe", to: "bulk_products#no_upload_unsafe", as: "no_upload_unsafe_bulk_upload"
+          get "no-upload-mixed", to: "bulk_products#no_upload_mixed", as: "no_upload_mixed_bulk_upload"
+
+          scope ":bulk_products_upload_id" do
+            get "create-case", to: "bulk_products#create_case", as: "create_case_bulk_upload"
+            put "create-case", to: "bulk_products#create_case"
+            get "create-business", to: "bulk_products#create_business", as: "create_business_bulk_upload"
+            put "create-business", to: "bulk_products#create_business"
+          end
         end
       end
 

--- a/db/migrate/20231019104345_create_bulk_products_uploads.rb
+++ b/db/migrate/20231019104345_create_bulk_products_uploads.rb
@@ -1,0 +1,9 @@
+class CreateBulkProductsUploads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bulk_products_uploads do |t|
+      t.references :investigation
+      t.references :user, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_12_141513) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_19_104345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,6 +84,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_141513) do
     t.string "summary"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["investigation_id"], name: "index_alerts_on_investigation_id"
+  end
+
+  create_table "bulk_products_uploads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "investigation_id"
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["investigation_id"], name: "index_bulk_products_uploads_on_investigation_id"
+    t.index ["user_id"], name: "index_bulk_products_uploads_on_user_id"
   end
 
   create_table "business_exports", force: :cascade do |t|

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -38,5 +38,20 @@ RSpec.feature "Bulk upload products", :with_stubbed_mailer do
     click_button "Continue"
 
     expect(page).to have_error_summary("Enter why the product is non-compliant")
+
+    fill_in "Why is the product non-compliant?", with: "Testing"
+    click_button "Continue"
+
+    expect(page).to have_content("Create a case for multiple products")
+
+    fill_in "Case name", with: "Test case"
+
+    click_button "Continue"
+
+    expect(page).to have_error_summary("Select yes if you want to add a reference number")
+
+    choose "Yes"
+    fill_in "Reference number", with: "1234"
+    click_button "Continue"
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1871

## Description

Adds the case creation page for bulk product uploads.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-10-19 at 15 46 29](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/30a476e5-493f-4c4f-a090-9fefb5a71b0a)

## Review apps

https://psd-pr-2635.london.cloudapps.digital/
https://psd-pr-2635-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
