### PR TITLE
Fix references to develop branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
     branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "develop" ]
+    branches: [ "main" ]
   schedule:
     - cron: '24 16 * * 2'
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   deploy:
@@ -24,7 +24,7 @@ jobs:
     - name: Create GitHub deployment for Staging
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: develop
+        BRANCH: main
       run: |
         source deploy-github-functions.sh
         gh_deploy_create staging
@@ -36,7 +36,7 @@ jobs:
         source deploy-github-functions.sh
 
         # URL where the deployment progress can be tracked. Exported for future steps.
-        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Adevelop+workflow%3ADeploy+Staging")
+        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Amain+workflow%3ADeploy+Staging")
         echo "LOG_URL=$log_url" >> $GITHUB_ENV
 
         gh_deploy_initiate staging $log_url

--- a/support_portal/support_portal.gemspec
+++ b/support_portal/support_portal.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database"
-  spec.metadata["changelog_uri"] = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/develop/support_portal/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/blob/main/support_portal/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "Rakefile", "README.md"]


### PR DESCRIPTION
## Description

Changes references to the old `develop` branch to point to `main`.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
