### PR TITLE
Refactor case name and ref number classes - PSD-2316

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,13 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  def set_notification_breadcrumbs
+    breadcrumb "cases.label", :businesses_path
+    breadcrumb breadcrumb_case_label, breadcrumb_case_path
+    breadcrumb @notification.pretty_id, investigation_path(@notification) if @notification&.persisted?
+  end
+
+  # TODO Remove this once all investigation controllers use notification instead
   def set_investigation_breadcrumbs
     breadcrumb "cases.label", :businesses_path
     breadcrumb breadcrumb_case_label, breadcrumb_case_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,7 +109,7 @@ protected
     breadcrumb @notification.pretty_id, investigation_path(@notification) if @notification&.persisted?
   end
 
-  # TODO Remove this once all investigation controllers use notification instead
+  # TODO: Remove this once all investigation controllers use notification instead
   def set_investigation_breadcrumbs
     breadcrumb "cases.label", :businesses_path
     breadcrumb breadcrumb_case_label, breadcrumb_case_path

--- a/app/controllers/investigations/base_controller.rb
+++ b/app/controllers/investigations/base_controller.rb
@@ -3,7 +3,7 @@ private
 
   def set_notification
     @notification_object = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
-    @notification = @investigation_object.decorate
+    @notification = @notification_object.decorate
   rescue ActiveRecord::RecordNotFound
     render_404_page
   end

--- a/app/controllers/investigations/base_controller.rb
+++ b/app/controllers/investigations/base_controller.rb
@@ -1,6 +1,18 @@
 class Investigations::BaseController < ApplicationController
 private
 
+  def set_notification
+    @notification_object = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+    @notification = @investigation_object.decorate
+  rescue ActiveRecord::RecordNotFound
+    render_404_page
+  end
+
+  def authorize_notification_updates
+    authorize @notification, :update?
+  end
+
+  # TODO Remove all below once all investigation controllers use notification instead
   def set_investigation
     @investigation_object = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     @investigation = @investigation_object.decorate

--- a/app/controllers/investigations/base_controller.rb
+++ b/app/controllers/investigations/base_controller.rb
@@ -12,7 +12,7 @@ private
     authorize @notification, :update?
   end
 
-  # TODO Remove all below once all investigation controllers use notification instead
+  # TODO: Remove all below once all investigation controllers use notification instead
   def set_investigation
     @investigation_object = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     @investigation = @investigation_object.decorate

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -12,7 +12,7 @@ module Investigations
       @case_name_form = CaseNameForm.new(case_name_params.merge(current_user:))
 
       if @case_name_form.valid?
-        ChangeCaseName.call!(investigation: @investigation, user_title: @case_name_form.user_title, user: current_user)
+        ChangeNotificationName.call!(notification: @investigation, user_title: @case_name_form.user_title, user: current_user)
         redirect_to investigation_path(@investigation), flash: { success: "The notification name was updated" }
       else
         render :edit

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -5,14 +5,14 @@ module Investigations
     before_action :set_notification_breadcrumbs
 
     def edit
-      @case_name_form = CaseNameForm.new(user_title: @notification.user_title, current_user:)
+      @notification_name_form = ChangeNotificationNameForm.new(user_title: @notification.user_title, current_user:)
     end
 
     def update
-      @case_name_form = CaseNameForm.new(case_name_params.merge(current_user:))
+      @notification_name_form = ChangeNotificationNameForm.new(case_name_params.merge(current_user:))
 
-      if @case_name_form.valid?
-        ChangeNotificationName.call!(notification: @notification, user_title: @case_name_form.user_title, user: current_user)
+      if @notification_name_form.valid?
+        ChangeNotificationName.call!(notification: @notification, user_title: @notification_name_form.user_title, user: current_user)
         redirect_to investigation_path(@notification), flash: { success: "The notification name was updated" }
       else
         render :edit

--- a/app/controllers/investigations/case_names_controller.rb
+++ b/app/controllers/investigations/case_names_controller.rb
@@ -1,19 +1,19 @@
 module Investigations
   class CaseNamesController < Investigations::BaseController
-    before_action :set_investigation
-    before_action :authorize_investigation_updates
-    before_action :set_investigation_breadcrumbs
+    before_action :set_notification
+    before_action :authorize_notification_updates
+    before_action :set_notification_breadcrumbs
 
     def edit
-      @case_name_form = CaseNameForm.new(user_title: @investigation.user_title, current_user:)
+      @case_name_form = CaseNameForm.new(user_title: @notification.user_title, current_user:)
     end
 
     def update
       @case_name_form = CaseNameForm.new(case_name_params.merge(current_user:))
 
       if @case_name_form.valid?
-        ChangeNotificationName.call!(notification: @investigation, user_title: @case_name_form.user_title, user: current_user)
-        redirect_to investigation_path(@investigation), flash: { success: "The notification name was updated" }
+        ChangeNotificationName.call!(notification: @notification, user_title: @case_name_form.user_title, user: current_user)
+        redirect_to investigation_path(@notification), flash: { success: "The notification name was updated" }
       else
         render :edit
       end

--- a/app/controllers/investigations/reference_numbers_controller.rb
+++ b/app/controllers/investigations/reference_numbers_controller.rb
@@ -1,18 +1,18 @@
 module Investigations
   class ReferenceNumbersController < Investigations::BaseController
-    before_action :set_investigation
-    before_action :authorize_investigation_updates
-    before_action :set_investigation_breadcrumbs
+    before_action :set_notification
+    before_action :authorize_notification_updates
+    before_action :set_notification_breadcrumbs
 
     def edit; end
 
     def update
-      if @investigation.complainant_reference == reference_number_params[:complainant_reference]
-        return redirect_to investigation_path(@investigation)
+      if @notification.complainant_reference == reference_number_params[:complainant_reference]
+        return redirect_to investigation_path(@notification)
       end
 
-      ChangeCaseReferenceNumber.call!(investigation: @investigation, reference_number: reference_number_params[:complainant_reference], user: current_user)
-      redirect_to investigation_path(@investigation), flash: { success: "The reference number was updated" }
+      ChangeNotificationReferenceNumber.call!(notification: @notification, reference_number: reference_number_params[:complainant_reference], user: current_user)
+      redirect_to investigation_path(@notification), flash: { success: "The reference number was updated" }
     end
 
   private

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -28,7 +28,7 @@ class Investigations::TsInvestigationsController < ApplicationController
                                  ReferenceNumberForm.new
                                end
     when :case_name
-      @case_name_form = CaseNameForm.new
+      @notification_name_form = ChangeNotificationNameForm.new
       @product = authorize_product
     when :case_created
       @investigation = session[:investigation]
@@ -79,11 +79,11 @@ class Investigations::TsInvestigationsController < ApplicationController
       session[:investigation].assign_attributes(complainant_reference: @reference_number_form.complainant_reference) if @reference_number_form.has_complainant_reference
       session[:form_answers].merge!(reference_number_params)
     when :case_name
-      @case_name_form = CaseNameForm.new(case_name_params.merge(current_user:))
+      @notification_name_form = ChangeNotificationNameForm.new(case_name_params.merge(current_user:))
       @product = authorize_product
-      return render_wizard unless @case_name_form.valid?
+      return render_wizard unless @notification_name_form.valid?
 
-      session[:investigation].assign_attributes(user_title: @case_name_form.user_title)
+      session[:investigation].assign_attributes(user_title: @notification_name_form.user_title)
     end
     redirect_to next_wizard_path
   end

--- a/app/forms/change_notification_name_form.rb
+++ b/app/forms/change_notification_name_form.rb
@@ -1,4 +1,4 @@
-class CaseNameForm
+class ChangeNotificationNameForm
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveModel::Serialization

--- a/app/services/change_notification_name.rb
+++ b/app/services/change_notification_name.rb
@@ -1,4 +1,4 @@
-class ChangeCaseName
+class ChangeNotificationName
   include Interactor
   include EntitiesToNotify
 

--- a/app/services/change_notification_name.rb
+++ b/app/services/change_notification_name.rb
@@ -2,18 +2,18 @@ class ChangeNotificationName
   include Interactor
   include EntitiesToNotify
 
-  delegate :investigation, :user_title, :user, to: :context
+  delegate :notification, :user_title, :user, to: :context
 
   def call
-    context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+    context.fail!(error: "No notification supplied") unless notification.is_a?(Investigation)
     context.fail!(error: "No case name supplied") unless user_title.is_a?(String)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
-    investigation.assign_attributes(user_title:)
-    return if investigation.changes.none?
+    notification.assign_attributes(user_title:)
+    return if notification.changes.none?
 
     ActiveRecord::Base.transaction do
-      investigation.save!
+      notification.save!
       create_audit_activity_for_user_title_changed
     end
 
@@ -23,11 +23,10 @@ class ChangeNotificationName
 private
 
   def create_audit_activity_for_user_title_changed
-    metadata = activity_class.build_metadata(investigation)
-
+    metadata = activity_class.build_metadata(notification)
     activity_class.create!(
       added_by_user: user,
-      investigation:,
+      investigation: notification,
       title: nil,
       body: nil,
       metadata:
@@ -39,9 +38,9 @@ private
   end
 
   def send_notification_email
-    email_recipients_for_case_owner(investigation).each do |recipient|
+    email_recipients_for_case_owner(notification).each do |recipient|
       NotifyMailer.notification_updated(
-        investigation.pretty_id,
+        notification.pretty_id,
         recipient.name,
         recipient.email,
         email_body(recipient),

--- a/app/services/change_notification_reference_number.rb
+++ b/app/services/change_notification_reference_number.rb
@@ -1,4 +1,4 @@
-class ChangeCaseReferenceNumber
+class ChangeNotificationReferenceNumber
   include Interactor
   include EntitiesToNotify
 

--- a/app/views/investigations/case_names/_form.html.erb
+++ b/app/views/investigations/case_names/_form.html.erb
@@ -1,5 +1,5 @@
-<%= error_summary @case_name_form.errors %>
-<% error_message = { text: @case_name_form.errors.full_messages_for("user_title").first } if @case_name_form.errors.any? %>
+<%= error_summary @notification_name_form.errors %>
+<% error_message = { text: @notification_name_form.errors.full_messages_for("user_title").first } if @notification_name_form.errors.any? %>
 
 <%= govukInput(
       form: form,

--- a/app/views/investigations/case_names/edit.html.erb
+++ b/app/views/investigations/case_names/edit.html.erb
@@ -1,13 +1,13 @@
 <% page_heading = "Edit the notification name?" %>
-<%= page_title page_heading, errors: @case_name_form.errors.any? %>
+<%= page_title page_heading, errors: @notification_name_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @case_name_form, url: investigation_case_names_path, method: :put, local: true do |form| %>
+    <%= form_with model: @notification_name_form, url: investigation_case_names_path, method: :put, local: true do |form| %>
       <%= render "form", form: form, heading: "Edit the notification name" %>
 
        <div class="govuk-button-group">
          <%= form.submit "Save", class: "govuk-button" %>
-         <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+         <%= link_to "Cancel", investigation_path(@notification), class: "govuk-link govuk-link--no-visited-state" %>
        </div>
     <% end %>
   </div>

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_heading = "Edit the reference number" %>
-<%= page_title page_heading, errors: @investigation.errors.any? %>
+<%= page_title page_heading, errors: @notification.errors.any? %>
 
 <% hint_html = capture do %>
   <div id="ref-number-hint" class="govuk-hint">You can add your own reference number to this notification.</div>
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with scope: :investigation, model: @investigation, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @notification, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
       <%= govukInput(
         key: :complainant_reference,
         id: "complainant_reference",
@@ -28,10 +28,9 @@
         classes: "govuk-input--width-20"
       ) %>
 
-
       <div class="govuk-button-group">
         <%= form.submit "Save", class: "govuk-button" %>
-        <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to "Cancel", investigation_path(@notification), class: "govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>
   </div>

--- a/app/views/investigations/ts_investigations/case_name.html.erb
+++ b/app/views/investigations/ts_investigations/case_name.html.erb
@@ -1,11 +1,10 @@
 <% page_heading = "What is the notification name?" %>
-<%= page_title page_heading, errors: @case_name_form.errors.any? %>
+<%= page_title page_heading, errors: @notification_name_form.errors.any? %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with scope: :investigation, model: @case_name_form, url: wizard_path, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @notification_name_form, url: wizard_path, method: :put, local: true do |form| %>
       <%= render "/investigations/case_names/form", form: form, heading: "What is the notification name?" %>
-
 
        <div class="govuk-button-group">
          <%= form.submit "Save", class: "govuk-button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -692,7 +692,7 @@ en:
               blank: "Select the primary hazard"
             hazard_description:
               blank: "Enter why the product is unsafe"
-        case_name_form:
+        change_notification_name_form:
           attributes:
             user_title:
               blank: "Enter a notification name"

--- a/spec/features/change_notification_name_spec.rb
+++ b/spec/features/change_notification_name_spec.rb
@@ -3,24 +3,24 @@ require "rails_helper"
 RSpec.feature "Edit a notification name", :with_stubbed_mailer do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:team_mate) { create(:user, :activated, has_viewed_introduction: true, team: user.team) }
-  let(:original_case_name) { "the original notification name" }
-  let(:new_case_name) { "new name" }
-  let(:taken_case_name) { "notification name that has already been taken" }
-  let(:investigation) { create(:allegation, user_title: original_case_name, creator: user) }
+  let(:original_notification_name) { "the original notification name" }
+  let(:new_notification_name) { "new name" }
+  let(:taken_notification_name) { "notification name that has already been taken" }
+  let(:notification) { create(:notification, user_title: original_notification_name, creator: user) }
 
   before do
-    create(:allegation, user_title: taken_case_name, creator: user)
+    create(:allegation, user_title: taken_notification_name, creator: user)
   end
 
   it "allows user to edit notification name" do
     sign_in(team_mate)
-    visit "/cases/#{investigation.pretty_id}"
+    visit "/cases/#{notification.pretty_id}"
 
     click_link "Edit the notification name"
 
-    expect(page).to have_current_path "/cases/#{investigation.pretty_id}/case_names/edit", ignore_query: true
+    expect(page).to have_current_path "/cases/#{notification.pretty_id}/case_names/edit", ignore_query: true
     expect(page).to have_css("h1", text: "Edit the notification name")
-    expect(page).to have_field("user_title", with: original_case_name)
+    expect(page).to have_field("user_title", with: original_notification_name)
     expect_to_have_notification_breadcrumbs
 
     fill_in :user_title, with: ""
@@ -31,7 +31,7 @@ RSpec.feature "Edit a notification name", :with_stubbed_mailer do
     expect(errors_list[0].text).to eq "Enter a notification name"
     expect_to_have_notification_breadcrumbs
 
-    fill_in :user_title, with: taken_case_name
+    fill_in :user_title, with: taken_notification_name
 
     click_button "Save"
 
@@ -39,20 +39,20 @@ RSpec.feature "Edit a notification name", :with_stubbed_mailer do
     expect(errors_list[0].text).to eq "The notification name has already been used in an open notification by your team"
     expect_to_have_notification_breadcrumbs
 
-    fill_in :user_title, with: new_case_name
+    fill_in :user_title, with: new_notification_name
 
     click_button "Save"
 
-    expect(page).to have_current_path "/cases/#{investigation.pretty_id}", ignore_query: true
+    expect(page).to have_current_path "/cases/#{notification.pretty_id}", ignore_query: true
     expect(page).to have_content "The notification name was updated"
 
-    expect(page.find("dt", text: "Notification name")).to have_sibling("dd", text: new_case_name)
+    expect(page.find("dt", text: "Notification name")).to have_sibling("dd", text: new_notification_name)
 
     click_link "Activity"
 
-    expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
+    expect_to_be_on_case_activity_page(case_id: notification.pretty_id)
     expect(page).to have_css("h3", text: "Notification name updated")
-    expect(page).to have_content("Notification name: #{new_case_name}")
+    expect(page).to have_content("Notification name: #{new_notification_name}")
 
     expect(delivered_emails.last.personalization[:subject_text]).to eq "Notification name updated"
   end

--- a/spec/features/change_notification_reference_number_spec.rb
+++ b/spec/features/change_notification_reference_number_spec.rb
@@ -5,15 +5,15 @@ RSpec.feature "Edit an notification reference number", :with_stubbed_mailer, typ
   let(:team_mate) { create(:user, :activated, has_viewed_introduction: true, team: user.team) }
   let(:original_reference_number) { "123" }
   let(:new_reference_number) { "999" }
-  let(:investigation) { create(:allegation, complainant_reference: original_reference_number, creator: user) }
+  let(:notification) { create(:notification, complainant_reference: original_reference_number, creator: user) }
 
   it "allows user to edit reference number" do
     sign_in(team_mate)
-    visit "/cases/#{investigation.pretty_id}"
+    visit "/cases/#{notification.pretty_id}"
 
     click_link "Edit the reference number"
 
-    expect(page).to have_current_path "/cases/#{investigation.pretty_id}/reference_numbers/edit", ignore_query: true
+    expect(page).to have_current_path "/cases/#{notification.pretty_id}/reference_numbers/edit", ignore_query: true
     expect(page).to have_css("h1", text: "Edit the reference number")
     expect(page).to have_field("complainant_reference", with: original_reference_number)
     expect_to_have_notification_breadcrumbs
@@ -22,7 +22,7 @@ RSpec.feature "Edit an notification reference number", :with_stubbed_mailer, typ
 
     click_button "Save"
 
-    expect(page).to have_current_path "/cases/#{investigation.pretty_id}", ignore_query: true
+    expect(page).to have_current_path "/cases/#{notification.pretty_id}", ignore_query: true
     expect(page).to have_content "The reference number was updated"
 
     expect(page.find("dt", text: "Reference")).to have_sibling("dd", text: new_reference_number)

--- a/spec/features/change_notification_reference_number_spec.rb
+++ b/spec/features/change_notification_reference_number_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Edit an case's reference number", :with_stubbed_mailer, type: :feature do
+RSpec.feature "Edit an notification reference number", :with_stubbed_mailer, type: :feature do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:team_mate) { create(:user, :activated, has_viewed_introduction: true, team: user.team) }
   let(:original_reference_number) { "123" }

--- a/spec/services/change_notification_name_spec.rb
+++ b/spec/services/change_notification_name_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe ChangeNotificationName, :with_test_queue_adapter do
+  subject(:result) { described_class.call!(notification:, user_title:, user:) }
+
+  let!(:notification) { create(:notification, user_title: previous_user_title, creator: user) }
+  let(:previous_user_title) { "Case name" }
+  let(:user_title) { "New case name" }
+  let(:user) { create(:user, :activated) }
+  let(:other_team) { create(:team) }
+  let(:other_user) { create(:user, :activated, team: other_team) }
+
+  context "with no notification parameter" do
+    subject(:result) { described_class.call(user:, user_title:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with no user parameter" do
+    subject(:result) { described_class.call(notification:, user_title:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with no user_title parameter" do
+    subject(:result) { described_class.call(notification:, user:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when the previous and the new name are the same" do
+    subject(:result) { described_class.call!(notification:, user_title: previous_user_title, user:) }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "does not create a new activity" do
+      expect { result }.not_to change(Activity, :count)
+    end
+
+    it "does not send an email" do
+      expect { result }.not_to have_enqueued_mail(NotifyMailer, :notification_updated)
+    end
+  end
+
+  context "when the previous user_title and the new user_title are different" do
+    def expected_email_subject
+      "Notification name updated"
+    end
+
+    def expected_email_body(name)
+      "Notification name was updated by #{name}."
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "changes the user_title for the notification" do
+      expect { result }.to change(notification, :user_title).from(previous_user_title).to(user_title)
+    end
+
+    it "creates a new activity for the change", :aggregate_failures do
+      expect { result }.to change(Activity, :count).by(1)
+      activity = notification.reload.activities.first
+      expect(activity).to be_a(AuditActivity::Investigation::UpdateCaseName)
+      expect(activity.added_by_user).to eq(user)
+    end
+
+    it_behaves_like "a service which notifies the notification owner", even_when_the_notification_is_closed: true
+    it_behaves_like "a service which notifies the notification creator", even_when_the_notification_is_closed: true
+  end
+end

--- a/spec/services/change_notification_reference_number_spec.rb
+++ b/spec/services/change_notification_reference_number_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe ChangeNotificationReferenceNumber, :with_test_queue_adapter do
+  subject(:result) { described_class.call!(notification:, reference_number:, user:) }
+
+  let!(:notification) { create(:notification, complainant_reference: previous_reference_number, creator: user) }
+  let(:previous_reference_number) { "Case name" }
+  let(:reference_number) { "New case name" }
+  let(:user) { create(:user, :activated) }
+  let(:other_team) { create(:team) }
+  let(:other_user) { create(:user, :activated, team: other_team) }
+
+  context "with no notification parameter" do
+    subject(:result) { described_class.call(user:, reference_number:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with no user parameter" do
+    subject(:result) { described_class.call(notification:, reference_number:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with no reference_number parameter" do
+    subject(:result) { described_class.call(notification:, user:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when the previous and the new name are the same" do
+    subject(:result) { described_class.call!(notification:, reference_number: previous_reference_number, user:) }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "does not create a new activity" do
+      expect { result }.not_to change(Activity, :count)
+    end
+  end
+
+  context "when the previous reference_number and the new reference_number are different" do
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "changes the reference_number for the notification" do
+      expect { result }.to change(notification, :complainant_reference).from(previous_reference_number).to(reference_number)
+    end
+
+    it "creates a new activity for the change", :aggregate_failures do
+      expect { result }.to change(Activity, :count).by(1)
+      activity = notification.reload.activities.first
+      expect(activity).to be_a(AuditActivity::Investigation::UpdateReferenceNumber)
+      expect(activity.added_by_user).to eq(user)
+    end
+  end
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2316

most of the new lines are two new specs covering the services that weren't previously tested

- Renames to ChangeCaseName to ChangeNotificationName and forms
- Renames ChangeCaseReference to ChangeNotificationReference and forms
- Adds new spec for both services
- Adds new controller helpers for before_filters surfacing @notification etc. with breadcrumbs & authorisation helpers
- Refactors controllers to use new notification controller helpers