### PR TITLE
Fix redirecting from PSD to support portal

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'devise/encryptable/encryptors/pbkdf2'
+require 'devise/custom_failure_app'
 
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
@@ -271,10 +272,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
+  config.warden do |manager|
+    manager.failure_app = Devise::CustomFailureApp
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/lib/devise/custom_failure_app.rb
+++ b/lib/devise/custom_failure_app.rb
@@ -1,0 +1,9 @@
+module Devise
+  class CustomFailureApp < Devise::FailureApp
+    def route(scope)
+      # Return the host-less path rather than the full URL
+      # to allow for different subdomains.
+      :"new_#{scope}_session_path"
+    end
+  end
+end

--- a/support_portal/lib/support_portal/engine.rb
+++ b/support_portal/lib/support_portal/engine.rb
@@ -9,16 +9,5 @@ module SupportPortal
     initializer "support_portal.assets.precompile" do |app|
       app.config.assets.precompile << "support_portal_manifest.js"
     end
-
-    if Rails.env.production?
-      initializer "action_controller" do |app|
-        # Override `default_url_options` in the parent app
-        # so that Devise redirects correctly
-        app.config.action_controller.default_url_options = {
-          host: ENV["PSD_HOST_SUPPORT"],
-          protocol: "https"
-        }
-      end
-    end
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2207

## Description

Fixes an issue where editing records in PSD attempts to redirect to the support portal host.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2739.london.cloudapps.digital/
https://psd-pr-2739-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
