### PR TITLE
Fix adding OPSS IMT team to case on corrective action

### DIFF
--- a/app/services/add_corrective_action_to_case.rb
+++ b/app/services/add_corrective_action_to_case.rb
@@ -24,10 +24,11 @@ class AddCorrectiveActionToCase
         has_online_recall_information:
       )
       corrective_action.document.attach(document)
-      add_incident_management_team
       create_audit_activity
       send_notification_email
     end
+
+    add_incident_management_team
   end
 
 private


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2037

## Description

Fixes an issue when attempting to create a new corrective action which triggers adding OPSS IMT to the case when they have already been added.

The nested transaction aborts, which also aborts the outer transaction and prevents the corrective action from being created.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2643.london.cloudapps.digital/
https://psd-pr-2643-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
