### PR TITLE
Remove unnecessary form attributes

### DIFF
--- a/app/views/businesses/contacts/edit.html.erb
+++ b/app/views/businesses/contacts/edit.html.erb
@@ -1,7 +1,7 @@
 <%= page_title "Edit contact", errors: @contact.errors.any? %>
 <h1 class="govuk-heading-l">Edit contact</h1>
 
-<%= form_with(model: @contact, url: business_contact_path(@business, @contact), local: true) do |form| %>
+<%= form_with(model: @contact, url: business_contact_path(@business, @contact)) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/businesses/contacts/new.html.erb
+++ b/app/views/businesses/contacts/new.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Add contact", errors: @contact.errors.any? %>
 <h1 class="govuk-heading-l">Add contact</h1>
 
-<%= form_with(model: @contact, url: business_contacts_path(@business), local: true) do |form| %>
+<%= form_with(model: @contact, url: business_contacts_path(@business)) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/businesses/contacts/remove.html.erb
+++ b/app/views/businesses/contacts/remove.html.erb
@@ -34,6 +34,6 @@
   </div>
 </div>
 
-<%= form_with url: business_contact_path(@business, @contact), method: :delete, local: true do |form| %>
+<%= form_with url: business_contact_path(@business, @contact), method: :delete do |form| %>
   <%= govukButton text: "Remove contact", classes: "govuk-button govuk-button--warning" %>
 <% end %>

--- a/app/views/businesses/edit.html.erb
+++ b/app/views/businesses/edit.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<%= form_with(model: @business, local: true, html: { autocomplete: :off, novalidate: true }) do |form| %>
+<%= form_with(model: @business, html: { autocomplete: :off }) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= govukErrorSummary form: form %>

--- a/app/views/businesses/index.html.erb
+++ b/app/views/businesses/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "businesses/heading/#{@page_name}", count: @count %>
 
-<%= form_with(model: @search, scope: "", url: businesses_path, method: :get, local: true, html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: businesses_path, method: :get, html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
 
     <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">

--- a/app/views/businesses/locations/edit.html.erb
+++ b/app/views/businesses/locations/edit.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Edit location", errors: @location.errors.any? %>
-<%= form_with(model: @location, url: business_location_path(@business, @location), local: true) do |form| %>
+<%= form_with(model: @location, url: business_location_path(@business, @location)) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/businesses/locations/new.html.erb
+++ b/app/views/businesses/locations/new.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Add location", errors: @location.errors.any? %>
-<%= form_with(model: @location, url: business_locations_path(@business), local: true) do |form| %>
+<%= form_with(model: @location, url: business_locations_path(@business)) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/businesses/locations/remove.html.erb
+++ b/app/views/businesses/locations/remove.html.erb
@@ -26,7 +26,7 @@
       </tbody>
     </table>
 
-    <%= form_with url: business_location_path(@business, @location), method: :delete, local: true do |form| %>
+    <%= form_with url: business_location_path(@business, @location), method: :delete do |form| %>
       <%= form.submit "Remove location", class: "govuk-button govuk-button--warning" %>
     <% end %>
   </div>

--- a/app/views/collaborators/edit.html.erb
+++ b/app/views/collaborators/edit.html.erb
@@ -2,93 +2,24 @@
 <% page_title title, errors: @edit_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= error_summary @edit_form.errors %>
-    <h1 class="govuk-heading-l"><%= title %></h1>
-    <%= form_with model: @edit_form, url: investigation_collaborator_path(@investigation, @collaboration), method: :put, local: true do |form| %>
-      <% remove_hint = @investigation.is_private? ? "Will not ordinarily be able to view notification details as it is restricted" :  "Will have default view rights"%>
-      <%= govukRadios(
-        form: form,
-        key: :permission_level,
-        classes: "",
-        fieldset: {
-          legend: {
-            text: "Permission level",
-            is_page_heading: false,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: [
-          {
-            id: "permission_level",
-            text: "View full notification",
-            value: Collaboration::Access::ReadOnly.model_name.human,
-            hint: {
-              text: "View full notification details including correspondence",
-            }
-          },
-          {
-            id: "permission_level_edit",
-            text: "Edit full notification",
-            value: Collaboration::Access::Edit.model_name.human,
-            hint: {
-              text: "View and edit all notification details. Cannot add or remove teams or close the notification.",
-            }
-          },
-          { key: "or", divider: "or" },
-          {
-            id: "permission_level_delete",
-            text: "Remove #{@collaborator.name} from the notification",
-            hint: {
-              text: remove_hint
-            },
-            value: EditNotificationCollaboratorForm::PERMISSION_LEVEL_DELETE
-          }
-        ]
-      ) %>
-
-      <p class="govuk-body">We’ll email <%= @collaborator.name %> to let them know that their permission level has been changed.
-      </p>
-
-      <% message_html = capture do %>
-        <%= govukTextarea(
-          form: form,
-          key: :message,
-          id: "message",
-          label: {
-            text: "Message to the #{@collaborator.name}"
-          },
-          hint: {
-            text: "Message will also be included on the notification timeline"
-          }
-        ) %>
+    <%= form_with model: @edit_form, url: investigation_collaborator_path(@investigation, @collaboration), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
+      <% remove_hint = @investigation.is_private? ? "Will not ordinarily be able to view notification details as it is restricted." :  "Will have default view rights." %>
+      <%= form.govuk_radio_buttons_fieldset(:permission_level, legend: { text: "Permission level" }) do %>
+        <%= form.govuk_radio_button :permission_level, Collaboration::Access::ReadOnly.model_name.human, label: { text: "View full notification" }, hint: { text: "View full notification details including correspondence." }, link_errors: true %>
+        <%= form.govuk_radio_button :permission_level, Collaboration::Access::Edit.model_name.human, label: { text: "Edit full notification" }, hint: { text: "View and edit all notification details. Cannot add or remove teams or close the notification." } %>
+        <%= form.govuk_radio_divider %>
+        <%= form.govuk_radio_button :permission_level, EditNotificationCollaboratorForm::PERMISSION_LEVEL_DELETE, label: { text: "Remove #{@collaborator.name} from the notification" }, hint: { text: remove_hint } %>
       <% end %>
-
-      <%= govukRadios(
-        form: form,
-        key: :include_message,
-        classes: "",
-        fieldset: {
-          legend: {
-            text: "Do you want to include more information?"
-          }
-        },
-        items: [
-          {
-            text: "Yes, add a message",
-            id: "include_message",
-            value: "true",
-            conditional: {
-              html: message_html
-            }
-          },
-          {
-            text: "No",
-            value: "false"
-          }
-        ]
-      ) %>
-
-      <%= govukButton(text: "Update team") %>
+      <p class="govuk-body">We’ll email <%= @collaborator.name %> to let them know that their permission level has been changed.</p>
+      <%= form.govuk_radio_buttons_fieldset(:include_message, legend: { text: "Do you want to include more information?" }) do %>
+        <%= form.govuk_radio_button :include_message, "true", label: { text: "Yes, add a message" }, link_errors: true do %>
+          <%= form.govuk_text_area :message, label: { text: "Message to #{@collaborator.name}" }, hint: { text: "Message will also be included on the notification timeline" } %>
+        <% end %>
+        <%= form.govuk_radio_button :include_message, "false", label: { text: "No" } %>
+      <% end %>
+      <%= form.govuk_submit("Update team") %>
     <% end %>
   </div>
 </div>

--- a/app/views/collaborators/new.html.erb
+++ b/app/views/collaborators/new.html.erb
@@ -2,101 +2,24 @@
 <% page_title title, errors: @form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= error_summary @form.errors %>
-    <h1 class="govuk-heading-l"><%= title %></h1>
-    <%= form_with model: @form, url: investigation_collaborators_path(@investigation), method: :post, local: true do |form| %>
-      <% team_select_items = [{text: "", value: ""}] + @teams.map { |team| { text: team.name, value: team.id, selected: (team.id == @form.team_id) } } %>
-      <% if @form.errors.include?(:team_id) %>
-        <% error_message = { text: @form.errors.full_messages_for(:team_id).first } %>
-      <% end %>
-
-      <%= govukSelect(
-        name: "add_team_to_notification_form[team_id]",
-        id: "team",
-        errorMessage: error_message,
-        items: team_select_items,
-        label: {
-          text: "Choose team",
-          classes: "govuk-label--s"
-        },
-        is_autocomplete: true,
-        show_all_values: true
-      ) %>
-
+    <%= form_with model: @form, url: investigation_collaborators_path(@investigation), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
+      <% team_select_items = [OpenStruct.new(id: "", name: "")] + @teams.map { |team| OpenStruct.new(id: team.id, name: team.name, selected: (team.id == @form.team_id)) } %>
+      <%= form.govuk_collection_select(:team_id, team_select_items, :id, :name, label: { text: "Choose team", size: "s" }) %>
       <p class="govuk-body">We’ll email the team to let them know they’ve been added to the notification.</p>
-
-      <%= govukRadios(
-        form: form,
-        key: :permission_level,
-        classes: "",
-        fieldset: {
-          legend: {
-            text: "Permission level",
-            is_page_heading: false,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: [
-          {
-            id: "permission_level",
-            text: "View full notification",
-            value: Collaboration::Access::ReadOnly.model_name.human,
-            hint: {
-              text: "View full notification details including correspondence",
-            }
-          },
-          {
-            id: "permission_level_edit",
-            text: "Edit full notification",
-            value: Collaboration::Access::Edit.model_name.human,
-            hint: {
-              text: "View and edit all notification details. Cannot add or remove teams or close the notification.",
-            }
-          }
-        ]
-      ) %>
-
-      <% message_html = capture do %>
-        <%= govukTextarea(
-          form: form,
-          key: :message,
-          id: "message",
-          label: {
-            text: "Message to the team"
-          },
-          hint: {
-            text: "Message will also be included on the notification timeline"
-          }
-        ) %>
+      <% permission_level_items = [
+        OpenStruct.new(id: Collaboration::Access::ReadOnly.model_name.human, name: "View full notification", description: "View full notification details including correspondence."),
+        OpenStruct.new(id: Collaboration::Access::Edit.model_name.human, name: "Edit full notification", description: "View and edit all notification details. Cannot add or remove teams or close the notification.")
+      ] %>
+      <%= form.govuk_collection_radio_buttons(:permission_level, permission_level_items, :id, :name, :description, legend: { text: "Permission level" }, bold_labels: false) %>
+      <%= form.govuk_radio_buttons_fieldset(:include_message, legend: { text: "Do you want to include instructions or more information?" }) do %>
+        <%= form.govuk_radio_button :include_message, "true", label: { text: "Yes, add a message" }, link_errors: true do %>
+          <%= form.govuk_text_area :message, label: { text: "Message to the team" }, hint: { text: "Message will also be included on the notification timeline" } %>
+        <% end %>
+        <%= form.govuk_radio_button :include_message, "false", label: { text: "No" } %>
       <% end %>
-
-      <%= govukRadios(
-        form: form,
-        key: :include_message,
-        classes: "",
-        fieldset: {
-          legend: {
-            text: "Do you want to include instructions or more information?"
-          }
-        },
-        items: [
-          {
-            id: "include_message",
-            text: "Yes, add a message",
-            value: "true",
-            conditional: {
-              html: message_html
-            }
-          },
-          {
-            text: "No",
-            value: "false"
-          }
-        ]
-      ) %>
-
-
-      <%= govukButton(text: "Add team to this notification") %>
+      <%= form.govuk_submit("Add team to this notification") %>
     <% end %>
   </div>
 </div>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "Add comment" %>
 <% page_title page_title, errors: @comment_form.errors.any? %>
-<%= form_with model: @comment_form, scope: :comment_form, local: true, builder: ApplicationFormBuilder, method: :post, html: {novalidate: true}, url: investigation_activity_comment_path(@investigation.pretty_id) do |form| %>
+<%= form_with model: @comment_form, scope: :comment_form, builder: ApplicationFormBuilder, method: :post, url: investigation_activity_comment_path(@investigation.pretty_id) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@comment_form.errors)%>

--- a/app/views/document_uploads/edit.html.erb
+++ b/app/views/document_uploads/edit.html.erb
@@ -1,6 +1,6 @@
 <% title = "Edit attachment" %>
 <%= page_title title, errors: @document_upload.errors.any? %>
-<%= form_with model: @document_upload, local: true, builder: ApplicationFormBuilder, html: { novalidate: true }, url: associated_document_upload_path(@parent, @document_upload), method: :patch do |form| %>
+<%= form_with model: @document_upload, builder: ApplicationFormBuilder, url: associated_document_upload_path(@parent, @document_upload), method: :patch do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@document_upload.errors, %i[title description])%>

--- a/app/views/document_uploads/new.html.erb
+++ b/app/views/document_uploads/new.html.erb
@@ -1,6 +1,6 @@
 <% title = "Add attachment" %>
 <%= page_title title, errors: @document_upload.errors.any? %>
-<%= form_with model: @document_upload, local: true, builder: ApplicationFormBuilder, html: { novalidate: true }, url: associated_document_uploads_path(@parent) do |form| %>
+<%= form_with model: @document_upload, builder: ApplicationFormBuilder, url: associated_document_uploads_path(@parent) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@document_upload.errors, %i[file_upload title description])%>

--- a/app/views/document_uploads/remove.html.erb
+++ b/app/views/document_uploads/remove.html.erb
@@ -44,6 +44,6 @@
   </div>
 </div>
 
-<%= form_with url: associated_document_upload_path(@parent, @document_upload), method: :delete, local: true do |form| %>
+<%= form_with url: associated_document_upload_path(@parent, @document_upload), method: :delete do |form| %>
   <%= form.submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
 <% end %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,6 +1,6 @@
 <% title = "Edit attachment" %>
 <% page_title title, errors: @document_form.errors.any? %>
-<%= form_with model: @document_form, scope: :document, local: true, builder: ApplicationFormBuilder, url: associated_document_path(@parent, @file), html: {novalidate: true}, method: :patch do |form| %>
+<%= form_with model: @document_form, scope: :document, builder: ApplicationFormBuilder, url: associated_document_path(@parent, @file), method: :patch do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@document_form.errors, %i[title description])%>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,6 +1,6 @@
 <% title = "Add attachment" %>
 <%= page_title title, errors: @document_form.errors.any? %>
-<%= form_with model: @document_form, scope: :document, local: true, builder: ApplicationFormBuilder, html: {novalidate: true}, url: associated_documents_path(@parent) do |form| %>
+<%= form_with model: @document_form, scope: :document, builder: ApplicationFormBuilder, url: associated_documents_path(@parent) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@document_form.errors, %i[document title description])%>

--- a/app/views/documents/remove.html.erb
+++ b/app/views/documents/remove.html.erb
@@ -43,6 +43,6 @@
   </div>
 </div>
 
-<%= form_with url: associated_document_path(@parent, @file), method: :delete, local: true do |form| %>
+<%= form_with url: associated_document_path(@parent, @file), method: :delete do |form| %>
   <%= form.submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
 <% end %>

--- a/app/views/image_uploads/new.html.erb
+++ b/app/views/image_uploads/new.html.erb
@@ -1,6 +1,6 @@
 <% title = "Add an image" %>
 <%= page_title title, errors: @image_upload.errors.any? %>
-<%= form_with model: @image_upload, local: true, builder: ApplicationFormBuilder, html: { novalidate: true }, url: associated_image_uploads_path(@parent) do |form| %>
+<%= form_with model: @image_upload, builder: ApplicationFormBuilder, url: associated_image_uploads_path(@parent) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@image_upload.errors, %i[file_upload])%>

--- a/app/views/image_uploads/remove.html.erb
+++ b/app/views/image_uploads/remove.html.erb
@@ -30,7 +30,7 @@
   </div>
 </div>
 
-<%= form_with url: associated_image_upload_path(@parent, @image_upload), method: :delete, local: true do |form| %>
+<%= form_with url: associated_image_upload_path(@parent, @image_upload), method: :delete do |form| %>
   <% if params[:multiple] %>
     <input type="hidden" name="multiple" value="true">
     <% (params[:image_upload_id] || []).each do |image_upload_id| %>

--- a/app/views/investigation_products/batch_numbers/edit.html.erb
+++ b/app/views/investigation_products/batch_numbers/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Edit the batch numbers" %>
 <%= page_title page_heading %>
-<%= form_with model: @investigation_product, url: investigation_product_batch_numbers_path, method: :put, local: true do |form| %>
+<%= form_with model: @investigation_product, url: investigation_product_batch_numbers_path, method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% hint_html = capture do %>

--- a/app/views/investigation_products/customs_codes/edit.html.erb
+++ b/app/views/investigation_products/customs_codes/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Edit the customs codes " %>
 <%= page_title page_heading %>
-<%= form_with model: @investigation_product, url: investigation_product_customs_code_path, method: :put, local: true do |form| %>
+<%= form_with model: @investigation_product, url: investigation_product_customs_code_path, method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/investigation_products/number_of_affected_units/edit.html.erb
+++ b/app/views/investigation_products/number_of_affected_units/edit.html.erb
@@ -2,7 +2,7 @@
 <% page_title page_heading, errors: @number_of_affected_units_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @number_of_affected_units_form, url: investigation_product_number_of_affected_units_path, builder: ApplicationFormBuilder, method: :put, html: {novalidate: true}, local: true do |form| %>
+    <%= form_with model: @number_of_affected_units_form, url: investigation_product_number_of_affected_units_path, builder: ApplicationFormBuilder, method: :put do |form| %>
     <%= error_summary @number_of_affected_units_form.errors %>
 
       <% legend = capture do %>

--- a/app/views/investigations/accident_or_incidents/edit.html.erb
+++ b/app/views/investigations/accident_or_incidents/edit.html.erb
@@ -2,7 +2,7 @@
 <% page_title page_heading %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @accident_or_incident_form, local: true,  url: investigation_accident_or_incident_path(@investigation, @accident_or_incident), method: :patch, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
+    <%= form_with(model: @accident_or_incident_form, url: investigation_accident_or_incident_path(@investigation, @accident_or_incident), method: :patch, builder: ApplicationFormBuilder) do |form| %>
       <%= error_summary(@accident_or_incident_form.errors, %i[is_date_known date investigation_product_id usage severity severity_other]) %>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>

--- a/app/views/investigations/accident_or_incidents/new.html.erb
+++ b/app/views/investigations/accident_or_incidents/new.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Record an #{@accident_or_incident_form.type.downcase}" %>
 <%= page_title page_heading, errors: @accident_or_incident_form.errors.any? %>
-<%= form_with model: @accident_or_incident_form, scope: :accident_or_incident_form, local: true, builder: ApplicationFormBuilder, method: :post, html: {novalidate: true}, url: investigation_accident_or_incidents_path(@investigation.pretty_id) do |form| %>
+<%= form_with model: @accident_or_incident_form, scope: :accident_or_incident_form, builder: ApplicationFormBuilder, method: :post, url: investigation_accident_or_incidents_path(@investigation.pretty_id) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@accident_or_incident_form.errors, %i[is_date_known date investigation_product_id usage severity severity_other])%>

--- a/app/views/investigations/accident_or_incidents_type/new.html.erb
+++ b/app/views/investigations/accident_or_incidents_type/new.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Are you recording an accident or incident?" %>
 <% page_title page_heading, errors: @accident_or_incident_type_form.errors.any? %>
-<%= form_with scope: :investigation, model: @accident_or_incident_type_form, url: investigation_accident_or_incidents_type_index_path(@investigation), builder: ApplicationFormBuilder, html: {novalidate: true}, method: :post, local: true do |form| %>
+<%= form_with scope: :investigation, model: @accident_or_incident_type_form, url: investigation_accident_or_incidents_type_index_path(@investigation), builder: ApplicationFormBuilder, method: :post do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary @accident_or_incident_type_form.errors %>

--- a/app/views/investigations/actions/index.html.erb
+++ b/app/views/investigations/actions/index.html.erb
@@ -2,7 +2,7 @@
 <% page_title(page_heading, errors: @actions_form.errors.any?) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @actions_form, local: true, url: investigation_actions_path(@investigation), html: {novalidate: true}, builder: ApplicationFormBuilder do |form| %>
+    <%= form_with model: @actions_form, url: investigation_actions_path(@investigation), builder: ApplicationFormBuilder do |form| %>
       <%= error_summary @actions_form.errors %>
       <%= form.govuk_radios :investigation_action, legend: page_heading, legend_classes: "govuk-fieldset__legend--l", items: radio_items_from_hash(@actions_form.actions) %>
       <%= form.submit "Continue", class: "govuk-button" %>

--- a/app/views/investigations/businesses/_form.html.erb
+++ b/app/views/investigations/businesses/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @remove_business_form, url: investigation_business_path(@investigation, @business), method: :delete, local: true, html: {novalidate: true}, builder: ApplicationFormBuilder) do |form| %>
+<%= form_with(model: @remove_business_form, url: investigation_business_path(@investigation, @business), method: :delete, builder: ApplicationFormBuilder) do |form| %>
   <%= form.govuk_radios :remove,
             legend: t(".remove_business_legend"),
    items: [

--- a/app/views/investigations/businesses/new.html.erb
+++ b/app/views/investigations/businesses/new.html.erb
@@ -4,8 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @business_form,
           url: investigation_businesses_path(@investigation),
-          local: true,
-          html: { autocomplete: :off, novalidate: true }) do |form| %>
+          html: { autocomplete: :off }) do |form| %>
 
       <%= error_summary @business_form.errors %>
 

--- a/app/views/investigations/case_names/edit.html.erb
+++ b/app/views/investigations/case_names/edit.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading, errors: @notification_name_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @notification_name_form, url: investigation_case_names_path, method: :put, local: true do |form| %>
+    <%= form_with model: @notification_name_form, url: investigation_case_names_path, method: :put do |form| %>
       <%= render "form", form: form, heading: "Edit the notification name" %>
 
        <div class="govuk-button-group">

--- a/app/views/investigations/confirm_deletion.html.erb
+++ b/app/views/investigations/confirm_deletion.html.erb
@@ -12,8 +12,8 @@
           </h1>
           <%= govuk_warning_text(text: "Notification #{@investigation.pretty_id} - including its images and supporting information - will be deleted.") %>
           <div class="govuk-button-group govuk-!-margin-top-8">
-            <%= form_with url: investigation_path(@investigation), method: :delete, local: true do |form| %>
-              <%= form.submit  "Delete the notification", class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
+            <%= form_with url: investigation_path(@investigation), method: :delete do |form| %>
+              <%= form.submit "Delete the notification", class: "govuk-button govuk-link--no-underline govuk-button--warning" %>
               <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
             <% end %>
           </div>

--- a/app/views/investigations/corrective_actions/edit.html.erb
+++ b/app/views/investigations/corrective_actions/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @corrective_action_form, scope: :corrective_action, url: investigation_corrective_action_path(@investigation, @corrective_action_form.id, bulk_products_upload_id: params[:bulk_products_upload_id]), method: :put, builder: ApplicationFormBuilder, html: { novalidate: true }, local: true do |form| %>
+    <%= form_with model: @corrective_action_form, scope: :corrective_action, url: investigation_corrective_action_path(@investigation, @corrective_action_form.id, bulk_products_upload_id: params[:bulk_products_upload_id]), method: :put, builder: ApplicationFormBuilder do |form| %>
       <%= error_summary(@corrective_action_form.errors, %i[action date_decided legislation has_online_recall_information online_recall_information measure_type duration geographic_scope related_file]) %>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>

--- a/app/views/investigations/corrective_actions/new.html.erb
+++ b/app/views/investigations/corrective_actions/new.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "Record corrective action" %>
 <%= page_title page_title, errors: @corrective_action_form.errors.any? %>
-<%= form_with model: @corrective_action_form, scope: :corrective_action, local: true, url: investigation_corrective_actions_path(@investigation.pretty_id), method: :post, html: { novalidate: true }, builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @corrective_action_form, scope: :corrective_action, url: investigation_corrective_actions_path(@investigation.pretty_id), method: :post, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@corrective_action_form.errors, %i[action date_decided legislation has_online_recall_information online_recall_information measure_type duration geographic_scopes related_file]) %>

--- a/app/views/investigations/correspondence_routing/new.html.erb
+++ b/app/views/investigations/correspondence_routing/new.html.erb
@@ -9,7 +9,7 @@
                  item
                end
     %>
-    <%= form_with local: true, url: investigation_correspondence_index_path(@investigation) do |form| %>
+    <%= form_with url: investigation_correspondence_index_path(@investigation) do |form| %>
       <%= govukRadios(
         form: form,
         key: :type,

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "investigations/heading/#{@page_name}", answer: @answer %>
 
-<%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, id: "cases-search-form", html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">

--- a/app/views/investigations/investigation_products/remove.html.erb
+++ b/app/views/investigations/investigation_products/remove.html.erb
@@ -1,6 +1,6 @@
 <%= page_title "Do you want to remove this product?", errors: @remove_product_form.errors.any? %>
 <%= error_summary @remove_product_form.errors %>
-<%= form_with scope: :investigation, model: @remove_product_form, url: unlink_investigation_investigation_product_path(@investigation), html: {novalidate: true}, builder: ApplicationFormBuilder, method: :delete, local: true do |form| %>
+<%= form_with scope: :investigation, model: @remove_product_form, url: unlink_investigation_investigation_product_path(@investigation), builder: ApplicationFormBuilder, method: :delete do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div class="govuk-form-group">

--- a/app/views/investigations/notifying_country/edit.html.erb
+++ b/app/views/investigations/notifying_country/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Change the notifying country" %>
 <% page_title page_heading, errors: @notifying_country_form.errors.any? %>
-<%= form_with scope: :investigation, model: @notifying_country_form, url: investigation_notifying_country_path(@investigation), html: {novalidate: true}, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @notifying_country_form, url: investigation_notifying_country_path(@investigation), method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= error_summary @notifying_country_form.errors %>

--- a/app/views/investigations/overseas_regulator/edit.html.erb
+++ b/app/views/investigations/overseas_regulator/edit.html.erb
@@ -2,7 +2,7 @@
 <% page_title page_heading, errors: @overseas_regulator_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), html: {novalidate: true}, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), method: :put do |form| %>
       <%= error_summary @overseas_regulator_form.errors, map_errors: {
         is_from_overseas_regulator: :investigation_is_from_overseas_regulator_true,
         overseas_regulator_country: :investigation_overseas_regulator_country

--- a/app/views/investigations/ownership/_owner_form.html.erb
+++ b/app/views/investigations/ownership/_owner_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: change_notification_owner_form, method: :put, url: wizard_path, local: true) do |form| %>
+<%= form_with(model: change_notification_owner_form, method: :put, url: wizard_path) do |form| %>
   <%= govukErrorSummary form: form %>
   <%= yield %>
 

--- a/app/views/investigations/ownership/confirm.html.erb
+++ b/app/views/investigations/ownership/confirm.html.erb
@@ -1,33 +1,17 @@
 <% page_heading = "Confirm ownership change" %>
 <%= page_title page_heading, errors: @investigation.errors.any? %>
-<%= form_with(
-      scope: :change_notification_owner_form,
-      model: @form,
-      local: true,
-      url: investigation_ownership_index_path(@investigation),
-      method: :post
-    ) do |form|
-%>
+<%= form_with(model: @form, scope: :change_notification_owner_form, url: investigation_ownership_index_path(@investigation), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= govukErrorSummary form: form %>
+      <%= form.govuk_error_summary %>
       <%= render "minimal_investigation_heading", investigation: @investigation, title: page_heading %>
-      <p>
+      <p class="govuk-body">
         You are changing the notification owner to:
-        <strong><%= @potential_owner.display_name(viewer: current_user) %></strong>
+        <strong><%= @potential_owner.display_name(viewer: current_user) %></strong>.
       </p>
-      <div class="govuk-form-group">
-        <%= govukTextarea(
-          key: :owner_rationale,
-          form: form,
-          classes: "govuk-!-width-two-thirds",
-          rows: "3",
-          label: { text: "Message to new notification owner (optional)" },
-          attributes: { maxlength: 5000 }
-        ) %>
-      </div>
+      <%= form.govuk_text_area(:owner_rationale, label: { text: "Message to new notification owner (optional)" }, rows: 3, max_chars: 5000) %>
       <div class="govuk-button-group">
-        <%= form.submit "Confirm change", class: "govuk-button" %>
+        <%= form.govuk_submit("Confirm change") %>
         <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link" %>
       </div>
     </div>

--- a/app/views/investigations/prism_risk_assessments/choose_product.html.erb
+++ b/app/views/investigations/prism_risk_assessments/choose_product.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= form_with url: new_investigation_prism_risk_assessment_path, method: :get, builder: ApplicationFormBuilder, html: { novalidate: true } do |form| %>
+    <%= form_with url: new_investigation_prism_risk_assessment_path, method: :get, builder: ApplicationFormBuilder do |form| %>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <%= govukRadios(
         form: form,

--- a/app/views/investigations/prism_risk_assessments/new.html.erb
+++ b/app/views/investigations/prism_risk_assessments/new.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with url: investigation_prism_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: { novalidate: true } do |form| %>
+    <%= form_with url: investigation_prism_risk_assessments_path, method: :post, builder: ApplicationFormBuilder do |form| %>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <div class="govuk-inset-text">

--- a/app/views/investigations/products/confirm.html.erb
+++ b/app/views/investigations/products/confirm.html.erb
@@ -1,7 +1,7 @@
 <%= page_title "Is this the product?", errors: @confirm_product_form.errors.any? %>
 <%= error_summary @confirm_product_form.errors %>
 
-<%= form_with model: @confirm_product_form, url: investigation_products_path(@investigation), html: {novalidate: true}, builder: ApplicationFormBuilder, local: true do |form| %>
+<%= form_with model: @confirm_product_form, url: investigation_products_path(@investigation), builder: ApplicationFormBuilder do |form| %>
   <%= form.hidden_field :product_id %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -1,6 +1,6 @@
 <%= page_title "Add a product to the notification", errors: @find_product_form.errors.any? %>
 <%= error_summary @find_product_form.errors %>
-<%= form_with model: @find_product_form, url: find_investigation_products_path(@investigation), html: {novalidate: true}, builder: ApplicationFormBuilder, local: true do |form| %>
+<%= form_with model: @find_product_form, url: find_investigation_products_path(@investigation), builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-label-wrapper opss-label-wrapper">

--- a/app/views/investigations/project/project_details.html.erb
+++ b/app/views/investigations/project/project_details.html.erb
@@ -3,7 +3,7 @@
   <%= link_to "Back to notifications", investigations_path, class: "govuk-back-link" %>
 <% end %>
 
-<%= form_with(model: @investigation, scope: :investigation, url: wizard_path, method: :put, local: true) do |form| %>
+<%= form_with(model: @investigation, scope: :investigation, url: wizard_path, method: :put) do |form| %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/investigations/record_emails/edit.html.erb
+++ b/app/views/investigations/record_emails/edit.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Edit email", errors: @email_correspondence_form.errors.any? %>
-<%= form_with(model: @email_correspondence_form, local: true, url: investigation_email_path(@investigation, @email), method: :patch, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
+<%= form_with(model: @email_correspondence_form, url: investigation_email_path(@investigation, @email), method: :patch, builder: ApplicationFormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary form.object.errors %>

--- a/app/views/investigations/record_emails/new.html.erb
+++ b/app/views/investigations/record_emails/new.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Record email", errors: @email_correspondence_form.errors.any? %>
-<%= form_with(model: @email_correspondence_form, local: true, url: investigation_emails_path, method: :post, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
+<%= form_with(model: @email_correspondence_form, url: investigation_emails_path, method: :post, builder: ApplicationFormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary form.object.errors %>

--- a/app/views/investigations/record_phone_calls/_form.html.erb
+++ b/app/views/investigations/record_phone_calls/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: correspondence_form, local: true, url: url, builder: ApplicationFormBuilder, html: { novalidate: true }) do |form| %>
+<%= form_with(model: correspondence_form, url:, builder: ApplicationFormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 

--- a/app/views/investigations/reference_numbers/edit.html.erb
+++ b/app/views/investigations/reference_numbers/edit.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with scope: :investigation, model: @notification, url: investigation_reference_numbers_path, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @notification, url: investigation_reference_numbers_path, method: :put do |form| %>
       <%= govukInput(
         key: :complainant_reference,
         id: "complainant_reference",

--- a/app/views/investigations/reported_reason/edit.html.erb
+++ b/app/views/investigations/reported_reason/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= page_title page_heading, errors: @reported_reason_form.errors.any? %>
 
-<%= form_with scope: :investigation, model: @reported_reason_form, url: investigation_reported_reason_path, html: {novalidate: true}, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @reported_reason_form, url: investigation_reported_reason_path, method: :put do |form| %>
   <%= error_summary @reported_reason_form.errors %>
   <% radio_items = (Investigation.reported_reasons.keys - ["other"]).map.with_index do |reason, index|
       id = index.zero? ? "reported_reason" : "reported_reason-#{index}"

--- a/app/views/investigations/risk_assessments/edit.html.erb
+++ b/app/views/investigations/risk_assessments/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder, html: { novalidate: true }) do |form| %>
+    <%= form_with(model: @risk_assessment_form, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder) do |form| %>
       <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level assessed_by investigation_product_ids risk_assessment_file])%>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>

--- a/app/views/investigations/risk_assessments/new.html.erb
+++ b/app/views/investigations/risk_assessments/new.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: { novalidate: true }) do |form| %>
+    <%= form_with(model: @risk_assessment_form, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder) do |form| %>
       <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level assessed_by investigation_product_ids risk_assessment_file]) %>
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>

--- a/app/views/investigations/risk_level/show.html.erb
+++ b/app/views/investigations/risk_level/show.html.erb
@@ -16,7 +16,7 @@
       ) %>
     </div>
 
-    <%= form_with scope: :investigation, model: @risk_level_form, url: investigation_risk_level_path(@investigation), method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @risk_level_form, url: investigation_risk_level_path(@investigation), method: :put do |form| %>
       <%= error_summary @risk_level_form.errors %>
 
       <% radio_items = (Investigation.risk_levels.keys - ["other", "not_conclusive"]).map do |level|

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = "Has the notification risk level been validated?" %>
 <% page_title page_heading, errors: @risk_validation_form.errors.any? %>
-<%= form_with scope: :investigation, model: @risk_validation_form, builder: ApplicationFormBuilder, url: investigation_risk_validations_path(@investigation), html: {novalidate: true}, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @risk_validation_form, builder: ApplicationFormBuilder, url: investigation_risk_validations_path(@investigation), method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary @risk_validation_form.errors %>

--- a/app/views/investigations/safety_and_compliance/edit.html.erb
+++ b/app/views/investigations/safety_and_compliance/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= page_title page_heading, errors: @edit_why_reporting_form.errors.any? %>
 
-<%= form_with scope: :investigation, model: @edit_why_reporting_form, url: investigation_safety_and_compliance_path, html: {novalidate: true}, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @edit_why_reporting_form, url: investigation_safety_and_compliance_path, method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= error_summary @edit_why_reporting_form.errors %>

--- a/app/views/investigations/status/_form.html.erb
+++ b/app/views/investigations/status/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @change_notification_status_form, url: form_path, local: true, method: :patch) do |form| %>
+<%= form_with(model: @change_notification_status_form, url: form_path, method: :patch) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/investigations/summary/edit.html.erb
+++ b/app/views/investigations/summary/edit.html.erb
@@ -5,9 +5,7 @@
     <%= form_with(model: @form,
                   url: investigation_summary_path(@investigation),
                   method: :patch,
-                  html: {novalidate: true},
-                  builder: ApplicationFormBuilder,
-                  local: true) do |form| %>
+                  builder: ApplicationFormBuilder) do |form| %>
 
       <%= form.govuk_text_area(:summary,
                                rows: 11,

--- a/app/views/investigations/test_results/confirm.html.erb
+++ b/app/views/investigations/test_results/confirm.html.erb
@@ -51,7 +51,7 @@
       </tbody>
     </table>
 
-    <%= form_with model: @test_result, scope: :test, url: investigation_test_results_path(@investigation), method: :post, local: true do |form| %>
+    <%= form_with model: @test_result, scope: :test, url: investigation_test_results_path(@investigation), method: :post do |form| %>
       <div class="govuk-button-group">
         <%= form.submit "Continue", class: "govuk-button" %>
         <%= link_to "Edit details", new_investigation_test_result_path(@investigation), class: "govuk-link" %>

--- a/app/views/investigations/test_results/edit.html.erb
+++ b/app/views/investigations/test_results/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "Record test result" %>
 <%= page_title page_title, errors: @test_result_form.errors.any? %>
-<%= form_with model: @test_result_form, scope: :test_result, local: true, url: investigation_test_result_path(@investigation, @test_result_form.id), method: :patch, html: {novalidate: true}, builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @test_result_form, scope: :test_result, url: investigation_test_result_path(@investigation, @test_result_form.id), method: :patch, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 

--- a/app/views/investigations/test_results/new.html.erb
+++ b/app/views/investigations/test_results/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @test_result_form, scope: :test_result, local: true, builder: ApplicationFormBuilder, html: {novalidate: true}, url: investigation_test_results_path(@investigation.pretty_id) do |form| %>
+    <%= form_with model: @test_result_form, scope: :test_result, builder: ApplicationFormBuilder, url: investigation_test_results_path(@investigation.pretty_id) do |form| %>
       <%= error_summary(@test_result_form.errors, %i[legislation standards_product_was_tested_against date result failure_details base])%>
 
       <h1 class="govuk-heading-l"><%= page_title %></h1>

--- a/app/views/investigations/ts_investigations/case_name.html.erb
+++ b/app/views/investigations/ts_investigations/case_name.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with scope: :investigation, model: @notification_name_form, url: wizard_path, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @notification_name_form, url: wizard_path, method: :put do |form| %>
       <%= render "/investigations/case_names/form", form: form, heading: "What is the notification name?" %>
 
        <div class="govuk-button-group">

--- a/app/views/investigations/ts_investigations/reason_for_concern.html.erb
+++ b/app/views/investigations/ts_investigations/reason_for_concern.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Why is the product of concern?" %>
 <%= page_title page_heading, errors: @edit_why_reporting_form.errors.any? %>
 
-<%= form_with scope: :investigation, model: @edit_why_reporting_form, url: wizard_path, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @edit_why_reporting_form, url: wizard_path, method: :put do |form| %>
   <%= error_summary @edit_why_reporting_form.errors, %i[hazard_type hazard_description anon_compliant_reason] %>
   <%= edit_why_reporting_checkboxes(form, page_heading, @edit_why_reporting_form.errors, disabled: false, classes: "govuk-!-padding-top-3", attribute: :reported_reason) %>
 

--- a/app/views/investigations/ts_investigations/reason_for_creating.html.erb
+++ b/app/views/investigations/ts_investigations/reason_for_creating.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = "Why are you creating a notification?" %>
 <%= page_title page_heading, errors: @reason_for_creating_form.errors.any? %>
 
-<%= form_with scope: :investigation, model: @reason_for_creating_form, url: wizard_path, builder: ApplicationFormBuilder, html: {novalidate: true}, method: :put, local: true do |form| %>
+<%= form_with scope: :investigation, model: @reason_for_creating_form, url: wizard_path, builder: ApplicationFormBuilder, method: :put do |form| %>
     <%= error_summary @reason_for_creating_form.errors %>
     <% error_message = { text: @reason_for_creating_form.errors.full_messages_for("case_is_safe").first } if @reason_for_creating_form.errors.any? %>
     <%= govukRadios(

--- a/app/views/investigations/ts_investigations/reference_number.html.erb
+++ b/app/views/investigations/ts_investigations/reference_number.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading, errors: @reference_number_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with scope: :investigation, model: @reference_number_form, url: wizard_path, method: :put, local: true do |form| %>
+    <%= form_with scope: :investigation, model: @reference_number_form, url: wizard_path, method: :put do |form| %>
       <%= error_summary @reference_number_form.errors %>
       <% has_complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("has_complainant_reference").first } if @reference_number_form.errors.any? %>
       <% complainant_reference_error_message = { text: @reference_number_form.errors.full_messages_for("complainant_reference").first } if @reference_number_form.errors.any? %>

--- a/app/views/investigations/update_case_risk_level_from_risk_assessment/show.html.erb
+++ b/app/views/investigations/update_case_risk_level_from_risk_assessment/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary @update_risk_level_from_risk_assessment_form.errors %>
-    <%= form_with model: @update_risk_level_from_risk_assessment_form, url: investigation_risk_assessment_update_case_risk_level_path(@investigation, @risk_assessment), method: :patch, local: true, builder: ApplicationFormBuilder, html: {novalidate: true} do |form| %>
+    <%= form_with model: @update_risk_level_from_risk_assessment_form, url: investigation_risk_assessment_update_case_risk_level_path(@investigation, @risk_assessment), method: :patch, builder: ApplicationFormBuilder do |form| %>
       <%= form.govuk_radios(:update_case_risk_level_to_match_investigation,
         legend: "Do you want to match this notification risk level to the risk assessment level?",
         legend_classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-5",

--- a/app/views/investigations/visibility/_form.html.erb
+++ b/app/views/investigations/visibility/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @change_case_visibility_form, url: form_path, local: true, method: :patch) do |form| %>
+<%= form_with(model: @change_case_visibility_form, url: form_path, method: :patch) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govukErrorSummary form: form %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "investigations/heading/#{@page_name}", answer: @answer %>
 
-<%= form_with(model: @search, scope: "", url: notifications_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: notifications_search_path, method: :get, id: "cases-search-form", html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
     <%= render 'notifications/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">

--- a/app/views/prism_risk_assessments/add_to_case.html.erb
+++ b/app/views/prism_risk_assessments/add_to_case.html.erb
@@ -2,7 +2,7 @@
 <%= page_title page_heading %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with url: add_to_case_prism_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: { novalidate: true } do |form| %>
+    <%= form_with url: add_to_case_prism_risk_assessments_path, method: :post, builder: ApplicationFormBuilder do |form| %>
       <span class="govuk-caption-l"><%= @prism_risk_assessment.name %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <div class="govuk-inset-text">

--- a/app/views/prism_risk_assessments/index.html.erb
+++ b/app/views/prism_risk_assessments/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "prism_risk_assessments/heading/#{@page_name}" %>
 
-<%= form_with(model: @search, scope: "", url: all_prism_risk_assessments_path, method: :get, local: true, html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: all_prism_risk_assessments_path, method: :get, html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
     <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
       <%= render "prism_risk_assessments/secondary_nav" %>

--- a/app/views/products/duplicate_checks/new.html.erb
+++ b/app/views/products/duplicate_checks/new.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Do you have a barcode number?", errors: @product_duplicate_check_form.errors.any? %>
-<%= form_with model: @product_duplicate_check_form, url: duplicate_check_products_path(@product_duplicate_check_form), html: {novalidate: true}, local: true, builder: ApplicationFormBuilder do |f| %>
+<%= form_with model: @product_duplicate_check_form, url: duplicate_check_products_path(@product_duplicate_check_form), builder: ApplicationFormBuilder do |f| %>
   <%= error_summary(@product_duplicate_check_form.errors, %i[barcode]) %>
 
   <div class="govuk-grid-row">

--- a/app/views/products/duplicate_checks/show.html.erb
+++ b/app/views/products/duplicate_checks/show.html.erb
@@ -1,5 +1,5 @@
 <% page_title "Is this the same product?", errors: @product_duplicate_confirmation_form.errors.any? %>
-<%= form_with model: @product_duplicate_confirmation_form, url: confirm_product_duplicate_checks_path(product_id: @product.id), html: {novalidate: true}, local: true, builder: ApplicationFormBuilder do |f| %>
+<%= form_with model: @product_duplicate_confirmation_form, url: confirm_product_duplicate_checks_path(product_id: @product.id), builder: ApplicationFormBuilder do |f| %>
   <%= error_summary(@product_duplicate_confirmation_form.errors, %i[correct]) %>
 
   <div class="govuk-grid-row">

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Edit product", errors: @product_form.errors.any? %>
-<%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, local: true, html: {novalidate: true}, builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings when_placed_on_market name]) %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "products/heading/#{@page_name}", count: @count %>
 
-<%= form_with(model: @search, scope: "", url: products_path, method: :get, local: true, html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: products_path, method: :get, html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
     <%= render 'products/filters', form: form %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Create a product record", errors: @product_form.errors.any? %>
-<%= form_with model: @product_form, scope: :product, url: products_path(@investigation), html: {novalidate: true}, local: true, builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @product_form, scope: :product, url: products_path(@investigation), builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings name when_placed_on_market barcode]) %>

--- a/app/views/searches/_new_search.html.erb
+++ b/app/views/searches/_new_search.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'investigations/heading/all_cases', answer: @answer %>
 
-<%= form_with(model: @search, scope: "", url: notifications_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: notifications_search_path, method: :get, id: "cases-search-form", html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row">
     <%= render 'notifications/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">

--- a/app/views/searches/_old_search.html.erb
+++ b/app/views/searches/_old_search.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'investigations/heading/all_cases', answer: @answer %>
 
-<%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
+<%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, id: "cases-search-form", html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row">
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">

--- a/spec/features/change_notification_ownership_spec.rb
+++ b/spec/features/change_notification_ownership_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature "Changing notification ownership", :with_stubbed_mailer, type: :fe
   end
 
   def fill_and_submit_change_owner_reason_form
-    fill_in "change_notification_owner_form_owner_rationale", with: "Test assign"
+    fill_in "change-notification-owner-form-owner-rationale-field", with: "Test assign"
     click_button "Confirm change"
   end
 

--- a/spec/features/change_team_permission_on_case_spec.rb
+++ b/spec/features/change_team_permission_on_case_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Changing a team's permissions on a notification", :with_stubbed_a
     expect(page).to have_selector("a", text: "Enter a message to the team")
 
     within_fieldset "Do you want to include more information?" do
-      fill_in "Message to the #{team.name}", with: "Thanks for collaborating on this notification with us before."
+      fill_in "Message to #{team.name}", with: "Thanks for collaborating on this notification with us before."
     end
 
     click_button "Update team"
@@ -107,7 +107,7 @@ RSpec.feature "Changing a team's permissions on a notification", :with_stubbed_a
     end
 
     within_fieldset "Do you want to include more information?" do
-      fill_in "Message to the #{team.name}", with: "You now have view read only access."
+      fill_in "Message to #{team.name}", with: "You now have view read only access."
     end
 
     click_button "Update team"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2172

## Description

Removes the `novalidate` and `local` attributes since they have no effect on our forms.

Also migrates some more forms to standard GOV.UK components.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2823.london.cloudapps.digital/
https://psd-pr-2823-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
