### PR TITLE
Fix redacted exports

### DIFF
--- a/redex/README.md
+++ b/redex/README.md
@@ -1,5 +1,5 @@
 # Redacted Export
 
-This folder contains a separate CloudFoundary App which is used when producing redacted database export.
+This folder contains a separate CloudFoundry app which is used when producing redacted database export.
 
-The app is pushed with the appropriate settings and schema creation script by a Github Actions workflow. A task is then run to generate a redacted export and upload it to an S3 bucket.
+The app is pushed with the appropriate settings and schema creation script by a GitHub Actions workflow. A task is then run to generate a redacted export and upload it to an S3 bucket.

--- a/redex/apt.yml
+++ b/redex/apt.yml
@@ -2,7 +2,7 @@
 keys:
 - https://www.postgresql.org/media/keys/ACCC4CF8.asc
 repos:
-- deb http://apt.postgresql.org/pub/repos/apt bionic-pgdg main
+- deb http://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main
 packages:
 - awscli
 - postgresql-client-13

--- a/redex/manifest.yml
+++ b/redex/manifest.yml
@@ -2,8 +2,8 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.15
-    - https://github.com/cloudfoundry/binary-buildpack.git#v1.1.3
+    - https://github.com/cloudfoundry/apt-buildpack.git#v0.3.2
+    - https://github.com/cloudfoundry/binary-buildpack.git#v1.1.7
   path: .
   stack: cflinuxfs3
   timeout: 180


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2134

## Description

Fix the redacted exports job to point to the PostgreSQL APT archive since the relevant binaries have been deprecated and removed from the main APT repository.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
