### PR TITLE
Add corrective actions for bulk product uploads

### DIFF
--- a/app/forms/bulk_products_choose_products_for_corrective_actions_form.rb
+++ b/app/forms/bulk_products_choose_products_for_corrective_actions_form.rb
@@ -1,0 +1,9 @@
+class BulkProductsChooseProductsForCorrectiveActionsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :random_uuid
+  attribute :product_ids, default: []
+
+  validates :product_ids, presence: true
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,15 +1,17 @@
 'use strict'
 
 import { Application } from '@hotwired/stimulus'
-import NestedForm from 'stimulus-rails-nested-form'
+import CheckboxSelectAll from 'stimulus-checkbox-select-all'
 import Clipboard from 'stimulus-clipboard'
+import NestedForm from 'stimulus-rails-nested-form'
 import Reveal from 'stimulus-reveal-controller'
 import AddRemoveController from './add_remove_controller'
 
 const application = Application.start()
 
-application.register('nested-form', NestedForm)
+application.register('checkbox-select-all', CheckboxSelectAll)
 application.register('clipboard', Clipboard)
+application.register('nested-form', NestedForm)
 application.register('reveal', Reveal)
 application.register('add-remove', AddRemoveController)
 

--- a/app/services/add_corrective_action_to_case.rb
+++ b/app/services/add_corrective_action_to_case.rb
@@ -25,7 +25,7 @@ class AddCorrectiveActionToCase
       )
       corrective_action.document.attach(document)
       create_audit_activity
-      send_notification_email
+      send_notification_email unless context.silent
     end
 
     add_incident_management_team

--- a/app/services/create_bulk_products_upload_business.rb
+++ b/app/services/create_bulk_products_upload_business.rb
@@ -27,7 +27,8 @@ class CreateBulkProductsUploadBusiness
         other_marketplace_name:,
         authorised_representative_choice:,
         investigation: bulk_products_upload.investigation,
-        user:
+        user:,
+        skip_email: true
       )
 
       # Keep track of the investigation business so we can refer to it unambiguously later

--- a/app/views/bulk_products/choose_products_for_corrective_actions.html.erb
+++ b/app/views/bulk_products/choose_products_for_corrective_actions.html.erb
@@ -1,0 +1,46 @@
+<% page_heading = "Choose products that require a corrective action - Upload multiple products" %>
+<% page_title page_heading, errors: @bulk_products_choose_products_for_corrective_actions_form.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink(text: "Back", href: review_products_bulk_upload_products_path(product_ids: @products.ids)) %>
+<% end %>
+<%= form_with model: @bulk_products_choose_products_for_corrective_actions_form, url: choose_products_for_corrective_actions_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true, data: { controller: "checkbox-select-all" } do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <%= error_summary @bulk_products_choose_products_for_corrective_actions_form.errors %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Upload multiple products</span>
+        Choose products that require a corrective action
+      </h1>
+      <p class="govuk-body">Select all that are applicable.</p>
+      <%
+        select_all = if @products.length > 1
+          [
+            { key: :product_ids, id: "product-id-select-all", name: "bulk_products_choose_products_for_corrective_actions_form[product_ids][]", value: "select_all", text: "Select all", attributes: { data: { checkbox_select_all_target: "checkboxAll" } }, disable_ghost: true },
+            { key: :product_ids, divider: "or" }
+          ]
+        else
+          []
+        end
+      %>
+      <%= govukCheckboxes(
+        form: form,
+        key: :agree,
+        items: select_all + @products.decorate.map do |product|
+          {
+            key: :product_ids,
+            id: "product-id-#{product.id}",
+            name: "bulk_products_choose_products_for_corrective_actions_form[product_ids][]",
+            value: product.id,
+            text: product.name_with_brand,
+            attributes: { data: { checkbox_select_all_target: "checkbox" } },
+            disable_ghost: true
+          }
+        end
+      ) %>
+      <div class="govuk-button-group">
+        <%= form.hidden_field :random_uuid, value: SecureRandom.uuid %>
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_products/create_corrective_action.html.erb
+++ b/app/views/bulk_products/create_corrective_action.html.erb
@@ -1,0 +1,43 @@
+<% page_heading = "Record corrective action - Upload multiple products" %>
+<% page_title page_heading, errors: @bulk_products_create_corrective_action_form.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink(text: "Back", href: choose_products_for_corrective_actions_bulk_upload_products_path) %>
+<% end %>
+<%= form_with model: @bulk_products_create_corrective_action_form, url: create_corrective_action_bulk_upload_products_path(product_ids: params[:product_ids]), builder: ApplicationFormBuilder, html: { novalidate: true }, method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <%= error_summary @bulk_products_create_corrective_action_form.errors %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Upload multiple products</span>
+        Record corrective action
+      </h1>
+      <div class="govuk-inset-text">
+        <h2 class="govuk-heading-m">Products selected for corrective action</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @products.decorate.each do |product| %>
+            <li><%= product.name_with_brand %></li>
+          <% end %>
+        </ul>
+      </div>
+      <%= render "investigations/corrective_actions/form",
+                 form: form,
+                 corrective_action: @bulk_products_create_corrective_action_form,
+                 investigation: @bulk_products_upload.investigation,
+                 allow_product_linking: false,
+                 allow_business_linking: false %>
+      <% file_field = capture do %>
+        <%= render "related_attachment_fields", form: form, file_blob: @file_blob, attachment_name: :file %>
+      <% end %>
+      <%= form.govuk_radios :related_file,
+         legend: "Are there any files related to the action?",
+         items: [
+           { text: "Yes", value: "true", conditional: { html: file_field }},
+           { text: "No", value: "off"}
+         ]
+      %>
+      <div class="govuk-button-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -774,6 +774,10 @@ en:
               wrong_headers: The selected file does not have the correct headers
               no_products: The selected file does not contain any products
               malformed_products: The selected file contains one or more products with errors
+        bulk_products_choose_products_for_corrective_actions_form:
+          attributes:
+            product_ids:
+              blank: Select at least one product to add a corrective action for
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,9 +268,13 @@ Rails.application.routes.draw do
             put "resolve-duplicate-products", to: "bulk_products#resolve_duplicate_products"
             get "review-products", to: "bulk_products#review_products", as: "review_products_bulk_upload"
             put "review-products", to: "bulk_products#review_products"
+            get "cancel-and-reupload", to: "bulk_products#cancel_and_reupload", as: "cancel_and_reupload_bulk_upload"
             get "choose-products-for-corrective-actions", to: "bulk_products#choose_products_for_corrective_actions", as: "choose_products_for_corrective_actions_bulk_upload"
             put "choose-products-for-corrective-actions", to: "bulk_products#choose_products_for_corrective_actions"
-            get "cancel-and-reupload", to: "bulk_products#cancel_and_reupload", as: "cancel_and_reupload_bulk_upload"
+            get "create-corrective-action", to: "bulk_products#create_corrective_action", as: "create_corrective_action_bulk_upload"
+            put "create-corrective-action", to: "bulk_products#create_corrective_action"
+            get "confirm", to: "bulk_products#confirm", as: "confirm_bulk_upload"
+            put "confirm", to: "bulk_products#confirm"
           end
         end
       end

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postcss": "^8.4.31",
     "sass": "^1.69.5",
     "standard": "^17.1.0",
+    "stimulus-checkbox-select-all": "^5.2.0",
     "stimulus-clipboard": "^4.0.1",
     "stimulus-rails-nested-form": "^4.1.0",
     "stimulus-reveal-controller": "^4.1.0",

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -103,5 +103,12 @@ RSpec.feature "Bulk upload products", :with_stubbed_mailer do
     expect(page).to have_content(duplicate_product.name)
 
     click_button "Continue"
+
+    expect(page).to have_content("Choose products that require a corrective action")
+
+    check duplicate_product.name
+    click_button "Continue"
+
+    expect(page).to have_content("Record corrective action")
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,6 +2233,11 @@ standard@^17.1.0:
     standard-engine "^15.0.0"
     version-guard "^1.1.1"
 
+stimulus-checkbox-select-all@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/stimulus-checkbox-select-all/-/stimulus-checkbox-select-all-5.2.0.tgz#5ce778e5241978c0b6cdc2b000092c7e3dc357a2"
+  integrity sha512-gONmYrkWMkw5adNUAX8UnS5riCiO//qLpqtVcFaD63ffMmNLAbS8N03Q/e4eCjvFPTfP5tOSI0TLFNx7MRq9aA==
+
 stimulus-clipboard@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/stimulus-clipboard/-/stimulus-clipboard-4.0.1.tgz#acc9212b479fedc633ecdec8f191a28c1d826a6b"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1876

## Description

Adds two pages to create corrective actions for bulk product uploads.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-11-02 at 14 42 21](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/75d3fd02-028a-4697-93d2-50a944e88431)

![Screenshot 2023-11-02 at 14 42 33](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/5d62a136-a224-434e-86ca-c9fc2b7beb51)

## Review apps

https://psd-pr-2659.london.cloudapps.digital/
https://psd-pr-2659-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
