### PR TITLE
Add business creation for bulk product uploads

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -5,6 +5,7 @@ class BulkProductsController < ApplicationController
 
   before_action :authorize_user
   before_action :bulk_products_upload, except: %i[triage no_upload_unsafe no_upload_mixed]
+  before_action :set_countries, only: %i[add_business_details]
 
   breadcrumb "products.label", :products_path
 
@@ -42,7 +43,10 @@ class BulkProductsController < ApplicationController
       @bulk_products_create_case_form = BulkProductsCreateCaseForm.new(bulk_products_create_case_params)
 
       if @bulk_products_create_case_form.valid?
-        @bulk_products_upload.investigation.update!(user_title: bulk_products_create_case_params[:name], complainant_reference: bulk_products_create_case_params[:reference_number])
+        @bulk_products_upload.investigation.update!(
+          user_title: bulk_products_create_case_params[:name],
+          complainant_reference: bulk_products_create_case_params[:reference_number_provided] == "true" ? bulk_products_create_case_params[:reference_number] : nil
+        )
 
         redirect_to create_business_bulk_upload_products_path(@bulk_products_upload)
       end
@@ -51,7 +55,69 @@ class BulkProductsController < ApplicationController
     end
   end
 
-  def create_business; end
+  def create_business
+    @online_marketplaces = OnlineMarketplace.approved.order(:name)
+
+    if request.put?
+      @bulk_products_add_business_type_form = BulkProductsAddBusinessTypeForm.new(bulk_products_add_business_type_params)
+
+      if @bulk_products_add_business_type_form.valid?
+        ActiveRecord::Base.transaction do
+          if @bulk_products_upload.investigation_business.present?
+            online_marketplace = if bulk_products_add_business_type_params[:other_marketplace_name].present?
+                                   OnlineMarketplace.find_or_create_by!(name: bulk_products_add_business_type_params[:other_marketplace_name], approved_by_opss: false)
+                                 else
+                                   OnlineMarketplace.find(bulk_products_add_business_type_params[:online_marketplace_id])
+                                 end
+            @bulk_products_upload.investigation_business.update!(
+              relationship: bulk_products_add_business_type_params[:type],
+              online_marketplace:,
+              authorised_representative_choice: bulk_products_add_business_type_params[:authorised_representative_choice]
+            )
+          else
+            # Use a fake name for now
+            business = Business.create!(
+              trading_name: "Auto-generated business for case #{@bulk_products_upload.investigation.pretty_id}",
+              added_by_user: current_user
+            )
+            # Location will not be valid until a country is added at the next step
+            business.locations.build(name: "Registered office address", added_by_user: current_user).save!(validate: false)
+            business.contacts.create!
+            AddBusinessToCase.call!(
+              business:,
+              relationship: bulk_products_add_business_type_params[:type],
+              online_marketplace: bulk_products_add_business_type_params[:online_marketplace_id].present? ? OnlineMarketplace.find(bulk_products_add_business_type_params[:online_marketplace_id]) : nil,
+              other_marketplace_name: bulk_products_add_business_type_params[:other_marketplace_name],
+              authorised_representative_choice: bulk_products_add_business_type_params[:authorised_representative_choice],
+              investigation: @bulk_products_upload.investigation,
+              user: current_user
+            )
+            @bulk_products_upload.update!(investigation_business_id: business.reload.investigation_businesses.first.id)
+          end
+        end
+
+        redirect_to add_business_details_bulk_upload_products_path(@bulk_products_upload)
+      end
+    else
+      @bulk_products_add_business_type_form = BulkProductsAddBusinessTypeForm.from(@bulk_products_upload)
+    end
+  end
+
+  def add_business_details
+    if request.put?
+      @bulk_products_add_business_details_form = BulkProductsAddBusinessDetailsForm.new(bulk_products_add_business_details_params)
+
+      if @bulk_products_add_business_details_form.valid?
+        @bulk_products_upload.investigation_business.business.update!(bulk_products_add_business_details_params)
+
+        redirect_to upload_products_file_bulk_upload_products_path(@bulk_products_upload)
+      end
+    else
+      @bulk_products_add_business_details_form = BulkProductsAddBusinessDetailsForm.from(@bulk_products_upload)
+    end
+  end
+
+  def upload_products_file; end
 
 private
 
@@ -69,5 +135,17 @@ private
 
   def bulk_products_create_case_params
     params.require(:bulk_products_create_case_form).permit(:name, :reference_number, :reference_number_provided)
+  end
+
+  def bulk_products_add_business_type_params
+    params.require(:bulk_products_add_business_type_form).permit(:type, :online_marketplace_id, :other_marketplace_name, :authorised_representative_choice)
+  end
+
+  def bulk_products_add_business_details_params
+    params.require(:bulk_products_add_business_details_form).permit(
+      :trading_name, :legal_name, :company_number,
+      locations_attributes: %i[id address_line_1 address_line_2 city county postal_code country],
+      contacts_attributes: %i[id name email phone_number job_title]
+    )
   end
 end

--- a/app/forms/bulk_products_add_business_details_form.rb
+++ b/app/forms/bulk_products_add_business_details_form.rb
@@ -1,0 +1,53 @@
+class BulkProductsAddBusinessDetailsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :trading_name
+  attribute :legal_name
+  attribute :company_number
+
+  attribute :locations, default: []
+  attribute :contacts, default: []
+
+  attribute :locations_attributes
+  attribute :contacts_attributes
+
+  validates :trading_name, presence: true
+  validate :validate_country_set_for_location
+
+  def initialize(*args)
+    super
+    self.locations = [Location.new] if locations.empty?
+    self.contacts = [Contact.new] if contacts.empty?
+  end
+
+  def primary_location
+    locations.first
+  end
+
+  def primary_contact
+    contacts.first
+  end
+
+  def self.from(bulk_products_upload)
+    business = bulk_products_upload.investigation_business&.business
+
+    if business.present?
+      new(
+        **business.serializable_hash.slice("trading_name", "legal_name", "company_number"),
+        locations: business.locations,
+        contacts: business.contacts
+      )
+    else
+      new
+    end
+  end
+
+private
+
+  def validate_country_set_for_location
+    return if locations_attributes["0"][:country].present?
+
+    errors.add(:base, "Select a country")
+  end
+end

--- a/app/forms/bulk_products_add_business_type_form.rb
+++ b/app/forms/bulk_products_add_business_type_form.rb
@@ -1,0 +1,43 @@
+class BulkProductsAddBusinessTypeForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :type
+  attribute :online_marketplace_id
+  attribute :other_marketplace_name
+  attribute :authorised_representative_choice
+
+  BUSINESS_TYPES = %w[
+    retailer online_seller online_marketplace manufacturer exporter importer fulfillment_house distributor authorised_representative responsible_person
+  ].freeze
+
+  validates :type, inclusion: { in: BUSINESS_TYPES }
+  validates :online_marketplace_id, presence: true, if: -> { is_approved_online_marketplace? }
+  validates :authorised_representative_choice, presence: true, if: -> { is_authorised_representative? }
+
+  def self.from(bulk_products_upload)
+    investigation_business = bulk_products_upload.investigation_business
+    online_marketplace = investigation_business&.online_marketplace
+
+    if investigation_business.present?
+      new(
+        type: investigation_business.relationship,
+        online_marketplace_id: investigation_business.online_marketplace_id,
+        other_marketplace_name: online_marketplace&.approved_by_opss ? nil : online_marketplace&.name,
+        authorised_representative_choice: investigation_business.authorised_representative_choice
+      )
+    else
+      new
+    end
+  end
+
+private
+
+  def is_authorised_representative?
+    type == "authorised_representative"
+  end
+
+  def is_approved_online_marketplace?
+    type == "online_marketplace" && other_marketplace_name.blank?
+  end
+end

--- a/app/models/bulk_products_upload.rb
+++ b/app/models/bulk_products_upload.rb
@@ -1,5 +1,6 @@
 class BulkProductsUpload < ApplicationRecord
-  belongs_to :investigation
+  belongs_to :investigation, dependent: :destroy
+  belongs_to :investigation_business, optional: true, dependent: :destroy
   belongs_to :user
   has_one_attached :products_file
 end

--- a/app/services/add_business_to_case.rb
+++ b/app/services/add_business_to_case.rb
@@ -25,7 +25,7 @@ class AddBusinessToCase
 private
 
   def create_online_marketplace
-    context.online_marketplace = OnlineMarketplace.create!(name: other_marketplace_name, approved_by_opss: false)
+    context.online_marketplace = OnlineMarketplace.find_or_create_by!(name: other_marketplace_name, approved_by_opss: false)
   end
 
   def create_audit_activity_for_business_added(business, investigation_business)

--- a/app/views/bulk_products/add_business_details.html.erb
+++ b/app/views/bulk_products/add_business_details.html.erb
@@ -1,0 +1,52 @@
+<% page_heading = "Provide the business details - Upload multiple products" %>
+<% page_title page_heading, errors: @bulk_products_add_business_details_form.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink(text: "Back", href: create_business_bulk_upload_products_path) %>
+<% end %>
+<%= form_with model: @bulk_products_add_business_details_form, url: add_business_details_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= error_summary @bulk_products_add_business_details_form.errors %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Upload multiple products</span>
+        Provide the business details
+      </h1>
+      <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Name and company number</legend>
+        <%= govukInput(
+          form: form,
+          key: :trading_name,
+          label: { text: t("businesses.form.trading_name.label") },
+          hint: { text: t("businesses.form.trading_name.hint"), classes: "govuk-!-font-size-16" },
+          id: "trading_name",
+          classes: "govuk-!-width-two-thirds"
+        ) %>
+        <%= govukInput(
+          form: form,
+          key: :legal_name,
+          label: { text: t("businesses.form.legal_name.label") },
+          hint: { html: t("businesses.form.legal_name.hint_html"), classes: "govuk-!-font-size-16" },
+          id: "legal_name",
+          classes: "govuk-!-width-two-thirds"
+        ) %>
+        <%= govukInput(
+          form: form,
+          key: :company_number,
+          label: { text: t("businesses.form.company_number.label") },
+          hint: { html: t("businesses.form.company_number.hint_html"), classes: "govuk-!-font-size-16" },
+          id: "company_number",
+          classes: "govuk-!-width-one-third"
+        ) %>
+      </fieldset>
+      <%= form.fields_for :locations, @bulk_products_upload.investigation_business.business.primary_location do |ff| %>
+        <%= render "locations/address_form", form: ff, countries: @countries %>
+      <% end %>
+      <%= form.fields_for :contacts, @bulk_products_upload.investigation_business.business.primary_contact do |ff| %>
+        <%= render "contacts/form", form: ff %>
+      <% end %>
+      <div class="govuk-button-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_products/create_business.html.erb
+++ b/app/views/bulk_products/create_business.html.erb
@@ -1,0 +1,97 @@
+<% page_heading = "Add the business to the case - Upload multiple products" %>
+<% page_title page_heading, errors: @bulk_products_add_business_type_form.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink(text: "Back", href: create_case_bulk_upload_products_path) %>
+<% end %>
+<%= form_with model: @bulk_products_add_business_type_form, url: create_business_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= error_summary @bulk_products_add_business_type_form.errors %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Upload multiple products</span>
+        Add the business to the case
+      </h1>
+      <% online_marketplace_radios = capture do %>
+        <% number_of_market_places = @online_marketplaces.length %>
+        <% online_marketplace_first_half = @online_marketplaces.slice(0..number_of_market_places/2) %>
+        <% online_marketplace_second_half = @online_marketplaces.slice(number_of_market_places/2+1, number_of_market_places) %>
+        <div class="govuk-form-group <%= class_names("govuk-form-group--error") if @bulk_products_add_business_type_form&.errors[:online_marketplace_id].present? %>">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half govuk-!-padding-right-0">
+              <div class="govuk-radios govuk-radios--small">
+                <% online_marketplace_first_half.each do |marketplace| %>
+                  <div class="govuk-radios__item">
+                    <%= form.radio_button :online_marketplace_id, marketplace.id, class: "govuk-radios__input js-radio-handle-other" %>
+                    <%= form.label :online_marketplace_id, marketplace.name, value: marketplace.id, class: "govuk-label govuk-radios__label" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <div class="govuk-grid-column-one-half govuk-!-padding-right-0">
+              <div class="govuk-radios govuk-radios--small">
+                <% online_marketplace_second_half.each do |marketplace| %>
+                  <div class="govuk-radios__item">
+                    <%= form.radio_button :online_marketplace_id, marketplace.id, class: "govuk-radios__input js-radio-handle-other" %>
+                    <%= form.label :online_marketplace_id, marketplace.name, value: marketplace.id, class: "govuk-label govuk-radios__label" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <%= govukInput(
+          form: form,
+          key: :other_marketplace_name,
+          label: { text: t("investigations.business_types.new.types.other.label"), classes: "govuk-label--m" },
+          id: "other_marketplace_name",
+          classes: "js-input-handle-other"
+        ) %>
+      <% end %>
+      <% authorised_representative_radios = capture do %>
+        <div class="govuk-form-group <%= class_names("govuk-form-group--error") if @bulk_products_add_business_type_form&.errors[:authorised_representative_choice].present? %>">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <div class="govuk-radios govuk-radios--small">
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :authorised_representative_choice, t("investigations.business_types.new.types.authorised_representative.uk.value"), class: "govuk-radios__input" %>
+                  <%= form.label :authorised_representative_choice, t("investigations.business_types.new.types.authorised_representative.uk.label"), value: t("investigations.business_types.new.types.authorised_representative.uk.value"), class: "govuk-label govuk-radios__label" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :authorised_representative_choice, t("investigations.business_types.new.types.authorised_representative.eu.value"), class: "govuk-radios__input" %>
+                  <%= form.label :authorised_representative_choice, t("investigations.business_types.new.types.authorised_representative.eu.label"), value: t("investigations.business_types.new.types.authorised_representative.eu.value"), class: "govuk-label govuk-radios__label" %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+      <% radio_items = [
+        { value: "retailer", text: t("investigations.business_types.new.types.retailer.label"), hint: { text: t("investigations.business_types.new.types.retailer.hint") } },
+        { value: "online_seller", text: t("investigations.business_types.new.types.online_seller.label"), hint: { text: t("investigations.business_types.new.types.online_seller.hint") } },
+        { value: "online_marketplace", text: t("investigations.business_types.new.types.online_marketplace.label"), hint: { text: t("investigations.business_types.new.types.online_marketplace.hint") }, conditional: { html: online_marketplace_radios }},
+        { value: "manufacturer", text: t("investigations.business_types.new.types.manufacturer.label") },
+        { value: "exporter", text: t("investigations.business_types.new.types.exporter.label") },
+        { value: "importer", text: t("investigations.business_types.new.types.importer.label") },
+        { value: "fulfillment_house", text: t("investigations.business_types.new.types.fulfillment_house.label") },
+        { value: "distributor", text: t("investigations.business_types.new.types.distributor.label") },
+        { value: "authorised_representative", text: t("investigations.business_types.new.types.authorised_representative.label"), conditional: { html: authorised_representative_radios }},
+        { value: "responsible_person", text: t("investigations.business_types.new.types.responsible_person.label") },
+      ] %>
+      <%= govukRadios(
+        form: form,
+        key: :type,
+        fieldset: {
+          legend: {
+            text: "What is the business type?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: { text: "What is the business role as an economic operator in the supply chain?" },
+        items: radio_items
+      ) %>
+      <div class="govuk-button-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_products/create_case.html.erb
+++ b/app/views/bulk_products/create_case.html.erb
@@ -17,7 +17,6 @@
         key: :name,
         label: { text: "Case name", classes: "govuk-label--m" },
         hint: { text: "Give the case a short descriptive title." },
-        value: @bulk_products_create_case_form.name,
         id: "name"
       ) %>
       <%= govukRadios(
@@ -35,7 +34,6 @@
             text: "Yes",
             value: "true",
             id: "reference_number_provided_true",
-            checked: @bulk_products_create_case_form.reference_number_provided,
             conditional: {
               html: govukInput(
                 form: form,
@@ -47,8 +45,7 @@
           {
             text: "No",
             value: "false",
-            id: "reference_number_provided_false",
-            checked: @bulk_products_create_case_form.reference_number_provided == false # Can be `nil` if the user has not made a choice
+            id: "reference_number_provided_false"
           }
         ]
       ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,18 @@ en:
               blank: Enter a reference number
             reference_number_provided:
               inclusion: Select yes if you want to add a reference number
+        bulk_products_add_business_type_form:
+          attributes:
+            type:
+              inclusion: Select the business type
+            online_marketplace_id:
+              blank: Select the online marketplace or enter another online platform name
+            authorised_representative_choice:
+              blank: Select whether the authorised representative is a UK or EU Authorised representative
+        bulk_products_add_business_details_form:
+          attributes:
+            trading_name:
+              blank: Enter a trading name
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,10 @@ Rails.application.routes.draw do
             put "create-case", to: "bulk_products#create_case"
             get "create-business", to: "bulk_products#create_business", as: "create_business_bulk_upload"
             put "create-business", to: "bulk_products#create_business"
+            get "add-business-details", to: "bulk_products#add_business_details", as: "add_business_details_bulk_upload"
+            put "add-business-details", to: "bulk_products#add_business_details"
+            get "upload-products-file", to: "bulk_products#upload_products_file", as: "upload_products_file_bulk_upload"
+            put "upload-products-file", to: "bulk_products#upload_products_file"
           end
         end
       end

--- a/db/migrate/20231020120918_add_investigation_business_to_bulk_products_uploads.rb
+++ b/db/migrate/20231020120918_add_investigation_business_to_bulk_products_uploads.rb
@@ -1,0 +1,7 @@
+class AddInvestigationBusinessToBulkProductsUploads < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :bulk_products_uploads, :investigation_business, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_19_104345) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_120918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -88,9 +88,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_19_104345) do
 
   create_table "bulk_products_uploads", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.bigint "investigation_business_id"
     t.bigint "investigation_id"
     t.datetime "updated_at", null: false
     t.uuid "user_id"
+    t.index ["investigation_business_id"], name: "index_bulk_products_uploads_on_investigation_business_id"
     t.index ["investigation_id"], name: "index_bulk_products_uploads_on_investigation_id"
     t.index ["user_id"], name: "index_bulk_products_uploads_on_user_id"
   end

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -2,8 +2,11 @@ require "rails_helper"
 
 RSpec.feature "Bulk upload products", :with_stubbed_mailer do
   let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[product_bulk_uploader]) }
+  let(:online_marketplace) { create(:online_marketplace, name: "My marketplace", approved_by_opss: true) }
 
   before do
+    online_marketplace
+
     sign_in(user)
   end
 
@@ -52,6 +55,21 @@ RSpec.feature "Bulk upload products", :with_stubbed_mailer do
 
     choose "Yes"
     fill_in "Reference number", with: "1234"
+    click_button "Continue"
+
+    expect(page).to have_content("Add the business to the case")
+
+    choose "Authorised representative"
+    click_button "Continue"
+
+    expect(page).to have_error_summary("Select whether the authorised representative is a UK or EU Authorised representative")
+
+    choose "EU Authorised representative"
+    click_button "Continue"
+
+    expect(page).to have_content("Provide the business details")
+
+    select "United Kingdom", from: "bulk_products_add_business_details_form_locations_attributes_0_country", match: :first
     click_button "Continue"
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1872

## Description

Adds the business creation pages for bulk product uploads.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-10-23 at 11 28 36](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/24f127fb-9d6e-4bb1-b3e8-56dddb09f880)

## Review apps

https://psd-pr-2640.london.cloudapps.digital/
https://psd-pr-2640-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
