### PR TITLE
Remove CSP - PSD-2225

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,66 +1,66 @@
-govuk_domains = [
-  "*.london.cloudapps.digital", # For preview apps
-  "*.service.gov.uk",
-].freeze
-google_analytics_domains = %w[www.google-analytics.com
-                              ssl.google-analytics.com
-                              stats.g.doubleclick.net
-                              www.googletagmanager.com
-                              www.region1.google-analytics.com
-                              region1.google-analytics.com]
-google_static_domains = %w[www.gstatic.com]
+# govuk_domains = [
+#   "*.london.cloudapps.digital", # For preview apps
+#   "*.service.gov.uk",
+# ].freeze
+# google_analytics_domains = %w[www.google-analytics.com
+#                               ssl.google-analytics.com
+#                               stats.g.doubleclick.net
+#                               www.googletagmanager.com
+#                               www.region1.google-analytics.com
+#                               region1.google-analytics.com]
+# google_static_domains = %w[www.gstatic.com]
 
-Rails.application.configure do
-  config.content_security_policy do |policy|
-    policy.default_src :self
+# Rails.application.configure do
+#   config.content_security_policy do |policy|
+#     policy.default_src :self
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri
-    policy.base_uri :none
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri
+#     policy.base_uri :none
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
-    policy.img_src :self,
-                   *govuk_domains,
-                   *google_analytics_domains, # Tracking pixels
-                   :data # Inline images via CSS
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
+#     policy.img_src :self,
+#                    *govuk_domains,
+#                    *google_analytics_domains, # Tracking pixels
+#                    :data # Inline images via CSS
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
-    # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
-    # they are security risks, if you need them for a legacy app please only apply them at
-    # an app level.
-    policy.script_src :self,
-                      *google_analytics_domains,
-                      *google_static_domains
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+#     # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
+#     # they are security risks, if you need them for a legacy app please only apply them at
+#     # an app level.
+#     policy.script_src :self,
+#                       *google_analytics_domains,
+#                       *google_static_domains
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
-    # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
-    # they are security risks, if you need them for a legacy app please only apply them at
-    # an app level.
-    policy.style_src :self,
-                     *google_static_domains
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
+#     # Note: we purposely don't include `data:`, `unsafe-inline` or `unsafe-eval` because
+#     # they are security risks, if you need them for a legacy app please only apply them at
+#     # an app level.
+#     policy.style_src :self,
+#                      *google_static_domains
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
-    # Note: we purposely don't include data here because it produces a security risk.
-    policy.font_src :self
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+#     # Note: we purposely don't include data here because it produces a security risk.
+#     policy.font_src :self
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
-    policy.connect_src :self,
-                       *govuk_domains,
-                       *google_analytics_domains
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
+#     policy.connect_src :self,
+#                        *govuk_domains,
+#                        *google_analytics_domains
 
-    # Disallow all <object>, <embed>, and <applet> elements
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
-    policy.object_src :none
+#     # Disallow all <object>, <embed>, and <applet> elements
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
+#     policy.object_src :none
 
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
-    policy.frame_src :self, *govuk_domains
+#     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
+#     policy.frame_src :self, *govuk_domains
 
-    policy.report_uri ENV.fetch("SENTRY_CSP_REPORT_URI") if ENV["SENTRY_CSP_REPORT_URI"].present?
-  end
+#     policy.report_uri ENV.fetch("SENTRY_CSP_REPORT_URI") if ENV["SENTRY_CSP_REPORT_URI"].present?
+#   end
 
-  # Generate session nonces for permitted importmap and inline scripts
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w[script-src]
+#   # Generate session nonces for permitted importmap and inline scripts
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#   config.content_security_policy_nonce_directives = %w[script-src]
 
-  # For now, only report to any reports to Sentry in production
-  config.content_security_policy_report_only = true
-end
+#   # For now, only report to any reports to Sentry in production
+#   config.content_security_policy_report_only = true
+# end


### PR DESCRIPTION
The autocomplete JS lib we use is compiled with webpack for inlining CSS, which uses unsafe JS eval

We need to upgrade this lib upstream first before we can enable CSP, as with unsafe-eval enabled the CSP would be fairly useless with respect to security

https://regulatorydelivery.atlassian.net/browse/PSD-2225

- Comments out CSP, allowing the same working config to be enabled at a later date