### PR TITLE
Fix case search counts with all cases & created date filters - PSD-2038

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -147,7 +147,7 @@ private
   end
 
   def default_params
-    [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type]].each do |param_value|
+    [params[:case_owner], params[:case_type], params[:created_by], params[:priority], params[:teams_with_access], params[:hazard_type], params[:created_from_date], params[:created_to_date]].each do |param_value|
       return false unless param_value == "all" || param_value.blank?
     end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2038

## Description

When all search filters are set as 'all' or kept as default, and new date filters are used, the result count is not accurate. 

This PR fixes that search count to detect when a date filter is used

## Screen-shots or screen-capture of UI changes

### Before
![CleanShot 2023-10-23 at 14 51 14@2x](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/22d602dc-609d-477d-aa65-7e199ed60697)

### After

![CleanShot 2023-10-23 at 14 49 17@2x](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/7851f384-c48c-457e-8613-534606197f63)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2641.london.cloudapps.digital/
https://psd-pr-2641-support.london.cloudapps.digital/