### PR TITLE
Notification task list: add notification details

### DIFF
--- a/app/forms/change_notification_details_form.rb
+++ b/app/forms/change_notification_details_form.rb
@@ -1,0 +1,23 @@
+class ChangeNotificationDetailsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :user_title, :string
+  attribute :description, :string
+  attribute :reported_reason, :string
+  attribute :current_user
+  attribute :notification_id
+
+  validates :user_title, :reported_reason, presence: true
+  validates :description, length: { maximum: 10_000 }
+  validate :unique_user_title_within_team
+
+  def unique_user_title_within_team
+    return unless user_title
+
+    notification_with_same_title = Investigation.where(user_title:, is_closed: false).where.not(id: notification_id)
+                                                .joins(:collaborations).where(collaborations: { collaborator_id: current_user.team.id })
+    errors.add(:user_title, "The notification name has already been used in another open notification by your team") unless notification_with_same_title.empty?
+  end
+end

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -41,6 +41,13 @@ module Notifications
       ]
     end
 
+    def reported_reason_options
+      [
+        OpenStruct.new(id: "unsafe_or_non_compliant", name: "A product is unsafe or non-compliant", description: "Examples of non-compliance in products include missing or incomplete markings, errors in product labeling, or inadequate documentation."),
+        OpenStruct.new(id: "safe_and_compliant", name: "A product is safe and compliant", description: "This helps other market surveillance authorities avoid testing the same product again.")
+      ]
+    end
+
   private
 
     def previous_task(task)

--- a/app/services/change_case_summary.rb
+++ b/app/services/change_case_summary.rb
@@ -17,7 +17,7 @@ class ChangeCaseSummary
       create_audit_activity_for_case_summary_changed
     end
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/change_notification_name.rb
+++ b/app/services/change_notification_name.rb
@@ -17,7 +17,7 @@ class ChangeNotificationName
       create_audit_activity_for_user_title_changed
     end
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/change_reported_reason.rb
+++ b/app/services/change_reported_reason.rb
@@ -20,7 +20,7 @@ class ChangeReportedReason
 
       context.changes_made = true
 
-      send_notification_email(investigation, user)
+      send_notification_email(investigation, user) unless context.silent
     end
   end
 

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -1,0 +1,26 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+          <%= t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title") %>
+        </h1>
+      </div>
+    </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_with model: @change_notification_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+          <%= f.govuk_text_field :user_title, label: { text: "Notification title", size: "m" }, hint: { text: "A recommended format for the notification title includes the name of the product(s) and the hazard associated with it." } %>
+          <%= f.govuk_text_area :description, label: { text: "Notification summary <span class=\"govuk-body-s\">(optional)</span>".html_safe, size: "m" }, hint: { text: "The notification summary provides a clear, concise overview to help users unfamiliar with the notification's details understand it better." }, max_chars: 10_000 %>
+          <%= f.govuk_collection_radio_buttons :reported_reason, reported_reason_options, :id, :name, :description, legend: { text: "Why are you creating the notification?" }, bold_labels: false %>
+          <%= f.govuk_submit "Save and continue" do %>
+            <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -826,6 +826,14 @@ en:
           attributes:
             agree:
               accepted: You must agree to the declaration to use this service
+        change_notification_details_form:
+          attributes:
+            user_title:
+              blank: Enter a notification title
+            description:
+              too_long: The notification description must be %{count} characters or less
+            reported_reason:
+              blank: Choose why you are creating the notification
 
   activerecord:
     models:

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
   end
 
-  scenario "Adding an existing product" do
+  scenario "Creating a notification with the normal flow" do
     visit "/notifications/create"
 
     expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
@@ -82,5 +82,15 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_button "Select", match: :first
 
     expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
+
+    click_link "Add notification details"
+    fill_in "Notification title", with: "Fake name"
+    fill_in "Notification summary", with: "This is a fake summary"
+    within_fieldset("Why are you creating the notification?") do
+      choose "A product is unsafe or non-compliant"
+    end
+    click_button "Save as draft"
+
+    expect(page).to have_selector(:id, "task-list-1-0-status", text: "Completed")
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2012

## Description

Adds the “add notification details” task.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-01-08 at 11 51 22](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/08910fc1-3847-480d-8dcd-a102c76538b5)

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
