### PR TITLE
Replace non-form custom elements with components

### DIFF
--- a/app/assets/stylesheets/opss/_opss-shared.scss
+++ b/app/assets/stylesheets/opss/_opss-shared.scss
@@ -629,25 +629,6 @@ div[class$="inset-text"] > ol li:last-child {
   border-width: 1px;
 }
 
-.opss-details--sm {
-  @include govuk-media-query($from: desktop) {
-    summary {
-      @include opss-font-size($s: 16px, $l: 1.25);
-      padding-left: govuk-spacing(3);
-
-      &:before {
-        border-width: 5px 0 7px 9px;
-      }
-    }
-
-    &[open] > summary:before {
-      border-width: 10px 6px 0 !important;
-    }
-
-    margin-bottom: govuk-spacing(2);
-  }
-}
-
 .opss-details--plain {
   & > div {
     padding: govuk-spacing(3) 0;

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -21,7 +21,7 @@ class ProductDecorator < ApplicationDecorator
     description
   end
 
-  def details_list(date_case_closed: nil, classes: "opss-summary-list-mixed opss-summary-list-mixed--narrow-dt")
+  def details_list(date_case_closed: nil)
     timestamp = date_case_closed.to_i if date_case_closed
     psd_ref_key_html = '<abbr title="Product Safety Database">PSD</abbr> <span title="reference">ref</span>'.html_safe
     psd_secondary_text_html = if date_case_closed.present?
@@ -34,26 +34,22 @@ class ProductDecorator < ApplicationDecorator
     psd_ref_value_html = date_case_closed.present? ? h.safe_join([psd_ref(timestamp:, investigation_was_closed: true), "<br>".html_safe]) : psd_ref(timestamp:, investigation_was_closed: false)
 
     rows = [
-      { key: { html: psd_ref_key_html }, value: { html: psd_ref_value_html, secondary_text: { html: psd_secondary_text_html } } },
+      { key: { text: psd_ref_key_html }, value: { text: psd_ref_value_html } },
       { key: { text: "Brand name" }, value: { text: object.brand } },
       { key: { text: "Product name" }, value: { text: object.name } },
       { key: { text: "Category" }, value: { text: category } },
       { key: { text: "Subcategory" }, value: { text: subcategory } },
       { key: { text: "Barcode" }, value: { text: barcode } },
       { key: { text: "Description" }, value: { text: description } },
-      { key: { text: "Webpage" }, value: { html: webpage_html } },
-      { key: { text: "Market date" }, value: { text: when_placed_on_market_value, secondary_text: { text: "Placed on the market" } } },
+      { key: { text: "Webpage" }, value: { text: webpage_html } },
+      { key: { text: "Market date" }, value: { text: when_placed_on_market_value } },
       { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
       { key: { text: "Counterfeit" }, value: counterfeit_row_value },
       { key: { text: "Product marking" }, value: { text: markings } },
       { key: { text: "Other product identifiers" }, value: { text: product_code } },
     ]
 
-    h.govukSummaryList classes:, rows:
-  end
-
-  def summary_list
-    details_list classes: "govuk-!-margin-top-8 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--narrow-actions"
+    h.govuk_summary_list(rows:)
   end
 
   def authenticity

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -93,11 +93,11 @@ class ProductDecorator < ApplicationDecorator
 
   def counterfeit_row_value
     if product.counterfeit?
-      return { html: "<span class='opss-tag opss-tag--risk2 opss-tag--lrg'>Yes</span>".html_safe, secondary_text: { text: counterfeit_explanation } }
+      return { text: "<span class=\"opss-tag opss-tag--risk2 opss-tag--lrg\">Yes</span> - #{counterfeit_explanation}".html_safe }
     end
 
     if product.genuine?
-      return { text: "No", secondary_text: { text: counterfeit_explanation } }
+      return { text: "No - #{counterfeit_explanation}" }
     end
 
     { text: I18n.t(object.authenticity || :missing, scope: Product.model_name.i18n_key) }

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -25,16 +25,16 @@ class ProductDecorator < ApplicationDecorator
     timestamp = date_case_closed.to_i if date_case_closed
     psd_ref_key_html = '<abbr title="Product Safety Database">PSD</abbr> <span title="reference">ref</span>'.html_safe
     psd_secondary_text_html = if date_case_closed.present?
-                                "<span class=\"govuk-visually-hidden\"> - </span>The <abbr>PSD</abbr> reference number for this version of the product record - as recorded when the notification was closed: #{date_case_closed.to_formatted_s(:govuk)}."
+                                " - The <abbr>PSD</abbr> reference number for this version of the product record - as recorded when the notification was closed: #{date_case_closed.to_formatted_s(:govuk)}."
                               else
-                                "<span class=\"govuk-visually-hidden\"> - </span>The <abbr>PSD</abbr> reference number for this product record"
+                                " - The <abbr>PSD</abbr> reference number for this product record"
                               end.html_safe
     webpage_html = "<span class='govuk-!-font-size-16'>#{webpage}</span>".html_safe
     when_placed_on_market_value = when_placed_on_market == "unknown_date" ? nil : when_placed_on_market
-    psd_ref_value_html = date_case_closed.present? ? h.safe_join([psd_ref(timestamp:, investigation_was_closed: true), "<br>".html_safe]) : psd_ref(timestamp:, investigation_was_closed: false)
+    psd_ref_value_html = date_case_closed.present? ? psd_ref(timestamp:, investigation_was_closed: true) : psd_ref(timestamp:, investigation_was_closed: false)
 
     rows = [
-      { key: { text: psd_ref_key_html }, value: { text: psd_ref_value_html } },
+      { key: { text: psd_ref_key_html }, value: { text: "#{psd_ref_value_html}#{psd_secondary_text_html}" } },
       { key: { text: "Brand name" }, value: { text: object.brand } },
       { key: { text: "Product name" }, value: { text: object.name } },
       { key: { text: "Category" }, value: { text: category } },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,7 +56,7 @@ module ApplicationHelper
       [
         existing_uploaded_file_id,
         render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file }),
-        govukDetails(summaryText: "Replace this file", html: file_upload_field)
+        govuk_details(summary_text: "Replace this file", text: file_upload_field)
       ]
     )
   end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -545,9 +545,6 @@ module InvestigationsHelper
   end
 
   def case_rows(investigation, user, team_list_html)
-    reference_value = { text: investigation.complainant_reference }
-    reference_value[:secondary_text] = { text: "Optional reference number" } if investigation.complainant_reference.present?
-
     rows = [
       {
         key: { text: "Notification name" },
@@ -556,59 +553,43 @@ module InvestigationsHelper
       },
       {
         key: { text: "Notification number" },
-        value: {
-          text: investigation.pretty_id,
-        },
-        actions: {}
+        value: { text: investigation.pretty_id }
       },
       {
         key: { text: "Reference" },
-        value: reference_value,
+        value: { text: investigation.complainant_reference },
         actions: reference_actions(investigation, user)
       },
       {
         key: { text: "Summary" },
-        value: {
-          html: summary_html(investigation)
-        },
+        value: { text: summary_html(investigation) },
         actions: summary_actions(investigation, user)
       },
       {
         key: { text: "Status" },
         value: status_value(investigation),
         actions: status_actions(investigation, user),
-        classes: "opss-summary-list__row--split"
       },
       {
         key: { text: "Last updated" },
-        value: {
-          text: time_ago_or_date(@investigation.updated_at)
-        }
+        value: { text: time_ago_or_date(@investigation.updated_at) }
       },
       {
         key: { text: "Created" },
-        value: {
-          text: time_ago_or_date(@investigation.created_at)
-        }
+        value: { text: time_ago_or_date(@investigation.created_at) }
       },
       {
         key: { text: "Created by" },
-        value: {
-          text: investigation.created_by
-        }
+        value: { text: investigation.created_by }
       },
       {
         key: { text: "Notification owner" },
-        value: {
-          text: investigation_owner(investigation)
-        },
+        value: { text: investigation_owner(investigation) },
         actions: case_owner_actions(investigation, user)
       },
       {
         key: { text: "Teams added" },
-        value: {
-          html: team_list_html
-        },
+        value: { text: team_list_html },
         actions: case_teams_actions(investigation)
       }
     ]
@@ -616,9 +597,7 @@ module InvestigationsHelper
     if investigation.is_private?
       rows << {
         key: { text: "Notification restriction" },
-        value: {
-          html: case_restriction_value(investigation)
-        },
+        value: { text: case_restriction_value(investigation) },
         actions: case_restriction_actions(investigation, user)
       }
     end
@@ -626,13 +605,11 @@ module InvestigationsHelper
     rows << [
       {
         key: { text: "Notification risk level" },
-        value: {
-          html: case_risk_level_value(investigation)
-        },
+        value: { text: case_risk_level_value(investigation) },
         actions: risk_level_actions(investigation, user)
       },
       {
-        key: { html: 'Risk <span class="govuk-visually-hidden">level</span> validated'.html_safe },
+        key: { text: 'Risk <span class="govuk-visually-hidden">level</span> validated'.html_safe },
         value: { text: risk_validated_value(investigation) },
         actions: risk_validation_actions(investigation, user)
       }
@@ -642,21 +619,14 @@ module InvestigationsHelper
     if investigation.coronavirus_related
       rows << {
         key: { text: "COVID-19" },
-        value: {
-          html: '<span class="opss-tag opss-tag--covid opss-tag--lrg">COVID-19 related</span>'.html_safe
-        },
-        actions: {
-          items: []
-        }
+        value: { text: '<span class="opss-tag opss-tag--covid opss-tag--lrg">COVID-19 related</span>'.html_safe }
       }
     end
 
     if policy(investigation).view_notifying_country?(user:)
       rows << {
         key: { text: "Notifying country" },
-        value: {
-          text: country_from_code(investigation.notifying_country, Country.notifying_countries)
-        },
+        value: { text: country_from_code(investigation.notifying_country, Country.notifying_countries) },
         actions: notifying_country_actions(investigation, user)
       }
     end
@@ -664,9 +634,7 @@ module InvestigationsHelper
     if policy(investigation).view_overseas_regulator?(user:)
       rows << {
         key: { text: "Overseas regulator" },
-        value: {
-          text: overseas_regulator_value(investigation)
-        },
+        value: { text: overseas_regulator_value(investigation) },
         actions: overseas_regulator_actions(investigation, user)
       }
     end
@@ -728,126 +696,126 @@ private
   end
 
   def case_name_actions(investigation, user)
-    return {} unless policy(investigation).update?(user:)
+    return [] unless policy(investigation).update?(user:)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_case_names_path(investigation.pretty_id),
         text: "Edit",
-        visuallyHiddenText: " the notification name"
-      ]
-    }
+        visually_hidden_text: "the notification name"
+      }
+    ]
   end
 
   def reference_actions(investigation, user)
-    return {} unless policy(investigation).update?(user:)
+    return [] unless policy(investigation).update?(user:)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_reference_numbers_path(investigation.pretty_id),
         text: "Edit",
-        visuallyHiddenText: " the reference number"
-      ]
-    }
+        visually_hidden_text: "the reference number"
+      }
+    ]
   end
 
   def summary_actions(investigation, user)
-    return {} unless policy(investigation).update?(user:)
+    return [] unless policy(investigation).update?(user:)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_summary_path(investigation.pretty_id),
         text: "Edit",
-        visuallyHiddenText: " the summary"
-      ]
-    }
+        visually_hidden_text: "the summary"
+      }
+    ]
   end
 
   def status_actions(investigation, user)
-    return {} unless policy(investigation).change_owner_or_status?(user:)
+    return [] unless policy(investigation).change_owner_or_status?(user:)
 
     status_path = investigation.is_closed ? reopen_investigation_status_path(investigation) : close_investigation_status_path(investigation)
     status_link_text = investigation.is_closed? ? "Re-open" : "Close"
 
-    {
-      items: [
+    [
+      {
         href: status_path,
         text: status_link_text,
-        visuallyHiddenText: " this notification"
-      ]
-    }
+        visually_hidden_text: "this notification"
+      }
+    ]
   end
 
   def notifying_country_actions(investigation, user)
-    return {} unless policy(investigation).change_notifying_country?(user:)
+    return [] unless policy(investigation).change_notifying_country?(user:)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_notifying_country_path(investigation),
-        text: "Change",
-        visuallyHiddenText: "notifying country"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "notifying country"
+      }
+    ]
   end
 
   def overseas_regulator_actions(investigation, user)
-    return {} unless policy(investigation).change_overseas_regulator?(user:)
+    return [] unless policy(investigation).change_overseas_regulator?(user:)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_overseas_regulator_path(investigation),
-        text: "Change",
-        visuallyHiddenText: "overseas regulator"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "overseas regulator"
+      }
+    ]
   end
 
   def case_owner_actions(investigation, user)
-    return {} unless policy(investigation).change_owner_or_status?(user:)
+    return [] unless policy(investigation).change_owner_or_status?(user:)
 
-    {
-      items: [
+    [
+      {
         href: new_investigation_ownership_path(investigation),
-        text: "Change",
-        visuallyHiddenText: " the notification owner"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "the notification owner"
+      }
+    ]
   end
 
   def case_teams_actions(investigation)
-    return {} unless policy(investigation).manage_collaborators?
+    return [] unless policy(investigation).manage_collaborators?
 
-    {
-      items: [
+    [
+      {
         href: investigation_collaborators_path(investigation),
-        text: "Change",
-        visuallyHiddenText: " the teams added"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "the teams added"
+      }
+    ]
   end
 
   def case_restriction_actions(investigation, user)
-    return {} unless policy(investigation).can_unrestrict?(user:)
+    return [] unless policy(investigation).can_unrestrict?(user:)
 
-    {
-      items: [
+    [
+      {
         href: investigation_visibility_path(investigation),
-        text: "Change",
-        visuallyHiddenText: " the notification restriction"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "the notification restriction"
+      }
+    ]
   end
 
   def risk_level_actions(investigation, user)
-    return {} unless policy(investigation).update?(user:)
+    return [] unless policy(investigation).update?(user:)
 
-    {
-      items: [
+    [
+      {
         href: investigation_risk_level_path(investigation),
-        text: "Change",
-        visuallyHiddenText: " the risk level"
-      ]
-    }
+        text: "Edit",
+        visually_hidden_text: "the risk level"
+      }
+    ]
   end
 
   def batch_number_actions(investigation_product, user)
@@ -899,14 +867,14 @@ private
   end
 
   def risk_validation_actions(investigation, user)
-    return {} unless policy(Investigation).risk_level_validation? && investigation.teams_with_access.include?(user.team)
+    return [] unless policy(Investigation).risk_level_validation? && investigation.teams_with_access.include?(user.team)
 
-    {
-      items: [
+    [
+      {
         href: edit_investigation_risk_validations_path(investigation.pretty_id),
         text: risk_validated_link_text(investigation)
-      ]
-    }
+      }
+    ]
   end
 
   def status_value(investigation)

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -788,7 +788,7 @@ private
     [
       {
         href: investigation_collaborators_path(investigation),
-        text: "Edit",
+        text: "Change",
         visually_hidden_text: "the teams added"
       }
     ]
@@ -800,7 +800,7 @@ private
     [
       {
         href: investigation_visibility_path(investigation),
-        text: "Edit",
+        text: "Change",
         visually_hidden_text: "the notification restriction"
       }
     ]
@@ -812,7 +812,7 @@ private
     [
       {
         href: investigation_risk_level_path(investigation),
-        text: "Edit",
+        text: "Change",
         visually_hidden_text: "the risk level"
       }
     ]

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -880,8 +880,7 @@ private
   def status_value(investigation)
     if investigation.is_closed?
       {
-        html: '<span class="opss-tag opss-tag--risk3">Notification closed</span>'.html_safe,
-        secondary_text: { text: investigation.date_closed.to_formatted_s(:govuk) }
+        text: "<span class=\"opss-tag opss-tag--risk3\">Notification closed</span> (#{investigation.date_closed.to_formatted_s(:govuk)})".html_safe
       }
     else
       {

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -752,7 +752,7 @@ private
     [
       {
         href: edit_investigation_notifying_country_path(investigation),
-        text: "Edit",
+        text: "Change",
         visually_hidden_text: "notifying country"
       }
     ]
@@ -764,7 +764,7 @@ private
     [
       {
         href: edit_investigation_overseas_regulator_path(investigation),
-        text: "Edit",
+        text: "Change",
         visually_hidden_text: "overseas regulator"
       }
     ]

--- a/app/views/application/_incomplete_bulk_products_upload_notification.html.erb
+++ b/app/views/application/_incomplete_bulk_products_upload_notification.html.erb
@@ -1,19 +1,7 @@
 <% if @incomplete_bulk_products_upload.present? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Important
-          </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-          <p class="govuk-notification-banner__heading">
-            We have noticed that your recent product upload is not complete, and the products have yet to be allocated to their respective notification.
-            <a class="govuk-notification-banner__link" href="<%= create_case_bulk_upload_products_path(@incomplete_bulk_products_upload) %>">Resume the upload process</a>.
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%=
+    govuk_notification_banner(title_text: "Important") do |banner|
+      banner.with_heading(text: "We have noticed that your recent product upload is not complete, and the products have yet to be allocated to their respective notification.", link_text: "Resume the upload process", link_href: create_case_bulk_upload_products_path(@incomplete_bulk_products_upload))
+    end
+  %>
 <% end %>

--- a/app/views/application/_related_attachment_fields.html.erb
+++ b/app/views/application/_related_attachment_fields.html.erb
@@ -31,7 +31,7 @@
           <%= link_to "#{file_blob.filename} (opens in new tab)", file_blob, target: "_blank", rel: "noreferrer noopener" %>
         </p>
 
-        <%= govukDetails(summaryText: "Replace this file", html: file_upload_field) %>
+        <%= govuk_details(summary_text: "Replace this file", text: file_upload_field) %>
       <% else %>
         <%= file_upload_field %>
       <% end %>

--- a/app/views/application/_upload_file_component.html.erb
+++ b/app/views/application/_upload_file_component.html.erb
@@ -3,7 +3,7 @@
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= legend %></legend>
     <%= render partial: "active_storage/blobs/blob", locals: { blob: old_file } %>
 
-    <%= govukDetails(summaryText: "Replace this file") do %>
+    <%= govuk_details(summary_text: "Replace this file") do %>
       <%= form.govuk_file_upload field_name, label: "Select file", label_classes: "govuk-label--s" %>
     <% end %>
   </fieldset>

--- a/app/views/bulk_products/add_business_details.html.erb
+++ b/app/views/bulk_products/add_business_details.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Provide the business details - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_add_business_details_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: create_business_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: create_business_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_add_business_details_form, url: add_business_details_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/check_corrective_actions.html.erb
+++ b/app/views/bulk_products/check_corrective_actions.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Check products selected for corrective actions - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_upload.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: choose_products_for_corrective_actions_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: choose_products_for_corrective_actions_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_upload, url: check_corrective_actions_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/choose_products_for_corrective_actions.html.erb
+++ b/app/views/bulk_products/choose_products_for_corrective_actions.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Choose products that require the same corrective action - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_choose_products_for_corrective_actions_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: review_products_bulk_upload_products_path(product_ids: @products.ids)) %>
+  <%= govuk_back_link(href: review_products_bulk_upload_products_path(product_ids: @products.ids)) %>
 <% end %>
 <%= form_with model: @bulk_products_choose_products_for_corrective_actions_form, url: choose_products_for_corrective_actions_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true, data: { controller: "checkbox-select-all" } do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/create_business.html.erb
+++ b/app/views/bulk_products/create_business.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Add the business to the notification - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_add_business_type_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: create_case_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: create_case_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_add_business_type_form, url: create_business_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/create_case.html.erb
+++ b/app/views/bulk_products/create_case.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Create a notification for multiple products - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_create_case_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: triage_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: triage_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_create_case_form, url: create_case_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/create_corrective_action.html.erb
+++ b/app/views/bulk_products/create_corrective_action.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Record corrective action - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_create_corrective_action_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: choose_products_for_corrective_actions_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: choose_products_for_corrective_actions_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_create_corrective_action_form, url: create_corrective_action_bulk_upload_products_path(product_ids: params[:product_ids]), builder: ApplicationFormBuilder, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/no_upload_mixed.html.erb
+++ b/app/views/bulk_products/no_upload_mixed.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "You can’t upload a mix of multiple non-compliant and unsafe products - Upload multiple products" %>
 <% page_title page_heading %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: triage_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: triage_bulk_upload_products_path) %>
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/bulk_products/no_upload_unsafe.html.erb
+++ b/app/views/bulk_products/no_upload_unsafe.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "You can’t upload multiple unsafe products - Upload multiple products" %>
 <% page_title page_heading %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: triage_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: triage_bulk_upload_products_path) %>
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/bulk_products/resolve_duplicate_products.html.erb
+++ b/app/views/bulk_products/resolve_duplicate_products.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "We found duplicate product records - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_resolve_duplicate_products_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: upload_products_file_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: upload_products_file_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_resolve_duplicate_products_form, url: resolve_duplicate_products_bulk_upload_products_path, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/review_products.html.erb
+++ b/app/views/bulk_products/review_products.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Review details of the products you are uploading - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_review_products_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: resolve_duplicate_products_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: resolve_duplicate_products_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_review_products_form, url: review_products_bulk_upload_products_path(barcodes: params[:barcodes], product_ids: params[:product_ids]), html: { novalidate: true }, method: :put, local: true, multipart: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/bulk_products/upload_products_file.html.erb
+++ b/app/views/bulk_products/upload_products_file.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Upload products by Excel - Upload multiple products" %>
 <% page_title page_heading, errors: @bulk_products_upload_products_file_form.errors.any? %>
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: add_business_details_bulk_upload_products_path) %>
+  <%= govuk_back_link(href: add_business_details_bulk_upload_products_path) %>
 <% end %>
 <%= form_with model: @bulk_products_upload_products_file_form, url: upload_products_file_bulk_upload_products_path, builder: ApplicationFormBuilder, html: { novalidate: true }, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">

--- a/app/views/businesses/heading/_all_businesses.html.erb
+++ b/app/views/businesses/heading/_all_businesses.html.erb
@@ -9,13 +9,9 @@
         Search all business records in the Product Safety Database (<%= psd_abbr title: false %>).
       </p>
 
-      <%= govukDetails(summaryText: "Help with the businesses search", classes: "opss-details--sm") do %>
-        <p class="govuk-body-s govuk-!-margin-bottom-1">
+      <%= govuk_details(summary_text: "Help with the businesses search") do %>
+        <p class="govuk-body">
           <span id="search-hint">You can search for one or more businesses using the keywords that describe them or search for a specific business by using its company number.</span> You can also sort the ordering of the search results.
-        </p>
-
-        <p class="govuk-body-s govuk-visually-hidden">
-          Search results appear within the following <code>form</code> and within the <code>role = region</code>.
         </p>
       <% end %>
   </div>

--- a/app/views/businesses/show.html.erb
+++ b/app/views/businesses/show.html.erb
@@ -6,27 +6,19 @@
   </div>
 </div>
 
-<%= govukTabs(
-  items: [
-    {
-      id: "full-detail",
-      label: "Full detail",
-      panel: { html: render("businesses/tabs/details") }
-    },
-    {
-      id: "locations",
-      label: "Locations (#{@business.locations.count})",
-      panel: { html: render("businesses/tabs/locations") }
-    },
-    {
-      id: "contacts",
-      label: "Contacts (#{@business.contacts.count})",
-      panel: { html: render("businesses/tabs/contacts") }
-    },
-    {
-      id: "cases",
-      label: "Notifications",
-      panel: { html: render("businesses/tabs/cases") }
-    }
-  ]
-) %>
+<%=
+  govuk_tabs(title: "Business details") do |tabs|
+    tabs.with_tab(label: "Full detail") do
+      render("businesses/tabs/details")
+    end
+    tabs.with_tab(label: "Locations (#{@business.locations.count})") do
+      render("businesses/tabs/locations")
+    end
+    tabs.with_tab(label: "Contacts (#{@business.contacts.count})") do
+      render("businesses/tabs/contacts")
+    end
+    tabs.with_tab(label: "Notifications") do
+      render("businesses/tabs/cases")
+    end
+  end
+%>

--- a/app/views/create_a_case_page/index.html.erb
+++ b/app/views/create_a_case_page/index.html.erb
@@ -18,15 +18,15 @@
               Find a product and create the notification from there.
             </p>
 
-            <%= govukDetails(summaryText: "How to create a notification") do %>
+            <%= govuk_details(summary_text: "How to create a notification") do %>
               <p class="govuk-body">
                 A notification and a product record are separate. Notifications record information about supply chains, evidence, and corrective actions. A product record describes the product and is included <em>within</em>&nbsp; a notification.
               </p>
 
               <ol class="govuk-list govuk-list--number govuk-list--spaced govuk-!-margin-left-6">
-                <li>In the products area search for your product</li>
-                <li>Select a product record to view the product record page</li>
-                <li>Select the '<span class="govuk-!-font-weight-bold">Create a product notification</span>' option</li>
+                <li>In the products area search for your product.</li>
+                <li>Select a product record to view the product record page.</li>
+                <li>Select the '<span class="govuk-!-font-weight-bold">Create a product notification</span>' option.</li>
               </ol>
 
               <p class="govuk-body">
@@ -38,17 +38,14 @@
               </p>
 
               <p class="govuk-body">
-                For more information, visit <%= link_to help_about_path, class: "govuk-link govuk-link--no-visited-state", rel: "noreferrer noopener", target: "_blank" do %>how to use the <%= psd_abbr %> <span class="govuk-visually-hidden">online service</span> (opens in a new tab)<% end %>
+                For more information, visit <%= link_to help_about_path, class: "govuk-link", rel: "noreferrer noopener", target: "_blank" do %>how to use the <%= psd_abbr %> (opens in a new tab)<% end %>.
               </p>
             <% end %>
           <% end %>
 
-          <%= govukInsetText({
-            html: inset_html,
-            classes: "govuk-!-margin-bottom-7"
-          }) %>
+          <%= govuk_inset_text(text: inset_html) %>
 
-          <%= link_to "Go to the products search page", products_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-24" %>
+          <%= link_to "Go to the products search page", products_path, class: "govuk-link govuk-!-font-size-24" %>
         </div>
       </div>
     </div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -2,7 +2,7 @@
 <%= page_title title %>
 
 <% content_for(:after_header) do %>
-  <%= govukBackLink(text: "Back to notification list", href: investigations_path) %>
+  <%= govuk_back_link(text: "Back to notification list", href: investigations_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/investigation_products/ucr_numbers/edit.html.erb
+++ b/app/views/investigation_products/ucr_numbers/edit.html.erb
@@ -1,10 +1,8 @@
 <% page_heading = "Edit the Unique Consignment Reference (UCR) numbers" %>
 
 <% page_title page_heading, errors: @investigation_product.errors.any? %>
-<%= govukBackLink(
-  text: "Back",
-  href: investigation_path(@investigation_product.investigation)
-) %>
+
+<%= govuk_back_link(href: investigation_path(@investigation_product.investigation)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -9,12 +9,12 @@
   <% if non_search_cases_page_names.exclude? @page_name %>
     <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
 
-    <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
+    <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
 
     <%= render "investigations/case_status_radios", form: form %>
     <%= render "investigations/coronavirus_and_risk_level_radios", form: form %>
 
-    <%= govukDetails(summaryText: "More options", classes: "opss-details--plain", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
+    <%= govuk_details(summary_text: "More options", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
       <%= render "investigations/case_owner_radios", form: form %>
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -14,7 +14,7 @@
     <%= render "investigations/case_status_radios", form: form %>
     <%= render "investigations/coronavirus_and_risk_level_radios", form: form %>
 
-    <%= govuk_details(summary_text: "More options", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
+    <%= govuk_details(summary_text: "More options", classes: "opss-details--plain", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
       <%= render "investigations/case_owner_radios", form: form %>
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>

--- a/app/views/investigations/cannot_close.html.erb
+++ b/app/views/investigations/cannot_close.html.erb
@@ -16,9 +16,7 @@
             </p>
           <% end %>
 
-          <%= govukInsetText({
-            html: inset_html,
-          }) %>
+          <%= govuk_inset_text(text: inset_html) %>
 
           <p class="govuk-body">
             Either add an active product record to the notification or delete the notification.

--- a/app/views/investigations/cannot_delete.html.erb
+++ b/app/views/investigations/cannot_delete.html.erb
@@ -17,7 +17,7 @@
             </p>
           <% end %>
 
-          <%= govukInsetText(html: inset_html,) %>
+          <%= govuk_inset_text(text: inset_html) %>
 
           <div class="govuk-!-margin-top-8">
             <p class="govuk-body">

--- a/app/views/investigations/created.html.erb
+++ b/app/views/investigations/created.html.erb
@@ -1,27 +1,19 @@
 <% page_heading = "Notification created" %>
-
 <%= page_title page_heading %>
-
-<% banner_content = capture do %>
-  <h1 class="govuk-heading-l"><%= page_heading %></h1>
-  <p class="govuk-body"><%= "Notification ID: #{@investigation&.pretty_id}" %></p>
-  <p class="govuk-body">
-    A confirmation email has been sent to <strong><%= current_user.email %></strong>.
-  </p>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= govukNotificationBanner html: banner_content %>
+    <h1 class="govuk-heading-l"><%= page_heading %></h1>
+    <p class="govuk-body"><%= "Notification ID: #{@investigation&.pretty_id}" %></p>
     <p class="govuk-body">
-      <% # TODO: this should be the case owner, shown as 'you' if the case owner
-         # is the case creator. %>
-      You are now the notification owner for
-      <strong><%= @investigation.title %></strong>.
+      A confirmation email has been sent to <strong><%= current_user.email %></strong>.
     </p>
-
+    <p class="govuk-body">
+      <% # TODO: this should be the notification owner, shown as 'you' if the notification owner
+         # is the notification creator. %>
+      You are now the notification owner for <strong><%= @investigation.title %></strong>.
+    </p>
     <p class="govuk-body">If you need to, you can add more information later.</p>
-
     <%= govuk_button_link_to("View notification", investigation_path(@investigation)) %>
   </div>
 </div>

--- a/app/views/investigations/heading/_all_cases.html.erb
+++ b/app/views/investigations/heading/_all_cases.html.erb
@@ -8,19 +8,15 @@
     <p class="govuk-body opss-secondary-text">
       Search all notifications in the Product Safety Database (<%= psd_abbr title: false %>).
     </p>
-    <%= govukDetails(summaryText: "Help with the notifications search", classes: "opss-details--sm") do %>
-      <p class="govuk-body-s govuk-!-margin-bottom-4">
-        <span id="search-hint">You can search for a notification using a notification number or the keywords that describe it and by filtering the results.</span> You can also filter all notification records without a notification number or a keyword search.
+    <%= govuk_details(summary_text: "Help with the notifications search") do %>
+      <p class="govuk-body">
+          <span id="search-hint">You can search for a notification using a notification number or the keywords that describe it and by filtering the results.</span> You can also filter all notification records without a notification number or a keyword search.
       </p>
       <% if policy(Investigation).export? && @investigations.any? %>
-        <p class="govuk-body-s govuk-!-margin-bottom-1">
-          When viewing a list of search results you can <%= link_to  "request the list", generate_case_exports_path(params: case_export_params), class: "govuk-link govuk-link--no-visited-state" %> as a downloadable <abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet) file.
+        <p class="govuk-body">
+            When viewing a list of search results you can <%= link_to  "request the list", generate_case_exports_path(params: case_export_params), class: "govuk-link govuk-link--no-visited-state" %> as a downloadable <abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet) file.
         </p>
       <% end %>
-
-      <p class="govuk-body-s govuk-visually-hidden">
-        Search results appear within the following <code>form</code> and within the <code>role = region</code>.
-      </p>
     <% end %>
   </div>
 

--- a/app/views/investigations/products/confirm.html.erb
+++ b/app/views/investigations/products/confirm.html.erb
@@ -40,9 +40,9 @@
                   ]
                 ) %>
                 <% if @product.virus_free_images.any? %>
-                  <%= govukDetails(
-                    summaryText: "Product image",
-                    html: capture {
+                  <%= govuk_details(
+                    summary_text: "Product image",
+                    text: capture {
                       render "image_uploads/image_preview",
                         image: @product.virus_free_images.first,
                         dimensions: [300, 500],

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -11,18 +11,15 @@
       </div>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <%= govukDetails(
-        classes: "govuk-!-margin-bottom-9 opss-details--sm",
-        summaryText: "Help with adding a product to the notification"
-      ) do %>
-        <p class="govuk-body-s">
+      <%= govuk_details(summary_text: "Help with adding a product to the notification") do %>
+        <p class="govuk-body">
           Use the Products area to find a product and its product record reference number. For example, psd-301.
         </p>
-        <p class="govuk-body-s">
+        <p class="govuk-body">
           Search for the product in the <%= link_to "Products area (opens in a new tab)", your_products_path, class: "govuk-link govuk-link--no-visited-state", rel: "noreferrer noopener", target: "_blank" %>
         </p>
-        <p class="govuk-body-s">
-        Using an existing <%= psd_abbr title: false %> product record to add to your notification avoids the need to create a new one and highlights other notifications investigating the same product. After checking that the product does not already exist within the <%= psd_abbr title: false %> product records, you can create a new product record (using the links provided in the Products area pages) and then use its <%= psd_abbr title: false %> reference number to add it to your notification.
+        <p class="govuk-body">
+          Using an existing <%= psd_abbr title: false %> product record to add to your notification avoids the need to create a new one and highlights other notifications investigating the same product. After checking that the product does not already exist within the <%= psd_abbr title: false %> product records, you can create a new product record (using the links provided in the Products area pages) and then use its <%= psd_abbr title: false %> reference number to add it to your notification.
         </p>
       <% end %>
       <%= form.govuk_input(:reference, prefix: { text: "psd-" }, classes: "govuk-input--width-5", spellcheck: false, describedBy: "add-product-hint") %>

--- a/app/views/investigations/record_phone_calls/_form.html.erb
+++ b/app/views/investigations/record_phone_calls/_form.html.erb
@@ -41,7 +41,7 @@
               <%= link_to "#{form.object.transcript.filename} (opens in new tab)", url_for(form.object.transcript), target: "_blank", rel: "noreferrer noopener" %>
             </p>
 
-            <%= govukDetails(summaryText: "Replace this file", html: file_upload_field) %>
+            <%= govuk_details(summary_text: "Replace this file", text: file_upload_field) %>
           <% else %>
             <%= file_upload_field %>
           <% end %>

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -4,8 +4,8 @@
 <% hint_html = capture do %>
   <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this notification.</div>
 
-  <%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
-    <p class="govuk-body-s">
+  <%= govuk_details(summary_text: "Help with adding a number") do %>
+    <p class="govuk-body">
       This might be a number already created in a different internal system for your notification, or a number you intend to use globally across different systems to reference your notification.
       The reference number will be searchable in the <%= psd_abbr %> notification search page. (You can add or edit this number later).
     </p>

--- a/app/views/investigations/tabs/_overview.html.erb
+++ b/app/views/investigations/tabs/_overview.html.erb
@@ -1,7 +1,6 @@
 <%= render('investigations/actions', investigation: @investigation) unless @investigation.is_closed? %>
 <%= render('investigations/actions', investigation: @investigation) if @investigation.is_closed? && current_user.is_superuser?  %>
 
-
 <% team_list_html = capture do %>
   <% if @investigation.teams_with_access.length > 1 %>
     <ul class="govuk-list govuk-list--bullet">
@@ -16,9 +15,8 @@
   <% end %>
 <% end %>
 
-<%= govukSummaryList(
-      classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--narrow-actions",
-      rows: case_rows(@investigation, current_user, team_list_html)
+<%= govuk_summary_list(
+    rows: case_rows(@investigation, current_user, team_list_html)
 ) %>
 
 <h3 id="safety" class="govuk-heading-m govuk-!-margin-top-6 opss-float-left">

--- a/app/views/investigations/tabs/_products.html.erb
+++ b/app/views/investigations/tabs/_products.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% else %>
   <h2 class="govuk-heading-m govuk-!-margin-top-1 govuk-visually-hidden">The products included in this notification</h2>
-  <%= govukInsetText(text: "This notification has reported any included products as safe and compliant.") if @investigation.safe_and_compliant? %>
+  <%= govuk_inset_text(text: "This notification has reported any included products as safe and compliant.") if @investigation.safe_and_compliant? %>
 
   <% @investigation.investigation_products.decorate.reverse.each.with_index(1) do |investigation_product, index| %>
     <% product = investigation_product.investigation_closed_at ? investigation_product.product.paper_trail.version_at(investigation_product.investigation_closed_at).decorate : investigation_product.product %>
@@ -42,26 +42,19 @@
           </div>
         </div>
       <% end %>
-      <%= govukTabs(
-        title: "Information related to this PSD product record",
-        items: [
-          {
-            id: "details-#{index}",
-            label: "Details",
-            panel: { html: render("products/case_product_info_tabs/details") }
-          },
-          {
-            id: "images-#{index}",
-            label: "Images (#{@product.virus_free_images.count})",
-            panel: { html: render("products/case_product_info_tabs/images") }
-          },
-          {
-            id: "cases-#{index}",
-            label: "Notifications (#{@product.unique_cases_except(@investigation).count})",
-            panel: { html: render("products/case_product_info_tabs/cases")}
-          }
-        ]
-      ) %>
+      <%=
+        govuk_tabs(title: "Information related to this PSD product record") do |tabs|
+          tabs.with_tab(label: "Details") do
+            render("products/case_product_info_tabs/details")
+          end
+          tabs.with_tab(label: "Images (#{@product.virus_free_images.count})") do
+            render("products/case_product_info_tabs/images")
+          end
+          tabs.with_tab(label: "Notifications (#{@product.unique_cases_except(@investigation).count})") do
+            render("products/case_product_info_tabs/cases")
+          end
+        end
+      %>
 
       <% if policy(@investigation_product).remove? %>
         <div class="opss-text-align-right opss-margin-bottom-1-desktop">

--- a/app/views/investigations/ts_investigations/reference_number.html.erb
+++ b/app/views/investigations/ts_investigations/reference_number.html.erb
@@ -21,8 +21,8 @@
       <% hint_html = capture do %>
         <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this notification.</div>
 
-        <%= govukDetails(summaryText: "Help with adding a number", classes: "govuk-!-margin-bottom-8 opss-details--sm") do %>
-          <p class="govuk-body-s">
+        <%= govuk_details(summary_text: "Help with adding a number") do %>
+          <p class="govuk-body">
             This might be a number already created in a different internal system for your notification, or a number you intend to use globally across different systems to reference your notification.
             The reference number will be searchable in the <%= psd_abbr %> notification search page. (You can add or edit this number later).
           </p>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -1,7 +1,7 @@
 <%= page_title "Invite a team member to #{@team.decorate.display_name(viewer: current_user)}", errors: @invite_user_to_team_form.errors.any? %>
 
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: @team) %>
+  <%= govuk_back_link(href: @team) %>
 <% end %>
 
 <%= form_with model: @invite_user_to_team_form, url: team_invitations_path(@team), local: true do |form| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -134,7 +134,7 @@
           <% end %>
           <% %i[success information warning].each do |key| %>
             <% if flash[key] %>
-              <% title = key.gsub("information", "important") %>
+              <% title = key.to_s.gsub("information", "important") %>
               <%= govuk_notification_banner(title_text: title.titlecase, text: flash[key], success: (key == "success")) %>
             <% end %>
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -134,7 +134,8 @@
           <% end %>
           <% %i[success information warning].each do |key| %>
             <% if flash[key] %>
-              <%= govukNotificationBanner text: flash[key], type: key %>
+              <% title = key.gsub("information", "important") %>
+              <%= govuk_notification_banner(title_text: title.titlecase, text: flash[key], success: (key == "success")) %>
             <% end %>
           <% end %>
           <%= content %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -135,7 +135,7 @@
           <% %i[success information warning].each do |key| %>
             <% if flash[key] %>
               <% title = key.to_s.gsub("information", "important") %>
-              <%= govuk_notification_banner(title_text: title.titlecase, text: flash[key], success: (key == "success")) %>
+              <%= govuk_notification_banner(title_text: title.titlecase, text: flash[key], success: (key == :success)) %>
             <% end %>
           <% end %>
           <%= content %>

--- a/app/views/notifications/_filters.html.erb
+++ b/app/views/notifications/_filters.html.erb
@@ -9,30 +9,30 @@
   <% if non_search_cases_page_names.exclude? @page_name %>
     <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
 
-    <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
+    <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
 
-    <%= govukDetails(summaryText: "Notification status", classes: "opss-details--plain", id: "case-status") do %>
+    <%= govuk_details(summary_text: "Notification status", classes: "opss-details--plain", id: "case-status") do %>
       <%= render "notifications/case_status_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Notification priority", classes: "opss-details--plain", id: "case-status") do %>
+    <%= govuk_details(summary_text: "Notification priority", classes: "opss-details--plain", id: "case-status") do %>
       <%= render "notifications/case_risk_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Notification owner", classes: "opss-details--plain", id: "case-owner") do %>
+    <%= govuk_details(summary_text: "Notification owner", classes: "opss-details--plain", id: "case-owner") do %>
       <%= render "notifications/case_owner_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Teams added to the notification", classes: "opss-details--plain", id: "cases-added-to-team") do %>
+    <%= govuk_details(summary_text: "Teams added to the notification", classes: "opss-details--plain", id: "cases-added-to-team") do %>
       <%= render "notifications/teams_with_access_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Created by", classes: "opss-details--plain", id: "cases-created-by") do %>
+    <%= govuk_details(summary_text: "Created by", classes: "opss-details--plain", id: "cases-created-by") do %>
       <%= render "notifications/case_creator_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Notification type", classes: "opss-details--plain", id: "case-type") do %>
+    <%= govuk_details(summary_text: "Notification type", classes: "opss-details--plain", id: "case-type") do %>
       <%= render "notifications/case_type_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Notification hazard type", classes: "opss-details--plain", id: "case-hazard-type") do %>
+    <%= govuk_details(summary_text: "Notification hazard type", classes: "opss-details--plain", id: "case-hazard-type") do %>
       <%= render "notifications/case_hazard_type_checkboxes", form: form %>
     <% end %>
-    <%= govukDetails(summaryText: "Reported reason", classes: "opss-details--plain", id: "reported-reason") do %>
+    <%= govuk_details(summary_text: "Reported reason", classes: "opss-details--plain", id: "reported-reason") do %>
       <%= render "notifications/reported_reason_checkboxes", form: form %>
     <% end %>
 

--- a/app/views/prism_risk_assessments/_table_row.html.erb
+++ b/app/views/prism_risk_assessments/_table_row.html.erb
@@ -9,7 +9,7 @@
     <%= date_or_recent_time_ago prism_risk_assessment.updated_at %>
   </td>
   <td class="govuk-table__cell">
-    <% if type == "submitted" %><%= govukTag(text: "Submitted", classes: "govuk-tag--green") %><% else %><%= govukTag(text: "Draft", classes: "govuk-tag--grey") %><% end %>
+    <% if type == "submitted" %><%= govuk_tag(text: "Submitted", colour: "green") %><% else %><%= govuk_tag(text: "Draft", colour: "grey") %><% end %>
   </td>
   <td class="govuk-table__cell">
     <% if type == "submitted" %><a href="<%= prism.view_submitted_assessment_risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">View assessment</a><hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><a href="<%= add_to_case_prism_risk_assessments_path(prism_risk_assessment_id: prism_risk_assessment.id) %>" class="govuk-link">Add to a notification</a><% else %><a href="<%= prism.risk_assessment_tasks_path(prism_risk_assessment) %>" class="govuk-link">Make changes</a><hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><a href="<%= prism.remove_risk_assessment_tasks_path(prism_risk_assessment, back_to: "dashboard") %>" class="govuk-link">Delete</a><% end %>

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <% if ["team_products", "your_products"].exclude? @page_name %>
     <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
-    <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
+    <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
     <%= govukSelect(
       key: "category",
       form: form,

--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -6,18 +6,15 @@
     <p class="govuk-body opss-secondary-text">
       Search all product records in the Product Safety Database (<%= psd_abbr %>).
     </p>
-    <%= govukDetails(summaryText: "Help with the products search", classes: "opss-details--sm") do %>
-      <p class="govuk-body-s">
+    <%= govuk_details(summary_text: "Help with the products search") do %>
+      <p class="govuk-body">
         <span id="search-hint">You can search for one or more products by using the keywords that describe them or use a single <%= psd_abbr title: false %> reference number to find a specific product record.</span> You can also sort the ordering of the search results.
       </p>
-      <p class="govuk-body-s govuk-!-margin-bottom-1">
+      <p class="govuk-body">
         You can filter the results by product category.
         <% if policy(Product).can_view_retired_products? %>
           As an OPSS user you can also include 'retired' product records in your search. (These are records which are no longer active and are now considered less relevant).
         <% end %>
-      </p>
-      <p class="govuk-body-s govuk-visually-hidden">
-        Search results appear within the following <code>form</code> and within the <code>role = region</code>.
       </p>
     <% end %>
   </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -66,26 +66,18 @@
 
     <h4 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-visually-hidden">Product details</h4>
 
-    <%= @product.summary_list %>
+    <%= @product.details_list %>
 
-    <%= govukAccordion id: "product-accordion", classes: "govuk-!-margin-top-9 opss-accordion--sm-all", items: [
-      {
-        heading: {
-          html: "Images <span class=\"govuk-!-font-weight-regular govuk-!-font-size-19\">(#{ @product.virus_free_images.size })</span>".html_safe
-        },
-        content: {
-          html: render("images", product: @product)
-        }
-      },
-      {
-        heading: {
-          html: "<span class=\"govuk-visually-hidden\">Related</span> Notifications <span class=\"govuk-!-font-weight-regular govuk-!-font-size-19\">(#{ @product.unique_investigation_products.size })</span>".html_safe
-        },
-        content: {
-          html: render("cases", product: @product)
-        }
-      }
-    ] %>
+    <%=
+      govuk_accordion do |accordion|
+        accordion.with_section(heading_text: "Images (#{@product.virus_free_images.size})") do
+          render("images", product: @product)
+        end
+        accordion.with_section(heading_text: "Notifications (#{@product.unique_investigation_products.size})") do
+          render("cases", product: @product)
+        end
+      end
+    %>
 
     <% unless @product.retired? %>
       <% if @product.owning_team.nil? %>

--- a/app/views/secondary_authentications/resend_code/new.html.erb
+++ b/app/views/secondary_authentications/resend_code/new.html.erb
@@ -2,7 +2,7 @@
 <% page_title(title, errors: @user.errors.any?) %>
 
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: new_secondary_authentication_path) %>
+  <%= govuk_back_link(href: new_secondary_authentication_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -15,7 +15,7 @@
     <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can resend it.</p>
     <%= form_with(model: @user,url: resend_secondary_authentication_code_path, method: "post", local: true) do |form| %>
       <% if @user.mobile_number_change_allowed? %>
-        <%= govukDetails(summaryText: "Change where the text message is sent", open: @user.errors.any?) do %>
+        <%= govuk_details(summary_text: "Change where the text message is sent", open: @user.errors.any?) do %>
           <%= govukInput(
             key: :mobile_number,
             form: form,

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -2,7 +2,7 @@
 <% page_title(title, errors: resource.errors.any?) %>
 
 <% content_for :after_header do %>
-  <%= govukBackLink(text: "Back", href: new_user_session_path) %>
+  <%= govuk_back_link(href: new_user_session_path) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/remove.html.erb
+++ b/app/views/users/remove.html.erb
@@ -2,10 +2,7 @@
 <%= page_title page_heading, errors: @remove_user_form.errors.any? %>
 
 <% content_for :after_header do %>
-  <%= govukBackLink(
-    text: "Back",
-    href: team_path(current_user.team)
-  ) %>
+  <%= govuk_back_link(href: team_path(current_user.team)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -9,54 +9,54 @@ RSpec.describe ProductDecorator, :with_stubbed_opensearch do
     specify { expect(decorated_product.pretty_description).to eq("Product: #{product.name}") }
   end
 
-  describe "#summary_list" do
+  describe "#details_list" do
     include CountriesHelper
 
-    let(:summary_list) { decorated_product.summary_list }
+    let(:details_list) { decorated_product.details_list }
 
     context "when displaying the product summary" do
       it "displays the Brand name" do
-        expect(summary_list).to summarise("Brand name", text: product.brand)
+        expect(details_list).to summarise("Brand name", text: product.brand)
       end
 
       it "displays the Product name" do
-        expect(summary_list).to summarise("Product name", text: product.name)
+        expect(details_list).to summarise("Product name", text: product.name)
       end
 
       it "displays the Category" do
-        expect(summary_list).to summarise("Category", text: product.category)
+        expect(details_list).to summarise("Category", text: product.category)
       end
 
       it "displays the Subcategory" do
-        expect(summary_list).to summarise("Subcategory", text: product.subcategory)
+        expect(details_list).to summarise("Subcategory", text: product.subcategory)
       end
 
       it "displays the Barcode" do
-        expect(summary_list).to summarise("Barcode", text: product.barcode)
+        expect(details_list).to summarise("Barcode", text: product.barcode)
       end
 
       it "displays the Description" do
-        expect(summary_list).to summarise("Description", text: product.description)
+        expect(details_list).to summarise("Description", text: product.description)
       end
 
       it "displays the Webpage" do
-        expect(summary_list).to summarise("Webpage", text: product.webpage)
+        expect(details_list).to summarise("Webpage", text: product.webpage)
       end
 
       it "displays the Country of origin" do
-        expect(summary_list).to summarise("Country of origin", text: country_from_code(product.country_of_origin))
+        expect(details_list).to summarise("Country of origin", text: country_from_code(product.country_of_origin))
       end
 
       it "displays product Authenticity" do
-        expect(summary_list).to summarise("Counterfeit", text: "Unsure")
+        expect(details_list).to summarise("Counterfeit", text: "Unsure")
       end
 
       it "displays the Product marking" do
-        expect(summary_list).to summarise("Product marking", text: decorated_product.markings)
+        expect(details_list).to summarise("Product marking", text: decorated_product.markings)
       end
 
       it "displays the Other product identifiers" do
-        expect(summary_list).to summarise("Other product identifiers", text: product.product_code)
+        expect(details_list).to summarise("Other product identifiers", text: product.product_code)
       end
     end
   end

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -72,8 +72,8 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
                         end
 
     expected_counterfeit_value = case attributes[:authenticity]
-                                 when "genuine" then "No This product record is about a genuine product"
-                                 when "counterfeit" then "Yes This is a product record for a counterfeit product"
+                                 when "genuine" then "No - This product record is about a genuine product"
+                                 when "counterfeit" then "Yes - This is a product record for a counterfeit product"
                                  end
 
     expect(page).to have_summary_item(key: "Brand name", value: attributes[:brand])

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     expect(page).to have_summary_item(key: "Webpage", value: attributes[:webpage])
     expect(page).to have_summary_item(key: "Country of origin", value: attributes[:country])
     expect(page).to have_summary_item(key: "Description", value: attributes[:description])
-    expect(page).to have_summary_item(key: "Market date", value: "#{I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key)} - Placed on the market")
+    expect(page).to have_summary_item(key: "Market date", value: I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key))
   end
 
   scenario "Adding a product with blank origin, it asserts validations" do

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     expect(page).to have_summary_item(key: "Webpage", value: attributes[:webpage])
     expect(page).to have_summary_item(key: "Country of origin", value: attributes[:country])
     expect(page).to have_summary_item(key: "Description", value: attributes[:description])
-    expect(page).to have_summary_item(key: "Market date", value: "#{I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key)} Placed on the market")
+    expect(page).to have_summary_item(key: "Market date", value: "#{I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key)} - Placed on the market")
   end
 
   scenario "Adding a product with blank origin, it asserts validations" do

--- a/spec/features/add_product_to_case_spec.rb
+++ b/spec/features/add_product_to_case_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Adding a product to a case", :with_stubbed_mailer, :with_stubbed_
     expect_to_have_notification_breadcrumbs
 
     expect(page).to have_selector("h3", text: right_product.name)
-    expect(page).to have_css(".govuk-summary-list__value", text: "#{right_product.psd_ref} - The PSD reference number for this product record", exact: true)
+    expect(page).to have_css(".govuk-summary-list__value", text: "#{right_product.psd_ref} - The <abbr>PSD</abbr> reference number for this product record", exact: true)
     expect(page).to have_css(".govuk-summary-list__value", text: "#{right_product.psd_ref}_#{investigation.reload.investigation_products.first.investigation_closed_at.to_i}")
     expect(investigation.reload.products.count).to eq(2)
     expect(investigation.products.first).to eq(right_product)

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -172,7 +172,7 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
 
     visit "/cases/all-cases"
 
-    expect_warning_banner("We have noticed that your recent product upload is not complete, and the products have yet to be allocated to their respective notification. Resume the upload process.")
+    expect_warning_banner("Important\nWe have noticed that your recent product upload is not complete, and the products have yet to be allocated to their respective notification. Resume the upload process")
 
     click_link "Resume the upload process"
 

--- a/spec/features/change_case_status_spec.rb
+++ b/spec/features/change_case_status_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Changing the status of a notification", :with_opensearch, :with_s
 
       expect_to_be_on_case_page(case_id: investigation.pretty_id)
       expect_confirmation_banner("The notification was closed")
-      expect(page).to have_summary_item(key: "Status", value: "Notification closed #{Date.current.to_formatted_s(:govuk)}")
+      expect(page).to have_summary_item(key: "Status", value: "Notification closed (#{Date.current.to_formatted_s(:govuk)})")
 
       click_link "Activity"
 

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
 
       expect(page).to have_summary_item(key: "Category", value: product.category)
       expect(page).to have_summary_item(key: "Subcategory", value: new_subcategory)
-      expect(page).to have_summary_item(key: "Counterfeit", value: "Yes This is a product record for a counterfeit product")
+      expect(page).to have_summary_item(key: "Counterfeit", value: "Yes - This is a product record for a counterfeit product")
       expect(page).to have_summary_item(key: "Product marking", value: expected_markings)
       expect(page).to have_summary_item(key: "Brand name", value: product.brand)
       expect(page).to have_summary_item(key: "Product name", value: product.name)
@@ -205,7 +205,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
 
       expect(page).to have_summary_item(key: "Category", value: product.category)
       expect(page).to have_summary_item(key: "Subcategory", value: new_subcategory)
-      expect(page).to have_summary_item(key: "Counterfeit", value: "Yes This is a product record for a counterfeit product")
+      expect(page).to have_summary_item(key: "Counterfeit", value: "Yes - This is a product record for a counterfeit product")
       expect(page).to have_summary_item(key: "Product marking", value: expected_markings)
       expect(page).to have_summary_item(key: "Brand name", value: product.brand)
       expect(page).to have_summary_item(key: "Product name", value: product.name)

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -258,6 +258,6 @@ RSpec.feature "notification export", :with_opensearch, :with_stubbed_antivirus, 
   end
 
   def expand_help_details
-    click_link "Help with the notifications search"
+    first(".govuk-details__summary").click
   end
 end

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -258,6 +258,6 @@ RSpec.feature "notification export", :with_opensearch, :with_stubbed_antivirus, 
   end
 
   def expand_help_details
-    find(".opss-details--sm").click
+    click_link "Help with the notifications search"
   end
 end

--- a/spec/features/product_versioning_spec.rb
+++ b/spec/features/product_versioning_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
     visit "/cases/#{first_investigation.pretty_id}/products"
 
     expect(page).to have_selector("h3.govuk-heading-m", text: product.name)
-    expect(page).to have_selector("dd.govuk-summary-list__value", text: "psd-#{product.id}_#{first_investigation.date_closed.to_i} - The PSD reference number for this version of the product record - as recorded when the notification was closed: #{first_investigation.date_closed.to_formatted_s(:govuk)}")
+    expect(page).to have_selector("dd.govuk-summary-list__value", text: "psd-#{product.id}_#{first_investigation.date_closed.to_i} - The <abbr>PSD</abbr> reference number for this version of the product record - as recorded when the notification was closed: #{first_investigation.date_closed.to_formatted_s(:govuk)}")
     expect(page).to have_selector("dd.govuk-summary-list__value", text: initial_product_description)
     expect(page).not_to have_link "Edit this product"
     expect(page).to have_link("Images (1)")

--- a/spec/features/product_versioning_spec.rb
+++ b/spec/features/product_versioning_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
 
   scenario "editing a product" do
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The PSD reference number for this product record")
+    expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The <abbr>PSD</abbr> reference number for this product record")
     expect(page).to have_summary_item(key: "Description", value: initial_product_description)
     expect(page).to have_link("Images (1)")
 
@@ -50,7 +50,7 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
 
     # Ensure product page shows latest version
     expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-    expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The PSD reference number for this product record")
+    expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{product.id} - The <abbr>PSD</abbr> reference number for this product record")
     expect(page).to have_summary_item(key: "Description", value: new_product_description)
     expect(page).to have_link("Images (1)")
 

--- a/spec/features/remove_product_from_a_case_spec.rb
+++ b/spec/features/remove_product_from_a_case_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature "Remove product from investigation", :with_stubbed_antivirus, :wit
       old_product_psd_text = "#{product.psd_ref}_#{investigation.reload.investigation_products.first.investigation_closed_at.to_i}"
 
       expect(page).to have_css(".govuk-summary-list__value", text: old_product_psd_text)
-      expect(page).to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The PSD reference number for this product record")
+      expect(page).to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The <abbr>PSD</abbr> reference number for this product record")
 
       # Only the timestamped product can be removed
       click_link "Remove this #{product.name} product from the notification"
@@ -157,7 +157,7 @@ RSpec.feature "Remove product from investigation", :with_stubbed_antivirus, :wit
       expect_to_be_on_investigation_products_page(case_id: investigation.pretty_id)
 
       expect(page).to have_css(".govuk-summary-list__value", text: old_product_psd_text)
-      expect(page).not_to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The PSD reference number for this product record")
+      expect(page).not_to have_css(".govuk-summary-list__value", text: "#{product.psd_ref} - The <abbr>PSD</abbr> reference number for this product record")
 
       click_link "Activity"
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)

--- a/spec/features/retired_products_spec.rb
+++ b/spec/features/retired_products_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Retired products", :with_opensearch, :with_stubbed_mailer, type: 
 
     scenario "the user can view a live product" do
       visit product_path(live_product)
-      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{live_product.id} - The PSD reference number for this product record")
+      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{live_product.id} - The <abbr>PSD</abbr> reference number for this product record")
       expect(page.find("dt", text: "Product record owner")).to have_sibling("dd", text: owning_team.name)
       expect(page).not_to have_content("This product record has been retired and can no longer be added to notifications")
       expect(page).to have_content "This product record is currently owned by #{owning_team.name}."
@@ -28,7 +28,7 @@ RSpec.feature "Retired products", :with_opensearch, :with_stubbed_mailer, type: 
 
     scenario "the user can view a retired product" do
       visit product_path(retired_product)
-      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{retired_product.id} - The PSD reference number for this product record")
+      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{retired_product.id} - The <abbr>PSD</abbr> reference number for this product record")
       expect(page).not_to have_css("dt", text: "Product record owner")
       expect(page).to have_content("This product record has been retired and can no longer be added to notifications")
       expect(page).not_to have_content "This product record is currently owned by #{Team.find(live_product.owning_team_id).name}."
@@ -48,7 +48,7 @@ RSpec.feature "Retired products", :with_opensearch, :with_stubbed_mailer, type: 
 
     scenario "the user can view a live product" do
       visit product_path(live_product)
-      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{live_product.id} - The PSD reference number for this product record")
+      expect(page).to have_summary_item(key: "PSD ref", value: "psd-#{live_product.id} - The <abbr>PSD</abbr> reference number for this product record")
     end
 
     scenario "the user can view a live product's owner" do

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, type: :feature d
 
     expect(page).to have_text "The product record was updated"
 
-    expect(page).to have_summary_item(key: "PSD ref", value: "#{product.psd_ref} - The PSD reference number for this product record")
+    expect(page).to have_summary_item(key: "PSD ref", value: "#{product.psd_ref} - The <abbr>PSD</abbr> reference number for this product record")
     expect(page).to have_summary_item(key: "Brand name", value: "MyBrand")
     expect(page).to have_summary_item(key: "Product name", value: "Washing machine")
     expect(page).to have_summary_item(key: "Category", value: "Electrical appliances and equipment")


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2172

## Description

Replaces non-form custom elements from the OPSS design system gem with components from the GOV.UK Design System.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2787.london.cloudapps.digital/
https://psd-pr-2787-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
