### PR TITLE
PRISM: Add evidence file name to generated PDF

### DIFF
--- a/prism/app/services/prism/risk_assessment_pdf_service.rb
+++ b/prism/app/services/prism/risk_assessment_pdf_service.rb
@@ -157,9 +157,9 @@ module Prism
         filename = if file.metadata["safe"] == true
                      file.blob.filename
                    elsif file.metadata["safe"] == false
-                     file.blob.filename (failed virus scan)
+                     "#{file.blob.filename} (failed virus scan)"
                    else
-                     file.blob.filename (pending virus scan)
+                     "#{file.blob.filename} (pending virus scan)"
                    end
         "\n\nAttachment: #{filename}"
       end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2153

## Description

Adds the names of files uploaded as evidence in PRISM in the generated PDF.

Also handles issues with unknown image types in Prawn by retrying without images.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2725.london.cloudapps.digital/
https://psd-pr-2725-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
