### PR TITLE
PRISM: add sensitivity analysis details

### DIFF
--- a/db/migrate/20231109111428_add_sensitivity_analysis_details_to_prism_evaluations.prism.rb
+++ b/db/migrate/20231109111428_add_sensitivity_analysis_details_to_prism_evaluations.prism.rb
@@ -1,0 +1,6 @@
+# This migration comes from prism (originally 20231109111312)
+class AddSensitivityAnalysisDetailsToPrismEvaluations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prism_evaluations, :sensitivity_analysis_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_02_164229) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_09_111428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -368,6 +368,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_164229) do
     t.boolean "risk_to_non_users"
     t.string "risk_tolerability"
     t.boolean "sensitivity_analysis"
+    t.text "sensitivity_analysis_details"
     t.string "significant_risk_differential"
     t.boolean "uncertainty_level_implications_for_risk_management"
     t.datetime "updated_at", null: false

--- a/prism/app/controllers/prism/tasks/evaluate_controller.rb
+++ b/prism/app/controllers/prism/tasks/evaluate_controller.rb
@@ -93,7 +93,7 @@ module Prism
     end
 
     def add_level_of_uncertainty_and_sensitivity_analysis_params
-      params.require(:evaluation).permit(:level_of_uncertainty, :sensitivity_analysis, :draft)
+      params.require(:evaluation).permit(:level_of_uncertainty, :sensitivity_analysis, :sensitivity_analysis_details, :draft)
     end
 
     def consider_the_nature_of_the_risk_params

--- a/prism/app/helpers/prism/tasks/evaluate_helper.rb
+++ b/prism/app/helpers/prism/tasks/evaluate_helper.rb
@@ -101,6 +101,10 @@ module Prism
       Prism::RiskMatrixService.risk_level(probability_frequency: Prism::ProbabilityService.overall_probability_of_harm(harm_scenario:).probability, severity_level: harm_scenario.severity.to_sym)
     end
 
+    def sensitivity_analysis_with_details(sensitivity_analysis, sensitivity_analysis_details)
+      sensitivity_analysis_details.present? ? "#{I18n.t('prism.evaluation.yes_no.true')}: #{sensitivity_analysis_details}" : I18n.t("prism.evaluation.yes_no.#{sensitivity_analysis}")
+    end
+
     def other_types_of_harm(other_types_of_harm)
       other_types_of_harm.present? ? other_types_of_harm.map { |oth| I18n.t("prism.evaluation.other_types_of_harm.#{oth}") }.join(", ") : I18n.t("prism.evaluation.other_types_of_harm.not_applicable")
     end

--- a/prism/app/models/prism/evaluation.rb
+++ b/prism/app/models/prism/evaluation.rb
@@ -75,5 +75,13 @@ module Prism
     validates :designed_to_provide_protective_function, inclusion: %w[yes no unknown], on: :consider_perception_and_tolerability_of_the_risk
     validates :user_control_over_risk, inclusion: [true, false], on: :consider_perception_and_tolerability_of_the_risk
     validates :risk_tolerability, inclusion: %w[tolerable intolerable], on: :risk_evaluation_outcome
+
+    before_save :clear_sensitivity_analysis_details
+
+  private
+
+    def clear_sensitivity_analysis_details
+      self.sensitivity_analysis_details = nil unless sensitivity_analysis
+    end
   end
 end

--- a/prism/app/services/prism/risk_assessment_pdf_service.rb
+++ b/prism/app/services/prism/risk_assessment_pdf_service.rb
@@ -106,7 +106,7 @@ module Prism
       pdf.move_down 10
       pdf.table([
         [{ content: "Level of uncertainty associated with the risk assessment", font_style: :bold }, evaluation_translate_simple("level_of_uncertainty", prism_risk_assessment.evaluation.level_of_uncertainty)],
-        [{ content: "Has sensitivity analysis been undertaken?", font_style: :bold }, evaluation_translate_simple("yes_no", prism_risk_assessment.evaluation.sensitivity_analysis)],
+        [{ content: "Has sensitivity analysis been undertaken?", font_style: :bold }, sensitivity_analysis_with_details(prism_risk_assessment.evaluation.sensitivity_analysis, prism_risk_assessment.evaluation.sensitivity_analysis_details)],
       ], width: 522, column_widths: { 0 => 200 })
       pdf.move_down 20
       pdf.text "Risk evaluation", color: "000000", style: :bold, size: 20

--- a/prism/app/views/prism/tasks/evaluate/add_level_of_uncertainty_and_sensitivity_analysis.html.erb
+++ b/prism/app/views/prism/tasks/evaluate/add_level_of_uncertainty_and_sensitivity_analysis.html.erb
@@ -26,19 +26,12 @@
         hint: { text: "Every risk assessment that involves some degree of estimation will come with an associated degree of uncertainty; this is normal and does not in itself mean that the risk assessment is flawed." },
         bold_labels: false
       %>
-      <%=
-        f.govuk_collection_radio_buttons :sensitivity_analysis,
-        [
-          OpenStruct.new(id: true, name: "Yes"),
-          OpenStruct.new(id: false, name: "No")
-        ],
-        :id,
-        :name,
-        legend: { text: "Has sensitivity analysis been undertaken?" },
-        hint: { text: "The implications of the uncertainty can be considered by undertaking a sensitivity analysis. For example, where there is uncertainty surrounding one or more of the probabilities within a harm scenario, then different probabilities can be applied (which can be higher, lower, or both than the orignal figures used) to fairly reflect the extent of the uncertainty." },
-        bold_labels: false,
-        inline: true
-      %>
+      <%= f.govuk_radio_buttons_fieldset :sensitivity_analysis, legend: { text: "Has sensitivity analysis been undertaken?", size: "m" }, hint: { text: "The implications of the uncertainty can be considered by undertaking a sensitivity analysis. For example, where there is uncertainty surrounding one or more of the probabilities within a harm scenario, then different probabilities can be applied (which can be higher, lower, or both than the orignal figures used) to fairly reflect the extent of the uncertainty." } do %>
+        <%= f.govuk_radio_button :sensitivity_analysis, true, label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_area :sensitivity_analysis_details, label: { text: "Add additional sensitivity analysis information if required." } %>
+        <% end %>
+        <%= f.govuk_radio_button :sensitivity_analysis, false, label: { text: "No" } %>
+      <% end %>
       <%= f.govuk_submit "Save and continue" do %>
         <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
       <% end %>

--- a/prism/app/views/prism/tasks/evaluate/review_and_submit_results_of_the_assessment.html.erb
+++ b/prism/app/views/prism/tasks/evaluate/review_and_submit_results_of_the_assessment.html.erb
@@ -153,7 +153,7 @@
           end
           summary_list.with_row do |row|
             row.with_key(text: "Has sensitivity analysis been undertaken?")
-            row.with_value(text: evaluation_translate_simple("yes_no", @prism_risk_assessment.evaluation.sensitivity_analysis))
+            row.with_value(text: sensitivity_analysis_with_details(@prism_risk_assessment.evaluation.sensitivity_analysis, @prism_risk_assessment.evaluation.sensitivity_analysis_details))
             row.with_action(text: "Change", href: task_path("evaluate", "add_level_of_uncertainty_and_sensitivity_analysis"), visually_hidden_text: "whether sensitivity analysis has been undertaken")
           end
         end

--- a/prism/app/views/prism/tasks/evaluate/review_and_submit_results_of_the_evaluation.html.erb
+++ b/prism/app/views/prism/tasks/evaluate/review_and_submit_results_of_the_evaluation.html.erb
@@ -69,7 +69,7 @@
           end
           summary_list.with_row do |row|
             row.with_key(text: "Has sensitivity analysis been undertaken?")
-            row.with_value(text: evaluation_translate_simple("yes_no", @prism_risk_assessment.evaluation.sensitivity_analysis))
+            row.with_value(text: sensitivity_analysis_with_details(@prism_risk_assessment.evaluation.sensitivity_analysis, @prism_risk_assessment.evaluation.sensitivity_analysis_details))
             row.with_action(text: "Change", href: task_path("evaluate", "add_level_of_uncertainty_and_sensitivity_analysis"), visually_hidden_text: "whether sensitivity analysis has been undertaken")
           end
         end

--- a/prism/app/views/prism/tasks/view_submitted_assessment.html.erb
+++ b/prism/app/views/prism/tasks/view_submitted_assessment.html.erb
@@ -136,7 +136,7 @@
         end
         summary_list.with_row do |row|
           row.with_key(text: "Has sensitivity analysis been undertaken?")
-          row.with_value(text: evaluation_translate_simple("yes_no", @prism_risk_assessment.evaluation.sensitivity_analysis))
+          row.with_value(text: sensitivity_analysis_with_details(@prism_risk_assessment.evaluation.sensitivity_analysis, @prism_risk_assessment.evaluation.sensitivity_analysis_details))
         end
       end
     %>

--- a/prism/db/migrate/20231109111312_add_sensitivity_analysis_details_to_prism_evaluations.rb
+++ b/prism/db/migrate/20231109111312_add_sensitivity_analysis_details_to_prism_evaluations.rb
@@ -1,0 +1,5 @@
+class AddSensitivityAnalysisDetailsToPrismEvaluations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prism_evaluations, :sensitivity_analysis_details, :text
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2080

## Description

Adds an optional text area to enter more details if sensitivity analysis has been undertaken.

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-11-09 at 12 56 56](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/28030908-5301-48cc-801a-3c8a6c0cae05)

## Review apps

https://psd-pr-2672.london.cloudapps.digital/
https://psd-pr-2672-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
