### PR TITLE
Limit free text fields to 32,767 characters

### DIFF
--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -50,7 +50,7 @@ class CorrectiveActionForm
   validates :action, inclusion: { in: CorrectiveAction.actions.keys }
   validates :other_action, presence: true, length: { maximum: 10_000 }, if: :other?
   validates :other_action, absence: true, unless: :other?
-  validates :details, length: { maximum: 50_000 }
+  validates :details, length: { maximum: 32_767 }
 
   before_validation { trim_whitespace(:other_action, :details, :file_description, :online_recall_information) }
   before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -24,7 +24,7 @@ class TestResultForm
   attribute :tso_certificate_reference_number, :string
   attribute :tso_certificate_issue_date, :govuk_date
 
-  validates :details, length: { maximum: 50_000 }
+  validates :details, length: { maximum: 32_767 }
   validates :legislation, inclusion: { in: Rails.application.config.legislation_constants["legislation"] }
   validates :standards_product_was_tested_against, presence: true
   validates :result, inclusion: { in: Test::Result.results.keys }

--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -7,7 +7,7 @@ class Correspondence < ApplicationRecord
   before_validation { trim_line_endings(:details) }
 
   validates :email_address, allow_blank: true, format: { with: URI::MailTo::EMAIL_REGEXP }, on: :context
-  validates :details, length: { maximum: 50_000 }
+  validates :details, length: { maximum: 32_767 }
   validate :date_cannot_be_in_the_future
 
   has_many_attached :documents

--- a/app/views/investigations/accident_or_incidents/_form.html.erb
+++ b/app/views/investigations/accident_or_incidents/_form.html.erb
@@ -21,6 +21,6 @@
 
 <%= form.govuk_radios :severity, legend: "Indicate the severity", items: [{ text: "Serious", value: "serious" },  { text: "High", value: "high" }, { text: "Medium", value: "medium" }, { text: "Low", value: "low" }, { text: "Unknown", value: "unknown_severity" }, { text: "Other", value: "other", conditional: { html: other } }] %>
 
-<%= form.govuk_text_area :additional_info, label: "Additional information (optional)", attributes: { maxlength: 50_000 } %>
+<%= form.govuk_text_area :additional_info, label: "Additional information (optional)", attributes: { maxlength: 32_767 } %>
 
 <%= form.hidden_field :type, value: form.object.type %>

--- a/app/views/investigations/record_emails/_form_fields.html.erb
+++ b/app/views/investigations/record_emails/_form_fields.html.erb
@@ -86,7 +86,7 @@
   <%= form.govuk_text_area :details,
     label: "Body",
     label_classes: "",
-    attributes: { maxlength: 50_000 }
+    attributes: { maxlength: 32_767 }
   %>
 
 <% end %>

--- a/app/views/investigations/record_phone_calls/_form.html.erb
+++ b/app/views/investigations/record_phone_calls/_form.html.erb
@@ -48,7 +48,7 @@
 
         </div>
 
-        <%= form.govuk_text_area :details, label: "Notes", label_classes: "govuk-!-width-two-thirds", attributes: { maxlength: 50_000 } %>
+        <%= form.govuk_text_area :details, label: "Notes", label_classes: "govuk-!-width-two-thirds", attributes: { maxlength: 32_767 } %>
 
       <% end %>
 

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -47,7 +47,7 @@
 
 <%= form.govuk_radios :result, legend: "What was the result?", items: result_items(form) %>
 
-<%= form.govuk_text_area :details, label: "Further details", attributes: { maxlength: 50_000 } %>
+<%= form.govuk_text_area :details, label: "Further details", attributes: { maxlength: 32_767 } %>
 
 <%= form.hidden_field :existing_document_file_id %>
 <%= render "related_attachment_fields",

--- a/spec/forms/corrective_action_form_spec.rb
+++ b/spec/forms/corrective_action_form_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_mailer, :with_stubbed_antivir
       end
     end
 
-    context "with details longer than 50,000 characters" do
-      let(:details) { Faker::Lorem.characters(number: 50_001) }
+    context "with details longer than 32,767 characters" do
+      let(:details) { Faker::Lorem.characters(number: 32_768) }
 
       it "returns false" do
         expect(corrective_action_form).not_to be_valid

--- a/spec/forms/test_result_form_spec.rb
+++ b/spec/forms/test_result_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TestResultForm, :with_stubbed_mailer, :with_stubbed_antivirus, ty
   end
 
   describe "validations" do
-    it { is_expected.to validate_length_of(:details).is_at_most(50_000) }
+    it { is_expected.to validate_length_of(:details).is_at_most(32_767) }
     it { is_expected.to validate_inclusion_of(:legislation).in_array(Rails.application.config.legislation_constants["legislation"]).with_message("Select the legislation that relates to this test") }
     it { is_expected.to validate_inclusion_of(:result).in_array(Test::Result.results.keys).with_message("Select result of the test") }
     it { is_expected.to validate_presence_of(:document).with_message("Provide the test results file") }


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2060

## Description

Changes all free text fields that were previously limited to 50,000 characters to instead be limited to 32,767 characters.

This is due to these fields being exportable to XLSX spreadsheets that have a per-cell character limit of 32,767.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2653.london.cloudapps.digital/
https://psd-pr-2653-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
