### PR TITLE
use correct breadcrumb for new notifications search

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -16,7 +16,11 @@ module BreadcrumbHelper
 
   def breadcrumb_case_path
     setting = cookies.fetch(:last_case_view, "your_cases")
-    setting = "all_cases" if setting == "index"
+
+    return :notifications if setting == "index" && current_user.can_access_new_search?
+
+    setting "all_cases" if setting == "index"
+
     "#{setting}_investigations".to_sym
   end
 

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -19,7 +19,7 @@ module BreadcrumbHelper
 
     return :notifications if setting == "index" && current_user.can_access_new_search?
 
-    setting "all_cases" if setting == "index"
+    setting = "all_cases" if setting == "index"
 
     "#{setting}_investigations".to_sym
   end


### PR DESCRIPTION
## Description

Provides the notifications_path for the breadcrumbs for a user using the new search

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
