### PR TITLE
Save case details for existing products when bulk uploading

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -170,8 +170,10 @@ class BulkProductsController < ApplicationController
                      []
                    end
     existing_products = Product.where(id: params[:product_ids]).map do |product|
-      { product:, investigation_product: product.investigation_products&.first }
+      cached_product = @bulk_products_upload.products_cache.detect { |p| p["barcode"] == product[:barcode] }
+      { product:, investigation_product: cached_product.present? ? InvestigationProduct.new(cached_product["investigation_data"]) : InvestigationProduct.new }
     end
+
     @products_to_review = new_products + existing_products
 
     if request.put?

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -21,6 +21,7 @@ class AddProductToCase
 
     change_product_owner_if_unowned
 
+    context.investigation_product = investigation_product
     context.activity = create_audit_activity_for_product_added
 
     send_notification_email unless skip_email

--- a/app/services/create_bulk_products_upload_products.rb
+++ b/app/services/create_bulk_products_upload_products.rb
@@ -33,7 +33,7 @@ class CreateBulkProductsUploadProducts
 
         AddProductToCase.call!(investigation: bulk_products_upload.investigation, product:, user:, skip_email: true)
 
-        product.investigation_products.first.update!(new_product[:investigation_product].serializable_hash.slice("batch_number", "customs_code", "number_of_affected_units"))
+        product.investigation_products.first.update!(new_product[:investigation_product].serializable_hash.slice("batch_number", "customs_code", "number_of_affected_units").merge(affected_units_status: "exact"))
 
         product
       end
@@ -44,7 +44,8 @@ class CreateBulkProductsUploadProducts
 
       # Products that already exist
       existing_products.each do |existing_product|
-        AddProductToCase.call!(investigation: bulk_products_upload.investigation, product: existing_product[:product], user:, skip_email: true)
+        context = AddProductToCase.call!(investigation: bulk_products_upload.investigation, product: existing_product[:product], user:, skip_email: true)
+        context.investigation_product.update!(existing_product[:investigation_product].serializable_hash.slice("batch_number", "customs_code", "number_of_affected_units").merge(affected_units_status: "exact"))
       end
     end
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2097

## Description

Saves the case-level details for existing products added during bulk product uploads. This includes batch numbers, customs codes and units affected.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2666.london.cloudapps.digital/
https://psd-pr-2666-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
