### PR TITLE
PRISM: allow drafts to be deleted

### DIFF
--- a/app/views/prism_risk_assessments/_table.html.erb
+++ b/app/views/prism_risk_assessments/_table.html.erb
@@ -6,7 +6,7 @@
       <th scope="col" class="govuk-table__header">Assessment title</th>
       <th scope="col" class="govuk-table__header">Last updated</th>
       <th scope="col" class="govuk-table__header">Status</th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden"><% if type == "submitted" %>View assessment<% else %>Make changes<% end %></span></th>
+      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden"><% if type == "submitted" %>View assessment<% else %>Make changes or delete<% end %></span></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -21,7 +21,7 @@
         <th scope="col" class="govuk-table__header">Assessment title</th>
         <th scope="col" class="govuk-table__header">Last updated</th>
         <th scope="col" class="govuk-table__header">Status</th>
-        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden"><% if type == "submitted" %>View assessment<% else %>Make changes<% end %></span></th>
+        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden"><% if type == "submitted" %>View assessment<% else %>Make changes or delete<% end %></span></th>
       </tr>
     </tfoot>
   <% end %>

--- a/app/views/prism_risk_assessments/_table_row.html.erb
+++ b/app/views/prism_risk_assessments/_table_row.html.erb
@@ -12,6 +12,6 @@
     <% if type == "submitted" %><%= govukTag(text: "Submitted", classes: "govuk-tag--green") %><% else %><%= govukTag(text: "Draft", classes: "govuk-tag--grey") %><% end %>
   </td>
   <td class="govuk-table__cell">
-    <% if type == "submitted" %><a href="<%= prism.view_submitted_assessment_risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">View assessment</a><hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><a href="<%= add_to_case_prism_risk_assessments_path(prism_risk_assessment_id: prism_risk_assessment.id) %>" class="govuk-link">Add to a case</a><% else %><a href="<%= prism.risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">Make changes</a><% end %>
+    <% if type == "submitted" %><a href="<%= prism.view_submitted_assessment_risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">View assessment</a><hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><a href="<%= add_to_case_prism_risk_assessments_path(prism_risk_assessment_id: prism_risk_assessment.id) %>" class="govuk-link">Add to a case</a><% else %><a href="<%= prism.risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">Make changes</a><hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><a href="<%= prism.remove_risk_assessment_tasks_path(prism_risk_assessment, back_to: "dashboard") %>" class="govuk-link">Delete</a><% end %>
   </td>
 </tr>

--- a/prism/app/controllers/prism/tasks_controller.rb
+++ b/prism/app/controllers/prism/tasks_controller.rb
@@ -1,7 +1,7 @@
 module Prism
   class TasksController < ApplicationController
     before_action :prism_risk_assessment, except: %i[view_submitted_assessment download_assessment_pdf]
-    before_action :disallow_editing_submitted_prism_risk_assessment, except: %i[confirmation view_submitted_assessment download_assessment_pdf]
+    before_action :disallow_changing_submitted_prism_risk_assessment, except: %i[confirmation view_submitted_assessment download_assessment_pdf]
     before_action :set_prism_risk_assessment_tasks_status, only: %i[index]
     before_action :ensure_associated_investigation_or_product, only: %i[index]
     before_action :ensure_one_harm_scenario, only: %i[index]
@@ -54,13 +54,25 @@ module Prism
       file&.close
     end
 
+    def remove; end
+
+    def delete
+      @prism_risk_assessment.destroy!
+
+      if params[:back_to] == "dashboard"
+        redirect_to main_app.your_prism_risk_assessments_path
+      else
+        redirect_to root_path
+      end
+    end
+
   private
 
     def prism_risk_assessment
       @prism_risk_assessment ||= Prism::RiskAssessment.includes(:harm_scenarios).find_by!(id: params[:risk_assessment_id], created_by_user_id: current_user.id)
     end
 
-    def disallow_editing_submitted_prism_risk_assessment
+    def disallow_changing_submitted_prism_risk_assessment
       redirect_to view_submitted_assessment_risk_assessment_tasks_path(@prism_risk_assessment) if @prism_risk_assessment.submitted?
     end
 

--- a/prism/app/views/prism/tasks/remove.html.erb
+++ b/prism/app/views/prism/tasks/remove.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, "Are you sure you want delete this risk assessment?" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @prism_risk_assessment, url: delete_risk_assessment_tasks_path(back_to: params[:back_to]), method: :delete do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want delete this risk assessment?
+      </h1>
+      <p class="govuk-body">This action will permanently remove the risk assessment from the system and cannot be undone. Please ensure that you want to proceed with this deletion.</p>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Delete risk assessment", warning: true %>
+        <a href="<%= params[:back_to] == "dashboard" ? main_app.your_prism_risk_assessments_path : risk_assessment_tasks_path(@prism_risk_assessment) %>" class="govuk-link">Cancel</a>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/prism/config/routes.rb
+++ b/prism/config/routes.rb
@@ -39,6 +39,8 @@ Prism::Engine.routes.draw do
         get "confirmation", to: "tasks#confirmation"
         get "view-submitted-assessment", to: "tasks#view_submitted_assessment"
         get "download-assessment-pdf", to: "tasks#download_assessment_pdf"
+        get "remove", to: "tasks#remove"
+        delete "delete", to: "tasks#delete"
       end
     end
   end

--- a/spec/features/prism_risk_assessment_spec.rb
+++ b/spec/features/prism_risk_assessment_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "PRISM risk assessment dashboard", type: :feature do
         expect(page).to have_text(draft_prism_risk_assessment.product_name)
         expect(page).to have_text(draft_prism_risk_assessment.name)
         expect(page).to have_link("Make changes")
+        expect(page).to have_link("Delete")
         expect(page).to have_text(submitted_prism_risk_assessment.product_name)
         expect(page).to have_text(submitted_prism_risk_assessment.name)
         expect(page).to have_link("View assessment")
@@ -51,6 +52,15 @@ RSpec.feature "PRISM risk assessment dashboard", type: :feature do
         expect(page).to have_current_path("/prism/risk-assessment/#{draft_prism_risk_assessment.id}/tasks")
       end
 
+      scenario "deleting an existing PRISM risk assessment" do
+        visit "/"
+
+        click_link "Risk assessments"
+        click_link "Delete"
+
+        expect(page).to have_current_path("/prism/risk-assessment/#{draft_prism_risk_assessment.id}/tasks/remove?back_to=dashboard")
+      end
+
       context "without an associated product" do
         before do
           draft_prism_risk_assessment.associated_products.destroy_all
@@ -70,7 +80,7 @@ RSpec.feature "PRISM risk assessment dashboard", type: :feature do
       end
     end
 
-    context "without existing PRISM risk asssessments" do
+    context "without existing PRISM risk assessments" do
       scenario "visiting the PRISM risk assessment dashboard" do
         visit "/"
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2103

## Description

Allows draft risk assessments to be deleted by the creating user.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2673.london.cloudapps.digital/
https://psd-pr-2673-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
