### PR TITLE
Re-add “unsure” option for product authenticity

### DIFF
--- a/app/forms/bulk_products_upload_products_file_form.rb
+++ b/app/forms/bulk_products_upload_products_file_form.rb
@@ -142,7 +142,7 @@ private
       next if ary.drop(1).compact.empty?
 
       entry_number, category, subcategory, customs_code, country_of_origin, barcode, name, description, number_of_affected_units, brand, batch_number, counterfeit, markings, marketed_before_brexit, *_extra_cells = ary
-      authenticity = counterfeit.blank? ? nil : { "Yes" => "counterfeit", "No" => "genuine" }[counterfeit]
+      authenticity = counterfeit.blank? ? nil : { "Yes" => "counterfeit", "No" => "genuine", "Unsure" => "unsure" }[counterfeit]
       has_markings = markings.blank? ? nil : ({ "No" => "markings_no", "Unknown" => "markings_unknown" }[markings] || "markings_yes")
       markings = has_markings == "markings_yes" ? markings.split(", ") : nil
       when_placed_on_market = marketed_before_brexit == "Yes" ? "before_2021" : "on_or_after_2021"

--- a/app/forms/product_recall_form.rb
+++ b/app/forms/product_recall_form.rb
@@ -12,7 +12,7 @@ class ProductRecallForm
   attribute :product_identifiers, :string
   attribute :product_description, :string
   attribute :country_of_origin, :string
-  attribute :counterfeit, :boolean
+  attribute :counterfeit, :string
   attribute :risk_type, :string
   attribute :risk_level, :string
   attribute :risk_description, :string

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -75,7 +75,8 @@ module ProductsHelper
   def items_for_authenticity(product_form)
     items = [
       { text: "Yes", value: "counterfeit" },
-      { text: "No", value: "genuine" }
+      { text: "No", value: "genuine" },
+      { text: "Unsure", value: "unsure" }
     ]
 
     return items if product_form.authenticity.blank?

--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -100,7 +100,7 @@ private
   def counterfeit
     return "Unknown" if params["counterfeit"].nil?
 
-    params["counterfeit"] ? "Yes" : "No"
+    { "counterfeit" => "Yes", "genuine" => "No", "unsure" => "Unsure" }[params["counterfeit"]]
   end
 
   def online_marketplace

--- a/app/views/products/recalls/product-details.html.erb
+++ b/app/views/products/recalls/product-details.html.erb
@@ -39,7 +39,7 @@
             label: { text: "Country of origin" },
             value: @product.country_of_origin,
           ) %>
-      <%= form.govuk_radios :counterfeit, legend: "Counterfeit", classes: "govuk-radios--small govuk-radios--inline", legend_classes: "govuk-fieldset__legend", items: [{ text: "Yes", value: "true" }, { text: "No", value: "false" }], value: @product.counterfeit? && !@product.unsure? %>
+      <%= form.govuk_radios :counterfeit, legend: "Counterfeit", classes: "govuk-radios--small govuk-radios--inline", legend_classes: "govuk-fieldset__legend", items: [{ text: "Yes", value: "counterfeit" }, { text: "No", value: "genuine" }, { text: "Unsure", value: "unsure" }], value: @product.authenticity %>
       <%= govukSelect(
             choices: hazard_types,
             key: :risk_type,


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2264

## Description

Adds the ability to choose “unsure” for the authenticity of a product.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2764.london.cloudapps.digital/
https://psd-pr-2764-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
