### PR TITLE
Prevent users from accepting default business name for bulk product uploads

### DIFF
--- a/app/forms/bulk_products_add_business_details_form.rb
+++ b/app/forms/bulk_products_add_business_details_form.rb
@@ -13,10 +13,13 @@ class BulkProductsAddBusinessDetailsForm
   attribute :contacts_attributes
 
   validates :trading_name, presence: true
+  validate :validate_trading_name_not_default
   validate :validate_country_set_for_location
 
   def initialize(*args)
     super
+    # Detect a default trading name and don't show it to force the user to enter their own
+    self.trading_name = nil if trading_name.start_with?("Auto-generated business for case")
     self.locations = [Location.new] if locations.empty?
     self.contacts = [Contact.new] if contacts.empty?
   end
@@ -44,6 +47,10 @@ class BulkProductsAddBusinessDetailsForm
   end
 
 private
+
+  def validate_trading_name_not_default
+    errors.add(:trading_name, :invalid) if trading_name.start_with?("Auto-generated business for case")
+  end
 
   def validate_country_set_for_location
     return if locations_attributes["0"][:country].present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -763,6 +763,7 @@ en:
           attributes:
             trading_name:
               blank: Enter a trading name
+              invalid: Enter a valid trading name
         bulk_products_upload_products_file_form:
           attributes:
             products_file_upload:

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -72,6 +72,7 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
 
     expect(page).to have_content("Provide the business details")
 
+    fill_in "Trading name", with: "Fake name"
     select "United Kingdom", from: "bulk_products_add_business_details_form_locations_attributes_0_country", match: :first
     click_button "Continue"
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2096

## Description

Prevents displaying the business trading name if it is the default assigned when the business was created to force the user to enter their own. Also adds validation to prevent a default business name being saved.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2665.london.cloudapps.digital/
https://psd-pr-2665-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
