### PR TITLE
Upgrade govuk-frontend

### DIFF
--- a/app/assets/stylesheets/_psd_header.scss
+++ b/app/assets/stylesheets/_psd_header.scss
@@ -77,15 +77,6 @@
       @include govuk-focused-text;
       color: $govuk-focus-text-colour;
     }
-
-    // alphagov/govuk_template includes a specific a:link:focus selector
-    // designed to make unvisited links a slightly darker blue when focussed, so
-    // we need to override the text colour for that combination of selectors.
-    @include govuk-compatibility(govuk_template) {
-      &:link:focus {
-        @include govuk-text-colour;
-      }
-    }
   }
 
   .psd-header__link--homepage {

--- a/app/assets/stylesheets/opss/_opss-psd.scss
+++ b/app/assets/stylesheets/opss/_opss-psd.scss
@@ -42,11 +42,11 @@ body > .govuk-width-container > .govuk-main-wrapper > .govuk-back-link {
 }
 
 @function govuk-tint($colour, $percentage) {
-  /// Make a colour lighter by mixing it with white
+  // Make a colour lighter by mixing it with white
   @return mix(govuk-colour("white"), $colour, $percentage);
 }
 
-$opss-retired-bg: govuk-tint(govuk-colour("light-grey"), 50);
+$opss-retired-bg: govuk-tint(govuk-colour("light-grey"), 50%);
 
 .opss-radios__divider--title .govuk-radios__divider {
   width: 100%;

--- a/app/assets/stylesheets/opss/_opss-shared.scss
+++ b/app/assets/stylesheets/opss/_opss-shared.scss
@@ -10,7 +10,7 @@
 }
 
 @function calculaterem($s) {
-  $remsize: $s / 16px;
+  $remsize: calc($s / 16px);
   @return #{$remsize}rem;
 }
 
@@ -1490,7 +1490,7 @@ label.opss-grouping__heading--norm {
     thead tr th:first-child,
     tbody tr th:first-child {
       width: auto;
-      max-width: $govuk-page-width / 2;
+      max-width: calc($govuk-page-width / 2);
     }
   }
 }

--- a/app/assets/stylesheets/opss/_opss-step-by-step-nav.scss
+++ b/app/assets/stylesheets/opss/_opss-step-by-step-nav.scss
@@ -28,12 +28,12 @@ $top-border: solid 2px $govuk-border-colour;
 
 @mixin step-nav-line-position {
   left: 0;
-  margin-left: ($number-circle-size / 2) - ($stroke-width / 2);
+  margin-left: calc(($number-circle-size / 2) - ($stroke-width / 2));
 }
 
 @mixin step-nav-line-position-large {
   left: 0;
-  margin-left: ($number-circle-size-large / 2) - ($stroke-width-large / 2);
+  margin-left: calc(($number-circle-size-large / 2) - ($stroke-width-large / 2));
   border-width: $stroke-width-large;
 }
 
@@ -162,8 +162,8 @@ $top-border: solid 2px $govuk-border-colour;
     z-index: 6;
     bottom: 0;
     left: 0;
-    margin-left: $number-circle-size / 4;
-    width: $number-circle-size / 2;
+    margin-left: calc($number-circle-size / 4);
+    width: calc($number-circle-size / 2);
     height: 0;
     border-bottom: solid $stroke-width $govuk-border-colour;
   }
@@ -176,8 +176,8 @@ $top-border: solid 2px $govuk-border-colour;
   .opss-step-nav--large & {
     @include govuk-media-query($from: tablet) {
       &:before {
-        margin-left: $number-circle-size-large / 4;
-        width: $number-circle-size-large / 2;
+        margin-left: calc($number-circle-size-large / 4);
+        width: calc($number-circle-size-large / 2);
         border-width: $stroke-width-large;
       }
 

--- a/app/javascript/menu.js
+++ b/app/javascript/menu.js
@@ -1,7 +1,5 @@
 'use strict'
 
-import { nodeListForEach } from 'govuk-frontend/govuk/common'
-
 function Menu ($module) {
   this.$module = $module
   this.keys = { esc: 27, up: 38, down: 40, tab: 9 }
@@ -162,7 +160,7 @@ Menu.prototype.convertLinkToButton = function () {
 
 document.addEventListener('DOMContentLoaded', () => {
   const $menus = document.querySelectorAll('[data-module="app-menu"]')
-  nodeListForEach($menus, ($menu) => {
+  $menus.forEach($menu => {
     new Menu($menu).init()
   })
 })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "accessible-autocomplete": "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main",
     "esbuild": "^0.19.5",
-    "govuk-frontend": "4.6.0",
+    "govuk-frontend": "4.7.0",
     "i18n-js": "^4.3.2",
     "postcss": "^8.4.31",
     "sass": "^1.69.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,10 +1157,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.6.0.tgz#662b41f7c468bb5468441218c720f0b31c948cbd"
-  integrity sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==
+govuk-frontend@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
+  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
 
 graceful-fs@^4.1.15:
   version "4.2.10"


### PR DESCRIPTION
## Description

Upgrades `govuk-frontend` from 4.6.0 to 4.7.0 and fixes some deprecations.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2686.london.cloudapps.digital/
https://psd-pr-2686-support.london.cloudapps.digital/

## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
