### PR TITLE
Hide notification type filter for non OPSS - PSD-2297

### DIFF
--- a/app/assets/stylesheets/opss/_opss-search.scss
+++ b/app/assets/stylesheets/opss/_opss-search.scss
@@ -30,16 +30,3 @@ $opss-search-icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGkAAABGCAMAAA
     z-index: 1;
   }
 }
-
-.govuk-label--s + .govuk-hint[class*="font-size-16"][class*="display-inline-block"] {
-  line-height: 1.1 !important;
-
-  &:before {
-    content: " - ";
-  }
-}
-
-.govuk-fieldset__legend--s + .govuk-hint[class*="font-size-16"][class*="display-inline-block"] {
-  position: relative;
-  top: -1px;
-}

--- a/app/views/investigations/_case_type_radios.html.erb
+++ b/app/views/investigations/_case_type_radios.html.erb
@@ -7,7 +7,7 @@
   classes: "govuk-radios govuk-radios--small",
   fieldset: {
     legend: {
-      text: "Notification type",
+      text: "Type",
       is_page_heading: false,
       classes: "govuk-fieldset__legend--s govuk-!-font-weight-regular"
     }

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -18,7 +18,9 @@
       <%= render "investigations/case_owner_radios", form: form %>
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>
-      <%= render "investigations/case_type_radios", form: form %>
+      <% if current_user.is_opss? %>
+        <%= render "investigations/case_type_radios", form: form %>
+      <% end %>
       <%= render "investigations/case_hazard_type_filter", form: form %>
       <%= render "investigations/case_change_date_filter", form: form %>
     <% end %>

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -3,7 +3,7 @@ require "sidekiq/testing"
 
 RSpec.feature "notification export", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
   let(:user_team) { create :team, name: "User Team" }
-  let(:user) { create :user, :all_data_exporter, :activated, team: user_team, organisation: user_team.organisation }
+  let(:user) { create :user, :all_data_exporter, :opss_user, :activated, team: user_team, organisation: user_team.organisation }
   let(:other_user_same_team) { create :user, :activated, team: user_team, organisation: user_team.organisation }
   let(:other_user_team) { create :team, name: "Other User Team" }
   let(:other_user) { create :user, :activated, team: other_user_team, organisation: other_user_team.organisation }

--- a/spec/features/filter_notifications_spec.rb
+++ b/spec/features/filter_notifications_spec.rb
@@ -388,7 +388,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
     end
 
     describe "notification type" do
-      context "as an OPSS user" do
+      context "with an OPSS user" do
         let(:user) { create(:user, :activated, :opss_user, organisation:, team:, has_viewed_introduction: true) }
 
         scenario "filtering for projects" do

--- a/spec/features/filter_notifications_spec.rb
+++ b/spec/features/filter_notifications_spec.rb
@@ -389,7 +389,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
 
     describe "notification type" do
       scenario "filtering for projects" do
-        within_fieldset "Notification type" do
+        within_fieldset "Type" do
           choose "Project"
         end
         click_button "Apply"
@@ -403,7 +403,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
       end
 
       scenario "filtering for enquiries" do
-        within_fieldset "Notification type" do
+        within_fieldset "Type" do
           choose "Enquiry"
         end
         click_button "Apply"
@@ -417,7 +417,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
       end
 
       scenario "filtering for notifications" do
-        within_fieldset "Notification type" do
+        within_fieldset "Type" do
           choose "Notification"
         end
         click_button "Apply"
@@ -431,7 +431,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
       end
 
       scenario "filtering for allegations" do
-        within_fieldset "Notification type" do
+        within_fieldset "Type" do
           choose "Allegation"
         end
         click_button "Apply"

--- a/spec/features/filter_notifications_spec.rb
+++ b/spec/features/filter_notifications_spec.rb
@@ -388,60 +388,56 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
     end
 
     describe "notification type" do
-      scenario "filtering for projects" do
-        within_fieldset "Type" do
-          choose "Project"
+      context "as an OPSS user" do
+        let(:user) { create(:user, :activated, :opss_user, organisation:, team:, has_viewed_introduction: true) }
+
+        scenario "filtering for projects" do
+          within_fieldset "Type" do
+            choose "Project"
+          end
+          click_button "Apply"
+
+          expect(page).not_to have_listed_case(allegation.pretty_id)
+          expect(page).not_to have_listed_case(notification.pretty_id)
+          expect(page).to     have_listed_case(project.pretty_id)
+          expect(page).not_to have_listed_case(enquiry.pretty_id)
         end
-        click_button "Apply"
 
-        expect(page).not_to have_listed_case(allegation.pretty_id)
-        expect(page).not_to have_listed_case(notification.pretty_id)
-        expect(page).to     have_listed_case(project.pretty_id)
-        expect(page).not_to have_listed_case(enquiry.pretty_id)
+        scenario "filtering for enquiries" do
+          within_fieldset "Type" do
+            choose "Enquiry"
+          end
+          click_button "Apply"
 
-        expect(find("details#filter-details")["open"]).to eq("open")
-      end
-
-      scenario "filtering for enquiries" do
-        within_fieldset "Type" do
-          choose "Enquiry"
+          expect(page).not_to have_listed_case(allegation.pretty_id)
+          expect(page).not_to have_listed_case(notification.pretty_id)
+          expect(page).not_to have_listed_case(project.pretty_id)
+          expect(page).to     have_listed_case(enquiry.pretty_id)
         end
-        click_button "Apply"
 
-        expect(page).not_to have_listed_case(allegation.pretty_id)
-        expect(page).not_to have_listed_case(notification.pretty_id)
-        expect(page).not_to have_listed_case(project.pretty_id)
-        expect(page).to     have_listed_case(enquiry.pretty_id)
+        scenario "filtering for notifications" do
+          within_fieldset "Type" do
+            choose "Notification"
+          end
+          click_button "Apply"
 
-        expect(find("details#filter-details")["open"]).to eq("open")
-      end
-
-      scenario "filtering for notifications" do
-        within_fieldset "Type" do
-          choose "Notification"
+          expect(page).not_to have_listed_case(allegation.pretty_id)
+          expect(page).to     have_listed_case(notification.pretty_id)
+          expect(page).not_to have_listed_case(project.pretty_id)
+          expect(page).not_to have_listed_case(enquiry.pretty_id)
         end
-        click_button "Apply"
 
-        expect(page).not_to have_listed_case(allegation.pretty_id)
-        expect(page).to     have_listed_case(notification.pretty_id)
-        expect(page).not_to have_listed_case(project.pretty_id)
-        expect(page).not_to have_listed_case(enquiry.pretty_id)
+        scenario "filtering for allegations" do
+          within_fieldset "Type" do
+            choose "Allegation"
+          end
+          click_button "Apply"
 
-        expect(find("details#filter-details")["open"]).to eq("open")
-      end
-
-      scenario "filtering for allegations" do
-        within_fieldset "Type" do
-          choose "Allegation"
+          expect(page).to     have_listed_case(allegation.pretty_id)
+          expect(page).not_to have_listed_case(notification.pretty_id)
+          expect(page).not_to have_listed_case(project.pretty_id)
+          expect(page).not_to have_listed_case(enquiry.pretty_id)
         end
-        click_button "Apply"
-
-        expect(page).to     have_listed_case(allegation.pretty_id)
-        expect(page).not_to have_listed_case(notification.pretty_id)
-        expect(page).not_to have_listed_case(project.pretty_id)
-        expect(page).not_to have_listed_case(enquiry.pretty_id)
-
-        expect(find("details#filter-details")["open"]).to eq("open")
       end
     end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2297

## Description

- Changes copy of notification type filter to just 'Type'
- Hides for non-OPSS user roles

## Screen-shots or screen-capture of UI changes

### With OPSS role
![CleanShot 2024-01-11 at 15 37 11](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/d94baa7d-1365-4e66-bc37-151997896f00)

### Without OPSS role
![CleanShot 2024-01-11 at 15 37 35](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/daa2caba-f3c0-46dd-ba88-ddbfe4dacc8f)

