### PR TITLE
Fix hint text issues

### DIFF
--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -523,7 +523,7 @@ module InvestigationsHelper
 
   def case_rows(investigation, user, team_list_html)
     reference_value = { text: investigation.complainant_reference }
-    reference_value[:secondary_text] = { text: "Optional reference number" } if investigation.complainant_reference
+    reference_value[:secondary_text] = { text: "Optional reference number" } if investigation.complainant_reference.present?
 
     rows = [
       {

--- a/app/views/businesses/index.html.erb
+++ b/app/views/businesses/index.html.erb
@@ -9,7 +9,7 @@
       <%= render 'businesses/secondary_nav' %>
 
       <% if @businesses.any? && policy(Business).export? && ["team_businesses", "your_businesses"].exclude?(@page_name) %>
-        <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-padding-left-3 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+        <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
           <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
             Request this list as a downloadable <br class="opss-br-desktop">
             <%= link_to(generate_business_exports_path(params: business_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <% if policy(Investigation).export? && @investigations.any? %>
-      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-padding-left-3 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
         <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
             Request this list as a downloadable <br class="opss-br-desktop"><%= link_to generate_case_exports_path(params: case_export_params), class: "govuk-link govuk-link--no-visited-state" do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
         </p>

--- a/app/views/notifications/_filters.html.erb
+++ b/app/views/notifications/_filters.html.erb
@@ -44,7 +44,7 @@
     </div>
 
     <% if policy(Investigation).export? && @investigations.any? %>
-      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-padding-left-3 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
         <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
             Request this list as a downloadable <br class="opss-br-desktop"><%= link_to generate_case_exports_path(params: case_export_params), class: "govuk-link govuk-link--no-visited-state" do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
         </p>

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -60,7 +60,7 @@
     </div>
 
     <% if @products.any? && policy(Product).export? %>
-      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-padding-left-3 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
         <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
           Request this list as a downloadable <br class="opss-br-desktop">
           <%= link_to(generate_product_exports_path(params: product_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.

--- a/app/views/products/heading/_team_products.html.erb
+++ b/app/views/products/heading/_team_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Team products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} product records linked to open cases where the #{current_user.team.name} team is the case owner." %>
+      <%= "There are #{count} product records included in open cases where the #{current_user.team.name} team is the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/products/heading/_your_products.html.erb
+++ b/app/views/products/heading/_your_products.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Your products</h1>
     <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "There are #{count} product records linked to open cases where you are the case owner." %>
+      <%= "There are #{count} product records included in open cases where you are the case owner." %>
     </p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/spec/features/products_navigation_spec.rb
+++ b/spec/features/products_navigation_spec.rb
@@ -25,12 +25,12 @@ RSpec.feature "Searching products", :with_stubbed_mailer, type: :feature do
     click_on "Your products"
 
     expect(highlighted_tab).to eq "Your products"
-    expect(page).to have_content "There are 0 product records linked to open cases where you are the case owner."
+    expect(page).to have_content "There are 0 product records included in open cases where you are the case owner."
 
     click_on "Team products"
 
     expect(highlighted_tab).to eq "Team products"
-    expect(page).to have_content "There are 0 product records linked to open cases where the #{team.name} team is the case owner."
+    expect(page).to have_content "There are 0 product records included in open cases where the #{team.name} team is the case owner."
   end
 
   scenario "Browsing products" do


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/PSD-1348, https://regulatorydelivery.atlassian.net/browse/PSD-1083, https://regulatorydelivery.atlassian.net/browse/PSD-1075

## Description

* Don’t show “optional reference number” when the reference number is not present
* Amend hint text on your and team products pages
* Fix mobile alignment for download as XLSX hint block

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2774.london.cloudapps.digital/
https://psd-pr-2774-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
