### PR TITLE
OSU Support Portal: fix redirection issue

### DIFF
--- a/support_portal/lib/support_portal/engine.rb
+++ b/support_portal/lib/support_portal/engine.rb
@@ -9,5 +9,16 @@ module SupportPortal
     initializer "support_portal.assets.precompile" do |app|
       app.config.assets.precompile << "support_portal_manifest.js"
     end
+
+    if Rails.env.production?
+      initializer "action_controller" do |app|
+        # Override `default_url_options` in the parent app
+        # so that Devise redirects correctly
+        app.config.action_controller.default_url_options = {
+          host: ENV["PSD_HOST_SUPPORT"],
+          protocol: "https"
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2140

## Description

Fixes an issue in `production` Rails enviroinments where visiting the Support Portal root path incorrectly redirects to the sign in path for the parent app.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2709.london.cloudapps.digital/
https://psd-pr-2709-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
