### PR TITLE
Remove PRISM links for non-PRISM users for bulk products uploads

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -29,9 +29,13 @@ class BulkProductsController < ApplicationController
     end
   end
 
-  def no_upload_unsafe; end
+  def no_upload_unsafe
+    @prism_user = current_user.is_prism_user?
+  end
 
-  def no_upload_mixed; end
+  def no_upload_mixed
+    @prism_user = current_user.is_prism_user?
+  end
 
   def create_case
     if request.put?

--- a/app/views/bulk_products/no_upload_mixed.html.erb
+++ b/app/views/bulk_products/no_upload_mixed.html.erb
@@ -9,9 +9,15 @@
       <span class="govuk-caption-l">Upload multiple products</span>
       You can’t upload a mix of multiple non-compliant and unsafe products
     </h1>
-    <p class="govuk-body">
-      Each unsafe product requires a <a href="<%= prism.perform_risk_triage_path %>" class="govuk-link">risk triage</a> or <a href="<%= your_prism_risk_assessments_path %>" class="govuk-link">risk assessment</a>.
-    </p>
+    <% if @prism_user %>
+      <p class="govuk-body">
+        Each unsafe product requires a <a href="<%= prism.perform_risk_triage_path %>" class="govuk-link">risk triage</a> or <a href="<%= your_prism_risk_assessments_path %>" class="govuk-link">risk assessment</a>.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        Each unsafe product requires a risk triage or risk assessment.
+      </p>
+    <% end %>
     <p class="govuk-body">
       You can only upload multiple non-compliant products.
     </p>

--- a/app/views/bulk_products/no_upload_unsafe.html.erb
+++ b/app/views/bulk_products/no_upload_unsafe.html.erb
@@ -9,9 +9,15 @@
       <span class="govuk-caption-l">Upload multiple products</span>
       You can’t upload multiple unsafe products
     </h1>
-    <p class="govuk-body">
-      Each unsafe product requires a <a href="<%= prism.perform_risk_triage_path %>" class="govuk-link">risk triage</a> or <a href="<%= your_prism_risk_assessments_path %>" class="govuk-link">risk assessment</a>.
-    </p>
+    <% if @prism_user %>
+      <p class="govuk-body">
+        Each unsafe product requires a <a href="<%= prism.perform_risk_triage_path %>" class="govuk-link">risk triage</a> or <a href="<%= your_prism_risk_assessments_path %>" class="govuk-link">risk assessment</a>.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        Each unsafe product requires a risk triage or risk assessment.
+      </p>
+    <% end %>
     <p class="govuk-body">
       You can only upload multiple non-compliant products.
     </p>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2120

## Description

Removes the links to PRISM for users that do not have PRISM access when they attempt to bulk upload multiple unsafe products or a mix of unsafe and non-compliant products.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2679.london.cloudapps.digital/
https://psd-pr-2679-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
