### PR TITLE
Show existing and new records for duplicate resolution

### DIFF
--- a/app/assets/stylesheets/opss/_opss-psd.scss
+++ b/app/assets/stylesheets/opss/_opss-psd.scss
@@ -218,6 +218,10 @@ $opss-retired-bg: govuk-tint(govuk-colour("light-grey"), 50);
         margin-right: govuk-spacing(3);
         margin-left: govuk-spacing(2);
       }
+
+      &.opss-panels__pair--merged--right {
+        border-left: none;
+      }
     }
   }
 }

--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -124,8 +124,10 @@ class BulkProductsController < ApplicationController
     # If there is nothing in the cache then we don't have a valid file, so redirect to the file upload page
     return redirect_to upload_products_file_bulk_upload_products_path(@bulk_products_upload) if @bulk_products_upload.products_cache.blank?
 
+    @products_cache = @bulk_products_upload.products_cache
+
     # Barcodes from all uploaded products
-    barcodes = @bulk_products_upload.products_cache.pluck("barcode").compact
+    barcodes = @products_cache.pluck("barcode").compact
 
     # Gets the newest product per barcode to present to the user as an alternative to what they've submitted
     @duplicate_products = Product.where(barcode: barcodes).select("DISTINCT ON (products.barcode) barcode, products.*").order(barcode: :asc, updated_at: :desc)

--- a/app/helpers/bulk_products_helper.rb
+++ b/app/helpers/bulk_products_helper.rb
@@ -1,0 +1,6 @@
+module BulkProductsHelper
+  def new_record_for_product(product)
+    new_record = @products_cache.detect { |cached_product| cached_product["barcode"] == product.barcode }
+    Product.new(new_record["product_data"].except("image", "existing_image_file_id"))
+  end
+end

--- a/app/views/bulk_products/resolve_duplicate_products.html.erb
+++ b/app/views/bulk_products/resolve_duplicate_products.html.erb
@@ -15,8 +15,10 @@
       <% @duplicate_products_length = @duplicate_products.length - 1 %>
       <% @duplicate_products.decorate.each_with_index do |product, index| %>
         <div class="opss-panels">
-          <div class="opss-panels__single">
-            <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= product.name_with_brand %></h2>
+          <!-- Existing record -->
+          <div class="opss-panels__pair opss-panels__pair--merged--left">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= product.name_with_brand %></h2>
+            <div class="govuk-tag govuk-tag--yellow govuk-!-margin-bottom-3">Existing PSD record</div>
             <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-6">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key"><%= psd_abbr %> <span title="reference">ref</span></dt>
@@ -55,6 +57,37 @@
               </details>
             <% end %>
           </div>
+          <!-- New record -->
+          <% new_record = new_record_for_product(product).decorate %>
+          <div class="opss-panels__pair opss-panels__pair--merged--right">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= new_record.name_with_brand %></h2>
+            <div class="govuk-tag govuk-tag--green govuk-!-margin-bottom-3">Imported Excel record</div>
+            <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-6">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key"><%= psd_abbr %> <span title="reference">ref</span></dt>
+                <dd class="govuk-summary-list__value">Not available</dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Brand name</dt>
+                <dd class="govuk-summary-list__value"><%= new_record.brand %></dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Product name</dt>
+                <dd class="govuk-summary-list__value"><%= new_record.name %></dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Barcode</dt>
+                <dd class="govuk-summary-list__value"><%= new_record.barcode %></dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Counterfeit</dt>
+                <dd class="govuk-summary-list__value">
+                  <%= new_record.counterfeit_value %>
+                  <span class="govuk-!-font-size-16 govuk-!-padding-left-2 opss-secondary-text"><%= new_record.counterfeit_explanation %></span>
+                </dd>
+              </div>
+            </dl>
+          </div>
         </div>
         <%= form.fields_for :resolution do |resolution_form| %>
           <%= govukRadios(
@@ -68,13 +101,13 @@
             },
             items: [
               {
-                text: "Use this product record instead",
+                text: "Use existing PSD record",
                 value: "existing_record;#{product.id}",
                 checked: @bulk_products_resolve_duplicate_products_form.resolution[product.barcode] == "existing_record;#{product.id}",
                 id: product.barcode
               },
               {
-                text: "Use the product record from my Excel file",
+                text: "Use imported Excel record",
                 value: "new_record",
                 checked: @bulk_products_resolve_duplicate_products_form.resolution[product.barcode] == "new_record"
               }

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
 
     expect(page).to have_error_summary("Select whether to use the existing product record or the one from your Excel file")
 
-    choose "Use this product record instead"
+    choose "Use existing PSD record"
     click_button "Continue"
 
     expect(page).to have_current_path("/products/bulk-upload/1/review-products?product_ids[]=#{duplicate_product.id}")


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2112


## Description

Displays the existing and new records side-by-side when resolving duplicates for bulk products uploads.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-11-08 at 11 17 44](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/66dee061-7d74-41a0-85bd-47383c6674b7)

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
