### PR TITLE
Upload image on product creation

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -55,17 +55,21 @@ class ProductForm
   end
 
   def cache_file!(user, product)
-    if image.present? && !image.is_a?(ActiveStorage::Blob)
-      self.image = ActiveStorage::Blob.create_and_upload!(
-        io: image,
-        filename: image.original_filename,
-        content_type: image.content_type
-      )
+    if image.present?
+      unless image.is_a?(ActiveStorage::Blob)
+        self.image = ActiveStorage::Blob.create_and_upload!(
+          io: image,
+          filename: image.original_filename,
+          content_type: image.content_type
+        )
 
-      image.analyze_later
+        image.analyze_later
+      end
 
       self.existing_image_file_id = image.signed_id
-    elsif existing_image_file_id.present? && product.present?
+    end
+
+    if existing_image_file_id.present? && product.present?
       image_upload = ImageUpload.new(upload_model: product, created_by: user.id, file_upload: ActiveStorage::Blob.find_signed!(existing_image_file_id))
       image_upload.save!
 

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Adding a product", :with_stubbed_mailer, :with_product_form_helper do
+RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer, :with_product_form_helper do
   let(:user)       { create(:user, :activated) }
   let(:attributes) do
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
@@ -142,6 +142,46 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_product_form_helpe
     fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
     fill_in "Other product identifiers", with: attributes[:product_code]
     fill_in "Webpage", with: attributes[:webpage]
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
+    within_fieldset("Is the product counterfeit?") do
+      choose counterfeit_answer(attributes[:authenticity])
+    end
+
+    within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
+      page.find("input[value='#{attributes[:has_markings]}']").choose
+    end
+
+    within_fieldset("Select product marking") do
+      attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
+    end
+
+    select "Unknown", from: "Country of origin"
+
+    fill_in "Description of product", with: attributes[:description]
+    click_on "Save"
+
+    expect(page).to have_current_path("/products")
+    expect(page).not_to have_error_messages
+    expect(page).to have_selector("h1", text: "Product record created")
+
+    click_on "View the product record"
+    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
+  end
+
+  scenario "Adding a product with an image" do
+    select attributes[:category], from: "Product category"
+    fill_in "Product subcategory", with: attributes[:subcategory]
+    fill_in "Manufacturer's brand name", with: attributes[:brand]
+    fill_in "Product name", with: attributes[:name]
+    fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
+    fill_in "Other product identifiers", with: attributes[:product_code]
+    fill_in "Webpage", with: attributes[:webpage]
+
+    attach_file "product[image]", "spec/fixtures/files/testImage.png"
 
     within_fieldset("Was the product placed on the market before 1 January 2021?") do
       choose when_placed_on_market_answer(attributes[:when_placed_on_market])


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2051

## Description

Correctly uploads the image on product creation if the product is initially valid.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2651.london.cloudapps.digital/
https://psd-pr-2651-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
