### PR TITLE
OSU Support Portal: fix 2FA redirection

### DIFF
--- a/support_portal/app/controllers/concerns/support_portal/secondary_authentication_concern.rb
+++ b/support_portal/app/controllers/concerns/support_portal/secondary_authentication_concern.rb
@@ -29,7 +29,7 @@ module SupportPortal
     end
 
     def last_action_was_resending_2fa_code?
-      request.fullpath == resend_secondary_authentication_code_path
+      request.fullpath == main_app.resend_secondary_authentication_code_path
     end
 
     # Use as `before_filter` in application_controller controller


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2142

## Description

Fixes the 2FA concern for the OSU Support Portal to correctly redirect to the 2FA page.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2711.london.cloudapps.digital/
https://psd-pr-2711-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
