### PR TITLE
Fix issue with empty row handling for bulk product uploads

### DIFF
--- a/app/forms/bulk_products_upload_products_file_form.rb
+++ b/app/forms/bulk_products_upload_products_file_form.rb
@@ -134,6 +134,8 @@ private
     error_messages = {}
 
     worksheet[2..].each do |row|
+      next if row.nil?
+
       ary = row.cells.map { |cell| cell&.value&.to_s }
 
       # Ignore completely empty rows or rows with just an entry number


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2101

## Description

Fixes a bug when a spreadsheet row is returned as `nil`.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2667.london.cloudapps.digital/
https://psd-pr-2667-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
