### PR TITLE
Replace summary lists

### DIFF
--- a/List.txt
+++ b/List.txt
@@ -1,9 +1,0 @@
-govukCheckboxes
-govukDateInput
-govukErrorSummary
-govukFileUpload
-govukInput
-govukRadios
-govukSelect
-govukSummaryList
-govukTextarea

--- a/app/decorators/investigation/allegation_decorator.rb
+++ b/app/decorators/investigation/allegation_decorator.rb
@@ -11,10 +11,6 @@ class Investigation < ApplicationRecord
       title.presence || "Untitled notification"
     end
 
-    def display_product_summary_list?
-      true
-    end
-
   private
 
     def compliance_line

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -10,26 +10,8 @@ class InvestigationDecorator < ApplicationDecorator
     user_title || complainant_reference || pretty_id
   end
 
-  def display_product_summary_list?
-    products.any?
-  end
-
   def risk_assessment_risk_levels
     risk_assessments.collect(&:risk_level_description).uniq
-  end
-
-  def product_summary_list
-    products_details = [products.count, "product".pluralize(products.count), "added"].join(" ")
-    rows = [
-      category.present? ? { key: { text: "Category" }, value: { text: category } } : nil,
-      {
-        key: { text: "Product details" },
-        value: { text: products_details },
-        actions: { items: [href: h.investigation_products_path(object), visually_hidden_text: "product details", text: "View"] }
-      },
-    ]
-    rows.compact!
-    h.govukSummaryList rows:, classes: "govuk-summary-list--no-border"
   end
 
   def risk_level_set?
@@ -65,9 +47,8 @@ class InvestigationDecorator < ApplicationDecorator
       values << { text: object.owner_team&.name || "&ndash;".html_safe }
     end
 
-    tag_class_name = is_closed? ? "opss-tag--risk3" : "opss-tag--plain"
-    action = h.tag.span("Notification #{status}", class: "opss-tag #{tag_class_name}")
-    values << { html: h.tag.dd(action, class: "govuk-summary-list__actions") }
+    values << { text: is_closed? ? "Closed (#{date_closed.to_formatted_s(:govuk)})" : "Open" }
+
     values
   end
 
@@ -84,7 +65,7 @@ class InvestigationDecorator < ApplicationDecorator
 
     rows.compact!
 
-    h.govukSummaryList rows:, classes: "govuk-summary-list govuk-summary-list--no-border opss-summary-list-mixed opss-summary-list-mixed--narrow-dt"
+    h.govuk_summary_list(rows:, borders: false, classes: "opss-summary-list-mixed opss-summary-list-mixed--narrow-dt")
   end
 
   def contact_details_list

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -47,7 +47,7 @@ class InvestigationDecorator < ApplicationDecorator
       values << { text: object.owner_team&.name || "&ndash;".html_safe }
     end
 
-    values << { text: is_closed? ? "Closed (#{date_closed.to_formatted_s(:govuk)})" : "Open" }
+    values << { text: status }
 
     values
   end

--- a/app/decorators/investigation_product_decorator.rb
+++ b/app/decorators/investigation_product_decorator.rb
@@ -10,8 +10,7 @@ class InvestigationProductDecorator < Draper::Decorator
   end
 
   def product_overview_summary_list
-    h.govukSummaryList(
-      classes: "govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4 opss-summary-list-mixed opss-summary-list-mixed--compact",
+    h.govuk_summary_list(
       rows: [
         {
           key: { text: "Last updated" },
@@ -23,9 +22,11 @@ class InvestigationProductDecorator < Draper::Decorator
         },
         {
           key: { text: "Product record owner" },
-          value: { html: owning_team_link }
+          value: { text: owning_team_link }
         }
-      ]
+      ],
+      borders: false,
+      classes: "govuk-!-margin-bottom-4 opss-summary-list-mixed opss-summary-list-mixed--compact"
     )
   end
 

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -143,14 +143,11 @@ class ProductDecorator < ApplicationDecorator
     unless product.retired?
       rows << {
         key: { text: "Product record owner" },
-        value: { html: owning_team_link }
+        value: { text: owning_team_link }
       }
     end
 
-    h.govukSummaryList(
-      classes: "govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4 opss-summary-list-mixed opss-summary-list-mixed--compact",
-      rows:
-    )
+    h.govuk_summary_list(rows:, borders: false, classes: "govuk-!-margin-bottom-4 opss-summary-list-mixed opss-summary-list-mixed--compact")
   end
 
   def product_name_with_cases
@@ -170,9 +167,6 @@ class ProductDecorator < ApplicationDecorator
       end
     end
 
-    h.govukSummaryList(
-      classes: "govuk-summary-list govuk-summary-list--no-border",
-      rows:
-    )
+    h.govuk_summary_list(rows:, borders: false)
   end
 end

--- a/app/helpers/investigations/accident_or_incidents_helper.rb
+++ b/app/helpers/investigations/accident_or_incidents_helper.rb
@@ -3,13 +3,13 @@ module Investigations
     def accident_or_incident_summary_list_rows(accident_or_incident)
       rows = [
         { key: { text: "Date of #{accident_or_incident.type.downcase}" }, value: { text: accident_or_incident.date_of_activity } },
-        { key: { text: "Product" },          value: { text: "#{accident_or_incident.investigation_product.name} (#{accident_or_incident.investigation_product.psd_ref})" } },
-        { key: { text: "Severity" },         value: { text: accident_or_incident.severity } },
-        { key: { text: "Product usage" },    value: { html: accident_or_incident.usage } }
+        { key: { text: "Product" }, value: { text: "#{accident_or_incident.investigation_product.name} (#{accident_or_incident.investigation_product.psd_ref})" } },
+        { key: { text: "Severity" }, value: { text: accident_or_incident.severity } },
+        { key: { text: "Product usage" }, value: { text: accident_or_incident.usage } }
       ]
 
       if accident_or_incident.additional_info.present?
-        rows << { key: { text: "Additional Information" },  value: { html: accident_or_incident.additional_info } }
+        rows << { key: { text: "Additional Information" }, value: { text: accident_or_incident.additional_info } }
       end
 
       rows

--- a/app/helpers/investigations/corrective_actions_helper.rb
+++ b/app/helpers/investigations/corrective_actions_helper.rb
@@ -7,15 +7,15 @@ module Investigations
       rows = [
         { key: { text: "Action" }, value: { text: action_text_for(corrective_action) } },
         { key: { text: "Event date" }, value: { text: corrective_action.date_of_activity } },
-        { key: { text: "Legislation" },               value: { text: corrective_action.legislation } },
-        { key: { text: "Product" },                   value: { text: "#{corrective_action.investigation_product.name} (#{corrective_action.investigation_product.psd_ref})" } },
-        { key: { text: "Business" },                  value: { html: business_text_for(corrective_action) } },
-        { key: { text: "Recall information" },        value: { html: recall_information } }
+        { key: { text: "Legislation" }, value: { text: corrective_action.legislation } },
+        { key: { text: "Product" }, value: { text: "#{corrective_action.investigation_product.name} (#{corrective_action.investigation_product.psd_ref})" } },
+        { key: { text: "Business" }, value: { text: business_text_for(corrective_action) } },
+        { key: { text: "Recall information" }, value: { text: recall_information } }
       ]
-      rows << { key: { text: "Type of action" },      value: { text: corrective_action.measure_type } } if corrective_action.measure_type.present?
+      rows << { key: { text: "Type of action" }, value: { text: corrective_action.measure_type } } if corrective_action.measure_type.present?
       rows << { key: { text: "Duration of measure" }, value: { text: corrective_action.duration } }
-      rows << { key: { text: "Geographic scopes" },   value: { text: corrective_action.geographic_scopes } }
-      rows << { key: { text: "Other details" },       value: { text: corrective_action.details } } if corrective_action.details.present?
+      rows << { key: { text: "Geographic scopes" }, value: { text: corrective_action.geographic_scopes } }
+      rows << { key: { text: "Other details" }, value: { text: corrective_action.details } } if corrective_action.details.present?
 
       rows
     end

--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -206,7 +206,7 @@ module Investigations::DisplayTextHelper
     # TODO: PSD-693 Add primary authorities to businesses
     # { key: { text: 'Primary authority' }, value: { text: 'Suffolk Trading Standards' } }
 
-    govukSummaryList rows:
+    govuk_summary_list(rows:)
   end
 
   def correspondence_summary_list(correspondence, attachments: nil)
@@ -218,7 +218,7 @@ module Investigations::DisplayTextHelper
       { key: { text: "Attachments" }, value: { text: attachments } }
     ]
 
-    govukSummaryList rows:
+    govuk_summary_list(rows:)
   end
 
   def report_summary_list(investigation)
@@ -235,6 +235,6 @@ module Investigations::DisplayTextHelper
       rows << { key: { text: "Hazard type" }, value: { text: investigation.hazard_type } }
     end
 
-    govukSummaryList rows:
+    govuk_summary_list(rows:)
   end
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -487,24 +487,24 @@ module InvestigationsHelper
   def investigation_product_rows(investigation_product = nil, user = nil)
     [
       {
-        key: { html: "<span id='case_batch_numbers_#{investigation_product&.id}'>Batch numbers</span>".html_safe },
+        key: { text: "<span id='case_batch_numbers_#{investigation_product&.id}'>Batch numbers</span>".html_safe },
         value: { text: investigation_product&.batch_number || "" },
         actions: batch_number_actions(investigation_product, user)
       },
       {
-        key: { html: "<span id='case_customs_codes_#{investigation_product&.id}'>Customs codes</span>".html_safe },
+        key: { text: "<span id='case_customs_codes_#{investigation_product&.id}'>Customs codes</span>".html_safe },
         value: { text: investigation_product&.customs_code || "" },
         actions: customs_code_actions(investigation_product, user)
       },
       {
-        key: { html: "<span id='case_ucr_numbers_#{investigation_product&.id}'>UCR numbers</span>".html_safe },
+        key: { text: "<span id='case_ucr_numbers_#{investigation_product&.id}'>UCR numbers</span>".html_safe },
         value: {
-          html: ucr_number_unordered_list(investigation_product&.ucr_numbers_list) || ""
+          text: ucr_number_unordered_list(investigation_product&.ucr_numbers_list) || ""
         },
         actions: ucr_numbers_actions(investigation_product, user)
       },
       {
-        key: { html: "<span id='case_units_affected_#{investigation_product&.id}'>Units affected</span>".html_safe },
+        key: { text: "<span id='case_units_affected_#{investigation_product&.id}'>Units affected</span>".html_safe },
         value: units_affected(investigation_product),
         actions: number_of_affected_units_actions(investigation_product, user)
       }
@@ -528,16 +528,16 @@ module InvestigationsHelper
     if investigation_product.number_of_affected_units.blank?
       { text: I18n.t("product.affected_units_status.#{investigation_product.affected_units_status}") }
     else
-      { html: "#{investigation_product.number_of_affected_units} <span class='govuk-!-font-size-16 govuk-!-padding-left-2 opss-secondary-text'>#{I18n.t("product.affected_units_status.#{investigation_product.affected_units_status}")} number</span>".html_safe }
+      { text: "#{investigation_product.number_of_affected_units} <span class='govuk-!-font-size-16 govuk-!-padding-left-2 opss-secondary-text'>#{I18n.t("product.affected_units_status.#{investigation_product.affected_units_status}")} number</span>".html_safe }
     end
   end
 
   def details_for_products_tab(investigation)
-    title_link = link_to investigation.title, investigation_path(investigation), class: "govuk-link govuk-link--no-visited-state"
+    title_link = link_to investigation.title, investigation_path(investigation), class: "govuk-link"
 
     [
       { key: { text: "Notification" }, value: { text: investigation.pretty_id } },
-      { key: { text: "Name" }, value: { html: title_link } },
+      { key: { text: "Name" }, value: { text: title_link } },
       { key: { text: "Team" }, value: { text: investigation.owner_team.name } },
       { key: { text: "Created" }, value: { text: investigation.created_at.to_formatted_s(:govuk) } },
       { key: { text: "Status" }, value: status_value(investigation) }
@@ -819,51 +819,43 @@ private
   end
 
   def batch_number_actions(investigation_product, user)
-    return {} unless investigation_product && policy(investigation_product.investigation).update?(user:)
+    return [] unless investigation_product && policy(investigation_product.investigation).update?(user:)
 
-    {
-      items: [
-        href: edit_investigation_product_batch_numbers_path(investigation_product),
-        text: "Edit",
-        visuallyHiddenText: "  the batch numbers for #{investigation_product.name}"
-      ]
-    }
+    [
+      href: edit_investigation_product_batch_numbers_path(investigation_product),
+      text: "Edit",
+      visually_hidden_text: "the batch numbers for #{investigation_product.name}"
+    ]
   end
 
   def customs_code_actions(investigation_product, user)
-    return {} unless investigation_product && policy(investigation_product.investigation).update?(user:)
+    return [] unless investigation_product && policy(investigation_product.investigation).update?(user:)
 
-    {
-      items: [
-        href: edit_investigation_product_customs_code_path(investigation_product),
-        text: "Edit",
-        visuallyHiddenText: "  the customs codes for #{investigation_product.name}"
-      ]
-    }
+    [
+      href: edit_investigation_product_customs_code_path(investigation_product),
+      text: "Edit",
+      visually_hidden_text: "the customs codes for #{investigation_product.name}"
+    ]
   end
 
   def ucr_numbers_actions(investigation_product, user)
-    return {} unless investigation_product && policy(investigation_product.investigation).update?(user:)
+    return [] unless investigation_product && policy(investigation_product.investigation).update?(user:)
 
-    {
-      items: [
-        href: edit_investigation_product_ucr_numbers_path(investigation_product),
-        text: "Edit",
-        visuallyHiddenText: "  the UCR numbers for #{investigation_product.name}"
-      ]
-    }
+    [
+      href: edit_investigation_product_ucr_numbers_path(investigation_product),
+      text: "Edit",
+      visually_hidden_text: "the UCR numbers for #{investigation_product.name}"
+    ]
   end
 
   def number_of_affected_units_actions(investigation_product, user)
-    return {} unless investigation_product && policy(investigation_product.investigation).update?(user:)
+    return [] unless investigation_product && policy(investigation_product.investigation).update?(user:)
 
-    {
-      items: [
-        href: edit_investigation_product_number_of_affected_units_path(investigation_product),
-        text: "Edit",
-        visuallyHiddenText: " the units affected for #{investigation_product.name}"
-      ]
-    }
+    [
+      href: edit_investigation_product_number_of_affected_units_path(investigation_product),
+      text: "Edit",
+      visually_hidden_text: "the units affected for #{investigation_product.name}"
+    ]
   end
 
   def risk_validation_actions(investigation, user)

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -18,7 +18,7 @@ module TestsHelper
     if test_result.tso_certificate_issue_date.present?
       rows << {
         key: { text: "Funded" },
-        value: { html: I18n.t("test_results.opss_funded.yes_html").html_safe }
+        value: { text: I18n.t("test_results.opss_funded.yes_html").html_safe }
       }
       rows << {
         key: { text: "Sample number" },

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -2,23 +2,19 @@
 <% page_title title %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-
     <h1 class="govuk-heading-l"><%= title %></h1>
-
-    <%= govukSummaryList(
+    <%= govuk_summary_list(
       rows: [
         {
           key: { text: "Name" },
           value: { text: current_user.name },
-          actions: {
-            items: [
-              {
-                href: account_name_path,
-                text: "Change",
-                visuallyHiddenText: "name"
-              }
-            ]
-          }
+          actions: [
+            {
+              href: account_name_path,
+              text: "Change",
+              visually_hidden_text: "name"
+            }
+          ]
         },
         {
           key: { text: "Email address" },
@@ -38,7 +34,6 @@
         }
       ]
     ) %>
-
     <div class="govuk-inset-text">
       If you need to change your details, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
     </div>

--- a/app/views/document_uploads/show.html.erb
+++ b/app/views/document_uploads/show.html.erb
@@ -40,11 +40,10 @@
           },
           value: {
             text: @document_upload.created_at.to_formatted_s(:govuk)
-
           }
         }
       ] %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
 
     <% if documentable_policy(@parent).update? %>
       <p class="govuk-body"><%= link_to "Edit attachment", edit_associated_document_upload_path(@parent, @document_upload), class: "govuk-link" %></p>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -40,11 +40,10 @@
           },
           value: {
             text: @file.date_added
-
           }
         }
       ] %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
 
     <% if documentable_policy(@parent).update? %>
       <p class="govuk-body"><%= link_to "Edit attachment", edit_investigation_document_path(@parent, @file), class: "govuk-link" %></p>

--- a/app/views/image_uploads/show.html.erb
+++ b/app/views/image_uploads/show.html.erb
@@ -32,11 +32,10 @@
           },
           value: {
             text: @image_upload.created_at.to_formatted_s(:govuk)
-
           }
         }
       ] %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
 
     <% if imageable_policy(@parent).remove? %>
       <p class="govuk-body"><%= link_to "Remove image", remove_associated_image_upload_path(@parent, @image_upload), class: "govuk-link" %></p>

--- a/app/views/investigations/accident_or_incidents/show.html.erb
+++ b/app/views/investigations/accident_or_incidents/show.html.erb
@@ -9,7 +9,7 @@
       </p>
     </div>
 
-    <%= govukSummaryList(rows: accident_or_incident_summary_list_rows(@accident_or_incident)) %>
+    <%= govuk_summary_list(rows: accident_or_incident_summary_list_rows(@accident_or_incident)) %>
 
     <% if policy(@investigation).update? %>
       <p class="govuk-body"><%= link_to "Edit #{@accident_or_incident.type.downcase}", edit_investigation_accident_or_incident_path(@investigation, @accident_or_incident), class: "govuk-link" %></p>

--- a/app/views/investigations/corrective_actions/show.html.erb
+++ b/app/views/investigations/corrective_actions/show.html.erb
@@ -12,7 +12,7 @@
       </p>
     </div>
 
-    <%= govukSummaryList(rows: corrective_action_summary_list_rows(@corrective_action)) %>
+    <%= govuk_summary_list(rows: corrective_action_summary_list_rows(@corrective_action)) %>
 
     <% if policy(@investigation).update? %>
       <p class="govuk-body"><%= link_to "Edit corrective action", edit_investigation_corrective_action_path(@investigation, @corrective_action), class: "govuk-link" %></p>

--- a/app/views/investigations/emails/show.html.erb
+++ b/app/views/investigations/emails/show.html.erb
@@ -58,7 +58,7 @@
         }
       end
     %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
     <% if policy(@investigation).update? %>
       <p class="govuk-body"><%= link_to "Edit email", edit_investigation_email_path(@investigation, @email), class: "govuk-link" %></p>
     <% end %>

--- a/app/views/investigations/meetings/show.html.erb
+++ b/app/views/investigations/meetings/show.html.erb
@@ -39,7 +39,7 @@
         }
       end
     %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
   </div>
 
   <% if @meeting.related_attachment.attached? %>

--- a/app/views/investigations/phone_calls/show.html.erb
+++ b/app/views/investigations/phone_calls/show.html.erb
@@ -39,7 +39,7 @@
       end
 
     %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
     <%= link_to_if policy(@investigation).update?, "Edit phone call", edit_investigation_phone_call_path(@investigation, @phone_call), class: "govuk-link" %>
   </div>
 </div>

--- a/app/views/investigations/products/confirm.html.erb
+++ b/app/views/investigations/products/confirm.html.erb
@@ -14,11 +14,11 @@
             <section class="govuk-grid-column-three-quarters opss-panels">
               <div class="opss-panels__single">
                 <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><%= @product.name_with_brand %></h2>
-                <%= govukSummaryList(
-                  classes: "govuk-summary-list--no-border govuk-!-margin-bottom-6",
+                <%= govuk_summary_list(
+                  borders: false,
                   rows: [
                     {
-                      key: { html: "#{psd_abbr title: false} <span title=\"reference\">ref</span>".html_safe },
+                      key: { text: "#{psd_abbr title: false} <span title=\"reference\">ref</span>".html_safe },
                       value: { text: @product.psd_ref }
                     },
                     {
@@ -35,7 +35,7 @@
                     },
                     {
                       key: { text: "Counterfeit" },
-                      value: { html: render("product_authenticity", authenticity: @product.object.authenticity) }
+                      value: { text: render("product_authenticity", authenticity: @product.object.authenticity) }
                     }
                   ]
                 ) %>

--- a/app/views/investigations/risk_assessments/show.html.erb
+++ b/app/views/investigations/risk_assessments/show.html.erb
@@ -55,7 +55,7 @@
         } %>
       <% end %>
 
-    <%= govukSummaryList(rows: rows) %>
+    <%= govuk_summary_list(rows:) %>
 
     <% if policy(@investigation).update? %>
       <p class="govuk-body"><%= link_to "Edit risk assessment", edit_investigation_risk_assessment_path(@investigation, @risk_assessment), class: "govuk-link" %></p>

--- a/app/views/investigations/tabs/_overview.html.erb
+++ b/app/views/investigations/tabs/_overview.html.erb
@@ -27,10 +27,7 @@
     Edit<span class="govuk-visually-hidden"> the safety and compliance</span>
   </a>
 <% end %>
-<%= govukSummaryList(
-  classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--narrow-actions",
-  rows: safety_and_compliance_rows(@investigation)
-) %>
+<%= govuk_summary_list(rows: safety_and_compliance_rows(@investigation)) %>
 
 <h3 id="product-info-1" class="govuk-heading-m govuk-!-margin-top-9">
   Notification specific product information
@@ -41,19 +38,15 @@
     You can add this information after a product has been added to the notification.
   </h4>
 
-  <%= govukSummaryList(
-    classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--narrow-actions",
-    rows: investigation_product_rows
-  ) %>
+  <%= govuk_summary_list(rows: investigation_product_rows) %>
 <% else %>
   <% @investigation.investigation_products.each_with_index do |investigation_product, index| %>
     <h4 class="govuk-body govuk-!-font-weight-regular govuk-!-margin-bottom-1 opss-secondary-text">
       <%= investigation_product.name %> (<%= investigation_product.product.paper_trail.version_at(investigation_product.investigation_closed_at).psd_ref(timestamp: investigation_product.investigation_closed_at.to_i, investigation_was_closed: investigation_product.investigation_closed_at.present?) %>)
     </h4>
-    <%= govukSummaryList(
-      classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--narrow-actions",
+    <%= govuk_summary_list(
       rows: investigation_product_rows(investigation_product.decorate, current_user),
-      attributes: {
+      html_attributes: {
         id: "product-#{index}"
       }
     ) %>

--- a/app/views/investigations/test_results/show.html.erb
+++ b/app/views/investigations/test_results/show.html.erb
@@ -9,7 +9,7 @@
       <p class="govuk-body govuk-hint">Added <%= @test_result.date_added %></p>
     </div>
 
-    <%= govukSummaryList(rows: test_result_summary_rows(@test_result)) %>
+    <%= govuk_summary_list(rows: test_result_summary_rows(@test_result)) %>
 
     <% if policy(@investigation).update? %>
       <p class="govuk-body"><%= link_to "Edit test result", edit_investigation_test_result_path(@investigation, @test_result), class: "govuk-link" %></p>

--- a/app/views/products/_cases.html.erb
+++ b/app/views/products/_cases.html.erb
@@ -5,11 +5,9 @@
     </p>
   </div>
 </div>
-
 <% if @product.investigations.any? %>
   <% rows = @product.investigations.uniq.map do |investigation| %>
-    <% { key: { text: investigation.case_title_key(@current_user) }, values: investigation.case_summary_values } %>
+    <% [investigation.case_title_key(@current_user), *investigation.case_summary_values] %>
   <% end %>
-
-  <%= govukSummaryList(rows: rows, classes: "govuk-summary-list opss-summary-list-mixed opss-summary-list-mixed--sm-font opss-summary-list-mixed--4-cols capy-cases") %>
+  <%= govuk_table(head: ["Notification name", "Notification number", "Notification owner", "Status"], rows:) %>
 <% end %>

--- a/app/views/products/_images.html.erb
+++ b/app/views/products/_images.html.erb
@@ -21,7 +21,7 @@
   <ul class="govuk-list govuk-!-margin-top-6">
     <% @product.virus_free_images.each do |image| %>
       <li>
-        <%= govukSummaryList classes: "govuk-!-padding-bottom-9 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt opss-summary-list-mixed--image opss-summary-list-mixed--sm-font", rows: [
+        <%= govuk_summary_list(rows: [
           {
             key: { text: "Image" },
             value: { text: product_image_preview(image, [400, 400]) },
@@ -30,16 +30,16 @@
             key: { text: "Updated" },
             value: { text: image_upload_updated_date_in_govuk_format(image) },
           }
-        ] %>
-        <div class="opss-text-align-right govuk-!-margin-bottom-8">
-          <ul class="govuk-list">
-            <% if imageable_policy(@product).destroy? %>
+        ], classes: "opss-summary-list-mixed opss-summary-list-mixed--image") %>
+        <% if imageable_policy(@product).destroy? %>
+          <div class="opss-text-align-right govuk-!-margin-bottom-8">
+            <ul class="govuk-list">
               <li class="govuk-!-display-inline govuk-!-margin-left-2">
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16 opss-text-underline-offset" href="<%= remove_product_image_upload_path(@product, image) %>">Remove this image</a>
               </li>
-            <% end %>
-          </ul>
-        </div>
+            </ul>
+          </div>
+        <% end %>
       </li>
 
     <% end %>

--- a/app/views/products/_owner_contact_details.html.erb
+++ b/app/views/products/_owner_contact_details.html.erb
@@ -14,7 +14,7 @@
 <%
   date_case_closed = local_assigns[:investigation_closed_at]
   psd_ref = date_case_closed.present? ? product.psd_ref(timestamp: date_case_closed.to_i, investigation_was_closed: true) : product.psd_ref
-  summary_rows = [
+  rows = [
     {
       key: { text: "Product record" },
       value: { text: psd_ref }
@@ -29,10 +29,10 @@
     }
   ]
   if contact_html.present?
-    summary_rows << {
+    rows << {
       key: { text: "Contact details" },
-      value: { html: contact_html }
+      value: { text: contact_html }
     }
   end
 %>
-<%= govukSummaryList rows: summary_rows %>
+<%= govuk_summary_list(rows:) %>

--- a/app/views/products/case_product_info_tabs/_cases.html.erb
+++ b/app/views/products/case_product_info_tabs/_cases.html.erb
@@ -6,9 +6,5 @@
   <p class="govuk-body-s govuk-!-margin-bottom-7 opss-secondary-text">The original product record was or is also included in these <%= unique_investigations.count %> notifications.</p>
 <% end %>
 <% unique_investigations.each do |investigation| %>
-  <%= govukSummaryList(
-    classes: "govuk-summary-list govuk-!-padding-bottom-6 opss-summary-list-mixed opss-summary-list-mixed--narrow-dt",
-    rows: details_for_products_tab(investigation.decorate)
-    )
-  %>
+  <%= govuk_summary_list(rows: details_for_products_tab(investigation.decorate)) %>
 <% end %>

--- a/spec/decorators/investigation/allegation_decorator_spec.rb
+++ b/spec/decorators/investigation/allegation_decorator_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Investigation::AllegationDecorator, :with_stubbed_mailer do
 
   let(:allegation) { create(:allegation, :reported_unsafe, user_title: "inputted user_title") }
 
-  describe "#display_product_summary_list?" do
-    it { is_expected.to be_display_product_summary_list }
-  end
-
   describe "#title" do
     context "when investigation has a user_title" do
       it "shows user_title" do

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -26,20 +26,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_mailer do
     create(:complainant, investigation: notification)
   end
 
-  describe "#display_product_summary_list?" do
-    let(:notification) { create(:enquiry) }
-
-    context "with no product" do
-      it { is_expected.not_to be_display_product_summary_list }
-    end
-
-    context "with products" do
-      before { notification.products << create(:product) }
-
-      it { is_expected.to be_display_product_summary_list }
-    end
-  end
-
   describe "#risk_level_description" do
     let(:risk_level_description) { decorated_notification.risk_level_description }
 
@@ -64,56 +50,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_mailer do
 
       it "displays 'Not set'" do
         expect(risk_level_description).to eq "Not set"
-      end
-    end
-  end
-
-  describe "#product_summary_list" do
-    let(:product_summary_list) { decorated_notification.product_summary_list }
-    let(:products) { create_list(:product, 2) }
-
-    it "displays the product details" do
-      expect(product_summary_list).to summarise("Product details", text: "2 products added")
-    end
-
-    it "displays the categories" do
-      notification.products.each do |product|
-        expect(product_summary_list).to summarise("Category", text: /#{Regexp.escape(product.category)}/i)
-      end
-    end
-
-    context "with two products of the same category" do
-      let(:washing_machine) { build(:product_washing_machine) }
-      let(:iphone_3g)       { build(:product_iphone_3g) }
-      let(:iphone)          { build(:product_iphone)  }
-      let(:samsung)         { build(:product_samsung) }
-      let(:products_list)   { [iphone_3g, samsung] }
-
-      before do
-        notification.assign_attributes(
-          product_category: iphone_3g.category,
-          products: products_list
-        )
-      end
-
-      it "displays the only category present a paragraphe" do
-        random_product_category = notification.products.sample.category
-        expect(Capybara.string(product_summary_list))
-          .to have_css("dd.govuk-summary-list__value p.govuk-body", text: random_product_category.upcase_first)
-      end
-
-      context "with two products on different categories" do
-        let(:products_list) { [iphone, washing_machine] }
-
-        it "displays the first product category" do
-          expect(Capybara.string(product_summary_list))
-            .to have_css("dd.govuk-summary-list__value ul.govuk-list li", text: iphone_3g.category.upcase_first)
-        end
-
-        it "displays the second product category" do
-          expect(Capybara.string(product_summary_list))
-            .to have_css("dd.govuk-summary-list__value ul.govuk-list li", text: iphone.category.upcase_first)
-        end
       end
     end
   end
@@ -252,7 +188,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_mailer do
   describe "#case_summary_values" do
     let(:case_summary_values) { decorated_notification.case_summary_values }
     let(:text_values) { case_summary_values.pluck(:text).compact }
-    let(:html_value) { case_summary_values.pluck(:html).compact.join }
+    let(:html_value) { case_summary_values.pluck(:text).compact.join }
 
     context "with unrestricted case" do
       let(:notification) { create(:allegation, is_closed: true) }

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Products listing", :with_stubbed_mailer, type: :feature do
       visit "/products/#{iphone.id}"
       expect(page).to have_text("This product record has been added to 1 notification")
 
-      within ".capy-cases" do
+      within "#notifications-1-section" do
         expect(page).to have_link(investigation.title, href: "/cases/#{investigation.pretty_id}")
         expect(page).to have_css("dd", text: investigation.pretty_id)
         expect(page).to have_css("dd", text: investigation.owner_team.name)
@@ -91,7 +91,7 @@ RSpec.feature "Products listing", :with_stubbed_mailer, type: :feature do
 
       expect(page).to have_text("This product record has been added to 1 notification")
 
-      within ".capy-cases" do
+      within "#notifications-1-section" do
         expect(page).to have_css("dt", text: "Notification restricted")
         expect(page).not_to have_css("dd", text: investigation.pretty_id)
         expect(page).not_to have_css("dd", text: investigation.owner_team.name)

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -92,9 +92,9 @@ RSpec.feature "Products listing", :with_stubbed_mailer, type: :feature do
       expect(page).to have_text("This product record has been added to 1 notification")
 
       within "#notifications-1-section" do
-        expect(page).to have_css("dt", text: "Notification restricted")
-        expect(page).not_to have_css("dd", text: investigation.pretty_id)
-        expect(page).not_to have_css("dd", text: investigation.owner_team.name)
+        expect(page).to have_css("td", text: "Notification restricted")
+        expect(page).not_to have_css("td", text: investigation.pretty_id)
+        expect(page).not_to have_css("td", text: investigation.owner_team.name)
       end
     end
 

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature "Products listing", :with_stubbed_mailer, type: :feature do
 
       within "#notifications-1-section" do
         expect(page).to have_link(investigation.title, href: "/cases/#{investigation.pretty_id}")
-        expect(page).to have_css("dd", text: investigation.pretty_id)
-        expect(page).to have_css("dd", text: investigation.owner_team.name)
+        expect(page).to have_css("td", text: investigation.pretty_id)
+        expect(page).to have_css("td", text: investigation.owner_team.name)
       end
       investigation.update!(is_private: true)
       visit "/products/#{iphone.id}"

--- a/spec/helpers/investigations/corrective_actions_helper_spec.rb
+++ b/spec/helpers/investigations/corrective_actions_helper_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
       [
         { key: { text: "Event date" }, value: { text: corrective_action.date_of_activity } },
         { key: { text: "Legislation" }, value: { text: corrective_action.legislation } },
-        { key: { text: "Recall information" }, value: { html: match(expected_online_recall_information) } },
+        { key: { text: "Recall information" }, value: { text: match(expected_online_recall_information) } },
         { key: { text: "Product" }, value: { text: "#{corrective_action.investigation_product.name} (#{corrective_action.investigation_product.psd_ref})" } },
-        { key: { text: "Business" }, value: { html: helper.link_to(corrective_action.business.trading_name, helper.business_path(corrective_action.business)) } },
+        { key: { text: "Business" }, value: { text: helper.link_to(corrective_action.business.trading_name, helper.business_path(corrective_action.business)) } },
         { key: { text: "Type of action" }, value: { text: corrective_action.measure_type.upcase_first } },
         { key: { text: "Duration of measure" }, value: { text: corrective_action.duration.upcase_first } },
         { key: { text: "Geographic scopes" }, value: { text: corrective_action.geographic_scopes } }
@@ -29,7 +29,7 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
       let(:business) { nil }
 
       it "does not link to the business" do
-        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Business" }, value: { html: "Not specified" })
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Business" }, value: { text: "Not specified" })
       end
     end
 
@@ -54,21 +54,21 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
         before { corrective_action.update!(online_recall_information: "something other than a url") }
 
         it "displays online recall info" do
-          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: expected_online_recall_information.to_s })
+          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: expected_online_recall_information.to_s })
         end
 
         it "does not link to the recall information" do
-          expect(helper.corrective_action_summary_list_rows(corrective_action)).not_to include(key: { text: "Recall information" }, value: { html: /href/ })
+          expect(helper.corrective_action_summary_list_rows(corrective_action)).not_to include(key: { text: "Recall information" }, value: { text: /href/ })
         end
       end
 
       context "when online_recall_information is a url" do
         it "displays online recall info" do
-          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: /"#{expected_online_recall_information}"/ })
+          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: /"#{expected_online_recall_information}"/ })
         end
 
         it "links to the recall information" do
-          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: /href/ })
+          expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: /href/ })
         end
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
       let(:expected_online_recall_information) { "Not published online" }
 
       it "show the no recall information published online" do
-        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: expected_online_recall_information })
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: expected_online_recall_information })
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
       let(:expected_online_recall_information) { "Not relevant" }
 
       it "shows not relevant" do
-        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: expected_online_recall_information })
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: expected_online_recall_information })
       end
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_mailer do
       let(:has_online_recall_information) { nil }
 
       it "does not show the recall information published online" do
-        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { html: "Not provided" })
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Recall information" }, value: { text: "Not provided" })
       end
     end
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2172

## Description

Replaces summary lists with the standard summary list component or tables where necessary.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2822.london.cloudapps.digital/
https://psd-pr-2822-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
