### PR TITLE
PRISM: Change risk level choice criteria

### DIFF
--- a/prism/app/controllers/prism/tasks/evaluate_controller.rb
+++ b/prism/app/controllers/prism/tasks/evaluate_controller.rb
@@ -15,6 +15,7 @@ module Prism
       case step
       when :confirm_overall_product_risk
         @identical_severity_levels = @harm_scenarios.map(&:severity).uniq.length <= 1
+        @multiple_hazard_types = @harm_scenarios.map(&:hazard_type).uniq.length > 1
       when :add_level_of_uncertainty_and_sensitivity_analysis
         @evaluation = @prism_risk_assessment.evaluation || @prism_risk_assessment.build_evaluation
       end
@@ -26,6 +27,7 @@ module Prism
       case step
       when :confirm_overall_product_risk
         @identical_severity_levels = @harm_scenarios.map(&:severity).uniq.length <= 1
+        @multiple_hazard_types = @harm_scenarios.map(&:hazard_type).uniq.length > 1
         @prism_risk_assessment.assign_attributes(confirm_overall_product_risk_params)
       when :add_level_of_uncertainty_and_sensitivity_analysis
         @evaluation = @prism_risk_assessment.evaluation || @prism_risk_assessment.build_evaluation

--- a/prism/app/views/prism/tasks/evaluate/confirm_overall_product_risk.html.erb
+++ b/prism/app/views/prism/tasks/evaluate/confirm_overall_product_risk.html.erb
@@ -55,7 +55,7 @@
       <% if @harm_scenarios.length == 1 %>
         <h2 class="govuk-heading-m">Overall product risk level</h2>
         <p class="govuk-body" data-test="overall-product-risk-level"><%= overall_risk_level(@harm_scenarios.first).risk_level_tag_html %></p>
-      <% elsif @identical_severity_levels %>
+      <% elsif @identical_severity_levels && @multiple_hazard_types %>
         <h2 class="govuk-heading-m">Choose the overall product risk level</h2>
         <%= f.govuk_radio_buttons_fieldset :overall_product_risk_methodology, legend: nil do %>
           <%= f.govuk_radio_button :overall_product_risk_methodology, "highest", label: { text: highest_risk_level(@harm_scenarios).risk_level_tag_html }, hint: { text: "<br>#{risk_level_plus_label}Where more than one harm scenario has been generated in relation to the same hazard, the overall level of risk for the product will be determined by the scenario that involves the greatest risk.".html_safe }, link_errors: true %>
@@ -65,7 +65,7 @@
         <h2 class="govuk-heading-m">Overall product risk level</h2>
         <p class="govuk-body">Where more than one harm scenario has been generated in relation to the same hazard, the overall level of risk for the product will be determined by the scenario that involves the greatest risk.</p>
         <p class="govuk-body" data-test="overall-product-risk-level"><%= highest_risk_level(@harm_scenarios).risk_level_tag_html %></p>
-        <%= risk_level_plus_label %>
+        <%= risk_level_plus_label if @multiple_hazard_types %>
       <% end %>
       <%= f.govuk_submit "Save and continue" do %>
         <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2049

## Description

Changes the risk level choice criteria as follows:

* One harm scenario -> risk level of the harm scenario
* More than one harm scenario with different severity levels and/or identical hazard types -> highest risk level
* More than one harm scenario with identical severity levels and different hazard types -> choice between highest and combined risk level

The risk level plus label is also only displayed for multiple hazard types.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2674.london.cloudapps.digital/
https://psd-pr-2674-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
