### PR TITLE
OSU Support Portal: remove delete account button

### DIFF
--- a/spec/features/support_portal/account_administration_spec.rb
+++ b/spec/features/support_portal/account_administration_spec.rb
@@ -208,7 +208,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_css("div.govuk-notification-banner", text: "The team admin role has been removed.")
   end
 
-  xscenario "Deleting an account" do
+  xit "Deleting an account" do
     visit "/account-admin/#{user2.id}"
 
     expect(page).to have_h1(user2.name)

--- a/spec/features/support_portal/account_administration_spec.rb
+++ b/spec/features/support_portal/account_administration_spec.rb
@@ -208,7 +208,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_css("div.govuk-notification-banner", text: "The team admin role has been removed.")
   end
 
-  scenario "Deleting an account" do
+  xscenario "Deleting an account" do
     visit "/account-admin/#{user2.id}"
 
     expect(page).to have_h1(user2.name)

--- a/support_portal/app/views/support_portal/account_administration/show.html.erb
+++ b/support_portal/app/views/support_portal/account_administration/show.html.erb
@@ -13,6 +13,7 @@
         end
       end
     %>
-    <%= govuk_button_link_to("Delete account", remove_user_account_administration_path(@user, q: params[:q]), warning: true) %>
+    <%# Button removed pending process for account deletion and recovery %>
+    <%# govuk_button_link_to("Delete account", remove_user_account_administration_path(@user, q: params[:q]), warning: true) %>
   </div>
 </div>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2157

## Description

Removes the “delete account” button when viewing user account details.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2726.london.cloudapps.digital/
https://psd-pr-2726-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
