### PR TITLE
Allow resumption of incomplete bulk products upload journeys

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -12,6 +12,9 @@ class InvestigationsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
+        # Find the most recent incomplete bulk products upload for the current user, if any
+        @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
+
         @answer         = opensearch_for_investigations(20)
         @count          = count_to_display
         @investigations = InvestigationDecorator
@@ -26,6 +29,9 @@ class InvestigationsController < ApplicationController
     authorize @investigation, :view_non_protected_details?
     breadcrumb breadcrumb_case_label, breadcrumb_case_path
     @complainant = @investigation.complainant&.decorate
+
+    # Find the most recent incomplete bulk products upload for the current user and case, if any
+    @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil, investigation: @investigation.object).order(updated_at: :desc).first
   end
 
   def created

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,6 +13,8 @@ class ProductsController < ApplicationController
   breadcrumb "products.label", :products_path
 
   def index
+    # Find the most recent incomplete bulk products upload for the current user, if any
+    @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
     @results = search_for_products(20)
     @count = count_to_display
     @products = ProductDecorator.decorate_collection(@results)

--- a/app/models/bulk_products_upload.rb
+++ b/app/models/bulk_products_upload.rb
@@ -6,6 +6,12 @@ class BulkProductsUpload < ApplicationRecord
   has_and_belongs_to_many :products
   has_one_attached :products_file
 
+  scope :incomplete, -> { where(submitted_at: nil) }
+
+  def incomplete?
+    submitted_at.nil?
+  end
+
   # Destroys all records created as part of the bulk products upload process
   def deep_destroy!
     # Products created (as opposed to existing ones added to the investigation)

--- a/app/views/application/_incomplete_bulk_products_upload_notification.html.erb
+++ b/app/views/application/_incomplete_bulk_products_upload_notification.html.erb
@@ -1,0 +1,19 @@
+<% if @incomplete_bulk_products_upload.present? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">
+            We have noticed that your recent product upload is not complete, and the products have yet to be allocated to their respective case.
+            <a class="govuk-notification-banner__link" href="<%= create_case_bulk_upload_products_path(@incomplete_bulk_products_upload) %>">Resume the upload process</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/investigations/heading/_all_cases.html.erb
+++ b/app/views/investigations/heading/_all_cases.html.erb
@@ -1,3 +1,5 @@
+<%= render "incomplete_bulk_products_upload_notification" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">

--- a/app/views/investigations/show.html.erb
+++ b/app/views/investigations/show.html.erb
@@ -3,6 +3,8 @@
 <% link_text = @investigation.is_closed? ? "Re-open case" : "Close case" %>
 <% secondary_text = @investigation.is_closed? ? "This case is closed." : "From here you can find all the information about this case. If you have editing rights for this case, you can add products, businesses and supporting information." %>
 
+<%= render "incomplete_bulk_products_upload_notification" %>
+
 <%= render "investigations/navigable_case_nav", investigation: @investigation,
                                                 current_tab: "overview",
                                                 case_page_heading: "Case",

--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -1,3 +1,5 @@
+<%= render "incomplete_bulk_products_upload_notification" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">All products – Search</h1>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2102

## Description

Shows a banner on the all cases and all products pages when the current user has one or more incomplete bulk products uploads. Also shows the banner on the case page of a case associated with an incomplete bulk products upload.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-11-08 at 10 12 52](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/5c4b16ef-ab56-4865-aaa7-1b0c8979c26e)

![Screenshot 2023-11-08 at 10 13 03](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/a104fd71-8ac1-4552-a811-55dab3426fe8)

![Screenshot 2023-11-08 at 10 24 27](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/caa144ef-9060-42b3-a306-99c75dae2aa0)

## Review apps

https://psd-pr-2668.london.cloudapps.digital/
https://psd-pr-2668-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
