### PR TITLE
add filter for reported reason on notification search

### DIFF
--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -39,6 +39,10 @@ class SearchParams
   attribute :teams_with_access_my_team, :boolean
   attribute :teams_with_access_others, :boolean
   attribute :teams_with_access_other_id
+  attribute :unsafe, :boolean
+  attribute :unsafe_and_non_compliant, :boolean
+  attribute :non_compliant, :boolean
+  attribute :safe_and_compliant, :boolean
   attribute :hazard_type
   attribute :category
   attribute :page_name

--- a/app/serializers/investigation_serializer.rb
+++ b/app/serializers/investigation_serializer.rb
@@ -1,7 +1,7 @@
 class InvestigationSerializer < ActiveModel::Serializer
   attributes :type, :owner_id, :creator_id, :hazard_type,
              :description, :product_category, :is_closed, :updated_at, :created_at,
-             :pretty_id, :hazard_description, :non_compliant_reason,
+             :pretty_id, :hazard_description, :reported_reason, :non_compliant_reason,
              :complainant_reference, :risk_level, :title, :user_title
 
   attribute :creator_user do

--- a/app/views/notifications/_filters.html.erb
+++ b/app/views/notifications/_filters.html.erb
@@ -32,6 +32,9 @@
     <%= govukDetails(summaryText: "Case hazard type", classes: "opss-details--plain", id: "case-hazard-type") do %>
       <%= render "notifications/case_hazard_type_checkboxes", form: form %>
     <% end %>
+    <%= govukDetails(summaryText: "Reported reason", classes: "opss-details--plain", id: "reported-reason") do %>
+      <%= render "notifications/reported_reason_checkboxes", form: form %>
+    <% end %>
 
     <%= render "investigations/case_change_date_filter", form: form %>
 

--- a/app/views/notifications/_reported_reason_checkboxes.html.erb
+++ b/app/views/notifications/_reported_reason_checkboxes.html.erb
@@ -1,0 +1,26 @@
+<%= govukCheckboxes(
+  key: "",
+  form: form,
+  items: [
+    {
+      key: "non_compliant",
+      text: "Non-compliant",
+      value: true
+    },
+    {
+      key: "unsafe",
+      text: "Unsafe",
+      value: true
+    },
+    {
+      key: "unsafe_and_non_compliant",
+      text: "Unsafe and non-compliant",
+      value: true
+    },
+    {
+      key: "safe_and_compliant",
+      text: "Safe and compliant",
+      value: true
+    }
+  ]
+) %>


### PR DESCRIPTION
## Description

Adds a filter for searching notifications on. the reported reason.
https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?assignee=6411e6661273131f2ae0b4b2&selectedIssue=PSD-2227

## Screen-shots or screen-capture of UI changes

![Screenshot 2023-12-08 at 12-36-53 All Cases – Search - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/9cc1a3ab-b80b-4a39-900c-ac7d1293ee74)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2751.london.cloudapps.digital/
https://psd-pr-2751-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
