### PR TITLE
OSU Support Portal: fix 2FA redirection

### DIFF
--- a/support_portal/app/controllers/concerns/support_portal/secondary_authentication_concern.rb
+++ b/support_portal/app/controllers/concerns/support_portal/secondary_authentication_concern.rb
@@ -20,7 +20,7 @@ module SupportPortal
         session[:secondary_authentication_user_id] = user_id_for_secondary_authentication
         auth = SecondaryAuthentication.new(user)
         auth.generate_and_send_code(current_operation)
-        redirect_to new_secondary_authentication_path
+        redirect_to main_app.new_secondary_authentication_path
       end
     end
 
@@ -52,7 +52,7 @@ module SupportPortal
         session[:secondary_authentication_user_id] = user_id_for_secondary_authentication
         auth = SecondaryAuthentication.new(user)
         auth.generate_and_send_code(current_operation)
-        redirect_to new_secondary_authentication_path
+        redirect_to main_app.new_secondary_authentication_path
       end
     end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2142

## Description

Fixes the 2FA concern for the OSU Support Portal to correctly redirect to the 2FA page.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2710.london.cloudapps.digital/
https://psd-pr-2710-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
