### PR TITLE
Notify OPSS IMT when adding them to a case

### DIFF
--- a/app/services/add_corrective_action_to_case.rb
+++ b/app/services/add_corrective_action_to_case.rb
@@ -50,8 +50,7 @@ private
       team:,
       collaboration_class: Collaboration::Access::Edit,
       user:,
-      message: "System added OPSS IMT with edit permissions due to either risk level or corrective action.",
-      silent: true
+      message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
     )
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2053

## Description

Sends an email to OPSS IMT members when the team is automatically added to a case due to the severity level or corrective action.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2648.london.cloudapps.digital/
https://psd-pr-2648-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
