### PR TITLE
Update error message for bulk products uploads

### DIFF
--- a/app/views/bulk_products/triage.html.erb
+++ b/app/views/bulk_products/triage.html.erb
@@ -30,7 +30,7 @@
                 form: form,
                 key: :hazard_description,
                 attributes: { maxlength: 10_000 },
-                label: { text: "Why is the product non-compliant?" }
+                label: { text: "Why are the products non-compliant?" }
               )
             }
           },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -740,8 +740,8 @@ en:
             compliance_and_safety:
               inclusion: Select how you would describe the products in terms of their compliance and safety
             hazard_description:
-              blank: Enter why the product is non-compliant
-              too_long: The reason why the product is non-compliant must be %{count} characters or less
+              blank: Enter why the products are non-compliant
+              too_long: The reason why the products are non-compliant must be %{count} characters or less
         bulk_products_create_case_form:
           attributes:
             name:

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -43,9 +43,9 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
     choose "Products are non-compliant"
     click_button "Continue"
 
-    expect(page).to have_error_summary("Enter why the product is non-compliant")
+    expect(page).to have_error_summary("Enter why the products are non-compliant")
 
-    fill_in "Why is the product non-compliant?", with: "Testing"
+    fill_in "Why are the products non-compliant?", with: "Testing"
     click_button "Continue"
 
     expect(page).to have_content("Create a case for multiple products")
@@ -160,7 +160,7 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
     expect(page).to have_content("How would you describe the products in terms of their compliance and safety?")
 
     choose "Products are non-compliant"
-    fill_in "Why is the product non-compliant?", with: "Testing"
+    fill_in "Why are the products non-compliant?", with: "Testing"
     click_button "Continue"
 
     expect(page).to have_content("Create a case for multiple products")


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2131

## Description

Updates the error message and textbox label for why the products are non-compliant to be plural.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2707.london.cloudapps.digital/
https://psd-pr-2707-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
