### PR TITLE
Added PSD Support URL to allowed hosts

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -46,7 +46,7 @@ class BusinessesController < ApplicationController
     respond_to do |format|
       if @business.save
         @business.investigations.reindex
-        format.html { redirect_to @business, flash: { success: "The business was updated" }, allow_other_host: true }
+        format.html { redirect_to @business, flash: { success: "The business was updated" } }
         format.json { render :show, status: :ok, location: @business }
       else
         format.html { render :edit }

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -46,7 +46,7 @@ class BusinessesController < ApplicationController
     respond_to do |format|
       if @business.save
         @business.investigations.reindex
-        format.html { redirect_to @business, flash: { success: "The business was updated" } }
+        format.html { redirect_to @business, flash: { success: "The business was updated" }, allow_other_host: true }
         format.json { render :show, status: :ok, location: @business }
       else
         format.html { render :edit }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.hosts << ENV["PSD_HOST_SUPPORT"]
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Sentry has been raising `ActionController::Redirecting::UnsafeRedirectError` - it appears that `config.hosts << ENV["PSD_HOST_SUPPORT"]` was not added to the `production` ENV