### PR TITLE
add unsafe reason to notifications extract

### DIFF
--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -133,7 +133,8 @@ private
                      Trading_Standards_Region
                      Regulator_Name
                      OPSS_Internal_Team
-                     Non_Compliant_Reason]
+                     Non_Compliant_Reason
+                     Unsafe_Reason]
   end
 
   def find_cases(ids)
@@ -175,7 +176,8 @@ private
       team_data.ts_region,
       team_data.regulator_name,
       (team_data.type == "internal"),
-      investigation.non_compliant_reason
+      investigation.non_compliant_reason,
+      investigation.hazard_description
     ]
   end
 
@@ -207,7 +209,9 @@ private
       "Restricted",
       team_data.ts_region,
       team_data.regulator_name,
-      (team_data.type == "internal")
+      (team_data.type == "internal"),
+      investigation.non_compliant_reason,
+      investigation.hazard_description
     ]
   end
 end

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -169,6 +169,10 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
       expect(sheet.cell(1, 26)).to eq "Non_Compliant_Reason"
       expect(sheet.cell(2, 26)).to eq investigation.non_compliant_reason
       expect(sheet.cell(3, 26)).to eq other_team_investigation.non_compliant_reason
+
+      expect(sheet.cell(1, 27)).to eq "Unsafe_Reason"
+      expect(sheet.cell(2, 27)).to eq investigation.hazard_description
+      expect(sheet.cell(3, 27)).to eq other_team_investigation.hazard_description
     end
     # rubocop:enable RSpec/ExampleLength
 


### PR DESCRIPTION
## Description

Add unsafe reason to notification extract

## Review apps

https://psd-pr-2802.london.cloudapps.digital/
https://psd-pr-2802-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
