### PR TITLE
Notification task list: add product safety and compliance details

### DIFF
--- a/app/forms/change_notification_product_safety_compliance_details_form.rb
+++ b/app/forms/change_notification_product_safety_compliance_details_form.rb
@@ -1,0 +1,25 @@
+class ChangeNotificationProductSafetyComplianceDetailsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :unsafe, :boolean
+  attribute :noncompliant, :boolean
+  attribute :primary_hazard, :string
+  attribute :primary_hazard_description, :string
+  attribute :noncompliance_description, :string
+  attribute :add_reference_number, :boolean
+  attribute :reference_number, :string
+  attribute :current_user
+
+  validate :at_least_one_of_unsafe_or_noncompliant
+  validates :primary_hazard, :primary_hazard_description, presence: true, if: -> { unsafe }
+  validates :noncompliance_description, presence: true, if: -> { noncompliant }
+  validates :add_reference_number, inclusion: [true, false]
+  validates :reference_number, presence: true, if: -> { add_reference_number }
+  validates :primary_hazard_description, :noncompliance_description, length: { maximum: 10_000 }
+
+  def at_least_one_of_unsafe_or_noncompliant
+    errors.add(:unsafe, :blank) if unsafe.nil? && noncompliant.nil?
+  end
+end

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -48,6 +48,13 @@ module Notifications
       ]
     end
 
+    def hazards_options
+      [OpenStruct.new(id: "", name: "")] +
+        Rails.application.config.hazard_constants["hazard_type"].map do |hazard_type|
+          OpenStruct.new(id: hazard_type.parameterize.underscore, name: hazard_type)
+        end
+    end
+
   private
 
     def previous_task(task)

--- a/app/views/investigations/_create_a_case_link.html.erb
+++ b/app/views/investigations/_create_a_case_link.html.erb
@@ -1,9 +1,0 @@
-<div class="govuk-grid-column-one-third">
-  <div class="opss-text-align-right govuk-!-margin-bottom-8">
-    <%= link_to "Create a notification",
-      create_a_case_page_index_path,
-      class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset",
-      data: { cy: "create-case" }
-    %>
-  </div>
-</div>

--- a/app/views/investigations/_create_a_notification_link.html.erb
+++ b/app/views/investigations/_create_a_notification_link.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-column-one-third">
+  <div class="opss-text-align-right govuk-!-margin-bottom-8">
+    <% if current_user.can_use_notification_task_list? %>
+      <p class="govuk-body"><a href="<%= notifications_create_index_path %>" class="govuk-link govuk-link--no-visited-state" data-cy="create-new-notification">Create a notification</a></p>
+    <% else %>
+      <p class="govuk-body"><a href="<%= create_a_case_page_index_path %>" class="govuk-link govuk-link--no-visited-state" data-cy="create-case">Create a notification</a></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/investigations/heading/_all_cases.html.erb
+++ b/app/views/investigations/heading/_all_cases.html.erb
@@ -20,5 +20,5 @@
     <% end %>
   </div>
 
-  <%= render "investigations/create_a_case_link" %>
+  <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_assigned_cases.html.erb
+++ b/app/views/investigations/heading/_assigned_cases.html.erb
@@ -8,5 +8,5 @@
     </p>
   </div>
 
-  <%= render "investigations/create_a_case_link" %>
+  <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_team_cases.html.erb
+++ b/app/views/investigations/heading/_team_cases.html.erb
@@ -8,5 +8,5 @@
     </p>
   </div>
 
-  <%= render "investigations/create_a_case_link" %>
+  <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_your_cases.html.erb
+++ b/app/views/investigations/heading/_your_cases.html.erb
@@ -8,5 +8,5 @@
     </p>
   </div>
 
-  <%= render "investigations/create_a_case_link" %>
+  <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -1,26 +1,19 @@
 <%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: false) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">
-          <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
-          <%= t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title") %>
-        </h1>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= form_with model: @change_notification_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-          <%= f.govuk_text_field :user_title, label: { text: "Notification title", size: "m" }, hint: { text: "A recommended format for the notification title includes the name of the product(s) and the hazard associated with it." } %>
-          <%= f.govuk_text_area :description, label: { text: "Notification summary <span class=\"govuk-body-s\">(optional)</span>".html_safe, size: "m" }, hint: { text: "The notification summary provides a clear, concise overview to help users unfamiliar with the notification's details understand it better." }, max_chars: 10_000 %>
-          <%= f.govuk_collection_radio_buttons :reported_reason, reported_reason_options, :id, :name, :description, legend: { text: "Why are you creating the notification?" }, bold_labels: false %>
-          <%= f.govuk_submit "Save and continue" do %>
-            <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @change_notification_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title") %>
+      </h1>
+      <%= f.govuk_text_field :user_title, label: { text: "Notification title", size: "m" }, hint: { text: "A recommended format for the notification title includes the name of the product(s) and the hazard associated with it." } %>
+      <%= f.govuk_text_area :description, label: { text: "Notification summary <span class=\"govuk-body-s\">(optional)</span>".html_safe, size: "m" }, hint: { text: "The notification summary provides a clear, concise overview to help users unfamiliar with the notification's details understand it better." }, max_chars: 10_000 %>
+      <%= f.govuk_collection_radio_buttons :reported_reason, reported_reason_options, :id, :name, :description, legend: { text: "Why are you creating the notification?" }, bold_labels: false %>
+      <%= f.govuk_submit "Save and continue" do %>
+        <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
+++ b/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
@@ -1,0 +1,39 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_safety_and_compliance_details.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @change_notification_product_safety_compliance_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_safety_and_compliance_details.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+        <% @notification.products.decorate.each do |product| %>
+          <li class="govuk-body-l"><%= product.name_with_brand %></li>
+        <% end %>
+        </ul>
+      <% end %>
+      <%= f.govuk_check_boxes_fieldset :unsafe, multiple: false, legend: { text: "What specific issues make the #{'product'.pluralize(@notification.products.count)} unsafe or non-compliant?", size: "m" } do %>
+        <%= f.govuk_check_box :unsafe, true, false, multiple: false, link_errors: true, label: { text: "Product hazard" } do %>
+          <%= f.govuk_collection_select :primary_hazard, hazards_options, :id, :name, label: { text: "What is the primary hazard?" } %>
+          <%= f.govuk_text_area :primary_hazard_description, label: { text: "Provide additional information about the product hazard" }, hint: { text: "If the product has been involved in an incident include this additional information." }, max_chars: 10_000 %>
+        <% end %>
+        <%= f.govuk_check_box :noncompliant, true, false, multiple: false, label: { text: "Product incomplete markings, labeling or other issues" } do %>
+          <%= f.govuk_text_area :noncompliance_description, label: { text: "Describe the product non-compliance issues" }, max_chars: 10_000 %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_radio_buttons_fieldset :add_reference_number, legend: { text: "Do you want to add your own reference number?", size: "m" } do %>
+        <%= f.govuk_radio_button :add_reference_number, true, label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_text_field :reference_number, label: { text: "Reference number" } %>
+        <% end %>
+        <%= f.govuk_radio_button :add_reference_number, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" do %>
+        <%= f.govuk_submit "Save as draft", secondary: true, name: "draft", value: "true" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -817,6 +817,22 @@ en:
               too_long: The notification description must be %{count} characters or less
             reported_reason:
               blank: Choose why you are creating the notification
+        change_notification_product_safety_compliance_details_form:
+          attributes:
+            unsafe:
+              blank: Choose at least one issue
+            primary_hazard:
+              blank: Choose the primary hazard
+            primary_hazard_description:
+              blank: Enter additional information about the product hazard
+              too_long: Additional information about the product hazard must be %{count} characters or less
+            noncompliance_description:
+              blank: Enter a description of the product non-compliance issues
+              too_long: Description of the product non-compliance issues must be %{count} characters or less
+            add_reference_number:
+              inclusion: Choose whether you want to add your own reference number
+            reference_number:
+              blank: Enter a reference number
 
   activerecord:
     models:

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -89,8 +89,22 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     within_fieldset("Why are you creating the notification?") do
       choose "A product is unsafe or non-compliant"
     end
+    click_button "Save and continue"
+
+    within_fieldset "What specific issues make the product unsafe or non-compliant?" do
+      check "Product hazard"
+      select "Chemical", from: "What is the primary hazard?"
+      fill_in "Provide additional information about the product hazard", with: "Fake description"
+    end
+
+    within_fieldset "Do you want to add your own reference number?" do
+      choose "Yes"
+      fill_in "Reference number", with: "123456"
+    end
+
     click_button "Save as draft"
 
     expect(page).to have_selector(:id, "task-list-1-0-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-1-1-status", text: "Completed")
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2013

## Description

Add the “add product safety and compliance details” task.

Also changes the “create a notification” link from the notification search pages to link to the task list when the user has the relevant role.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-01-10 at 12 31 33](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/b0ff2af5-9cb7-4978-859e-19d3b0c211c5)

## Review apps

https://psd-pr-2826.london.cloudapps.digital/
https://psd-pr-2826-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
