### PR TITLE
Notifications task list: add product identification details

### DIFF
--- a/app/forms/change_notification_product_safety_compliance_details_form.rb
+++ b/app/forms/change_notification_product_safety_compliance_details_form.rb
@@ -10,11 +10,12 @@ class ChangeNotificationProductSafetyComplianceDetailsForm
   attribute :noncompliance_description, :string
   attribute :add_reference_number, :boolean
   attribute :reference_number, :string
+  attribute :safe_and_compliant, :boolean # Whether the notification has already been marked as "safe and compliant"
   attribute :current_user
 
-  validate :at_least_one_of_unsafe_or_noncompliant
-  validates :primary_hazard, :primary_hazard_description, presence: true, if: -> { unsafe }
-  validates :noncompliance_description, presence: true, if: -> { noncompliant }
+  validate :at_least_one_of_unsafe_or_noncompliant, unless: -> { safe_and_compliant }
+  validates :primary_hazard, :primary_hazard_description, presence: true, if: -> { unsafe }, unless: -> { safe_and_compliant }
+  validates :noncompliance_description, presence: true, if: -> { noncompliant }, unless: -> { safe_and_compliant }
   validates :add_reference_number, inclusion: [true, false]
   validates :reference_number, presence: true, if: -> { add_reference_number }
   validates :primary_hazard_description, :noncompliance_description, length: { maximum: 10_000 }

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -85,6 +85,7 @@ module Notifications
       index = mandatory_tasks.index(task)
       unless index.nil?
         return if index.zero?
+
         return mandatory_tasks.at(index - 1)
       end
 

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -11,9 +11,11 @@ module Notifications
     end
 
     def task_status(task)
+      previous_task = previous_task(task)
+
       if %w[in_progress completed].include?(@notification.tasks_status[task.to_s])
         @notification.tasks_status[task.to_s]
-      elsif first_task?(task) || @notification.tasks_status[previous_task(task).to_s] == "completed"
+      elsif previous_task.nil? || @notification.tasks_status[previous_task.to_s] == "completed"
         "not_started"
       else
         "cannot_start_yet"
@@ -55,14 +57,47 @@ module Notifications
         end
     end
 
+    def number_of_affected_units(affected_units_status, number_of_affected_units)
+      case affected_units_status
+      when "exact"
+        number_of_affected_units
+      when "approx"
+        "Approximately #{number_of_affected_units}"
+      when "unknown"
+        "Unknown"
+      when "not_relevant"
+        "Not relevant"
+      else
+        "Not provided"
+      end
+    end
+
   private
 
     def previous_task(task)
-      task_index = wizard_steps.index(task)
+      return if first_task?(task)
 
-      return task if task_index.zero? # The task is the first task
+      all_tasks = wizard_steps
+      optional_tasks = Notifications::CreateController::TASK_LIST_SECTIONS.slice(*Notifications::CreateController::TASK_LIST_SECTIONS_OPTIONAL).values.flatten
+      mandatory_tasks = all_tasks - optional_tasks
 
-      wizard_steps.at(task_index - 1)
+      # Return the previous mandatory task or `nil` if this is the first mandatory task
+      index = mandatory_tasks.index(task)
+      unless index.nil?
+        return if index.zero?
+        return mandatory_tasks.at(index - 1)
+      end
+
+      # This is an optional task - find and return the last mandatory task or `nil` if we get to the first task without a match
+      previous_index = all_tasks.index(task) - 1
+
+      loop do
+        previous_task = all_tasks.at(previous_index)
+        return previous_task if mandatory_tasks.include?(previous_task)
+        return if previous_index.zero?
+
+        previous_index -= 1
+      end
     end
 
     def first_task?(task)

--- a/app/services/change_batch_number.rb
+++ b/app/services/change_batch_number.rb
@@ -17,7 +17,7 @@ class ChangeBatchNumber
       create_audit_activity_for_batch_number_changed
     end
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/change_customs_code.rb
+++ b/app/services/change_customs_code.rb
@@ -19,7 +19,7 @@ class ChangeCustomsCode
     end
     context.changed = true
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/change_number_of_affected_units.rb
+++ b/app/services/change_number_of_affected_units.rb
@@ -19,7 +19,7 @@ class ChangeNumberOfAffectedUnits
 
     context.changed = true
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/change_safety_and_compliance_data.rb
+++ b/app/services/change_safety_and_compliance_data.rb
@@ -20,7 +20,7 @@ class ChangeSafetyAndComplianceData
 
     context.changes_made = true
 
-    send_notification_email(investigation, user)
+    send_notification_email(investigation, user) unless context.silent
   end
 
 private
@@ -40,6 +40,12 @@ private
 
     if reported_reason.to_s == "non_compliant"
       investigation.assign_attributes(hazard_description: nil, hazard_type: nil, non_compliant_reason:, reported_reason:)
+    end
+
+    # Clear everything so the user can re-choose if they chose "unsafe and/or non-compliant" and the previous choice was "safe and compliant"
+    # to avoid clobbering previously-entered data
+    if reported_reason.to_s == "unsafe_or_non_compliant" && investigation.reported_reason == "safe_and_compliant"
+      investigation.assign_attributes(hazard_description: nil, hazard_type: nil, non_compliant_reason: nil, reported_reason: nil)
     end
   end
 

--- a/app/services/change_ucr_numbers.rb
+++ b/app/services/change_ucr_numbers.rb
@@ -16,7 +16,7 @@ class ChangeUcrNumbers
     end
     context.changed = true
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/views/notifications/create/_ucr_numbers_form.html.erb
+++ b/app/views/notifications/create/_ucr_numbers_form.html.erb
@@ -1,0 +1,14 @@
+<div class="nested-form-wrapper govuk-grid-row govuk-!-margin-bottom-0" data-new-record="<%= f.object.new_record? %>">
+  <div class="govuk-grid-column-three-quarters">
+    <%= f.govuk_text_field :number, label: nil %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <p class="govuk-body">
+      <a href="#" class="govuk-link govuk-link--no-visited-state opss-nojs-hide" data-action="nested-form#remove">Remove</a>
+      <% if f.object.persisted? %>
+        <a href="<%= delete_ucr_number_notification_create_index_path(ucr_number_id: f.object.id) %>" class="govuk-link govuk-link--no-visited-state opss-js-enabled-hidden" rel="nofollow">Remove</a>
+      <% end %>
+      <%= f.hidden_field :_destroy %>
+    </p>
+  </div>
+</div>

--- a/app/views/notifications/create/add_business_details.html.erb
+++ b/app/views/notifications/create/add_business_details.html.erb
@@ -1,0 +1,14 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_details.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_business_details.title") %>
+      </h1>
+      <p class="govuk-body">This page intentionally left blank.</p>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: false) %>
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: @change_notification_details_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/notifications/create/add_product_identification_details.html.erb
+++ b/app/views/notifications/create/add_product_identification_details.html.erb
@@ -1,0 +1,74 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+        <% @notification.investigation_products.decorate.each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
+        <% end %>
+        </ul>
+      <% end %>
+      <p class="govuk-body">Add product identification details if known.</p>
+      <% @notification.investigation_products.decorate.each do |investigation_product| %>
+        <%=
+          govuk_summary_list(
+            card: { title: investigation_product.product.name_with_brand },
+            rows: [
+              {
+                key: { text: "Batch numbers" },
+                value: { text: investigation_product.batch_number.presence || "Not provided" },
+                actions: [
+                  {
+                    text: "Add",
+                    href: batch_numbers_notification_create_index_path(@notification, investigation_product.id),
+                    visually_hidden_text: "batch numbers"
+                  }
+                ]
+              },              {
+                key: { text: "Customs codes" },
+                value: { text: investigation_product.customs_code.presence || "Not provided" },
+                actions: [
+                  {
+                    text: "Add",
+                    href: customs_codes_notification_create_index_path(@notification, investigation_product.id),
+                    visually_hidden_text: "customs codes"
+                  }
+                ]
+              },
+              {
+                key: { text: "Unique Consignment Reference (UCR) numbers" },
+                value: { text: investigation_product.ucr_numbers.pluck(:number).join(", ").presence || "Not provided" },
+                actions: [
+                  {
+                    text: "Add",
+                    href: ucr_numbers_notification_create_index_path(@notification, investigation_product.id),
+                    visually_hidden_text: "unique consignment reference numbers"
+                  }
+                ]
+              },
+              {
+                key: { text: "Number of units affected" },
+                value: { text: number_of_affected_units(investigation_product.affected_units_status, investigation_product.number_of_affected_units) },
+                actions: [
+                  {
+                    text: "Add",
+                    href: number_of_affected_units_notification_create_index_path(@notification, investigation_product.id),
+                    visually_hidden_text: "number of units affected"
+                  }
+                ]
+              }
+            ]
+          )
+        %>
+      <% end %>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_identification_details_batch_numbers.html.erb
+++ b/app/views/notifications/create/add_product_identification_details_batch_numbers.html.erb
@@ -1,0 +1,22 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_batch_numbers.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: batch_numbers_notification_create_index_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_batch_numbers.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
+        </ul>
+      <% end %>
+      <%= f.govuk_text_field :batch_number, label: nil, hint: { text: "Use a comma and a space to separate multiple batch numbers. For example, 37364361, 98774776" }, value: @investigation_product.batch_number %>
+      <%= f.govuk_submit "Save" do %>
+        <a href="<%= wizard_path(:add_product_identification_details) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_identification_details_customs_codes.html.erb
+++ b/app/views/notifications/create/add_product_identification_details_customs_codes.html.erb
@@ -1,0 +1,22 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_customs_codes.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: customs_codes_notification_create_index_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_customs_codes.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
+        </ul>
+      <% end %>
+      <%= f.govuk_text_field :customs_code, label: nil, hint: { text: "For example, a CN code (8 digits) or a TARIC code (10 digits). Use a comma and a space to separate multiple customs codes." }, value: @investigation_product.customs_code %>
+      <%= f.govuk_submit "Save" do %>
+        <a href="<%= wizard_path(:add_product_identification_details) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_identification_details_number_of_affected_units.html.erb
+++ b/app/views/notifications/create/add_product_identification_details_number_of_affected_units.html.erb
@@ -1,0 +1,33 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_number_of_affected_units.title"), errors: @number_of_affected_units_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @number_of_affected_units_form, url: number_of_affected_units_notification_create_index_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_number_of_affected_units.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
+        </ul>
+      <% end %>
+      <%= f.govuk_radio_buttons_fieldset :affected_units_status, legend: nil do %>
+        <%= f.govuk_radio_button :affected_units_status, "exact", label: { text: "Exact number" }, link_errors: true do %>
+          <%= f.govuk_number_field :exact_units, label: { text: "How many units are affected?" } %>
+        <% end %>
+        <%= f.govuk_radio_button :affected_units_status, "approx", label: { text: "Approxmate number" } do %>
+          <%= f.govuk_number_field :approx_units, label: { text: "How many units are affected?" } %>
+        <% end %>
+        <%= f.govuk_radio_button :affected_units_status, "unknown", label: { text: "Unknown" } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :affected_units_status, "not_relevant", label: { text: "Not relevant" } %>
+      <% end %>
+      <%= f.govuk_submit "Save" do %>
+        <a href="<%= wizard_path(:add_product_identification_details) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_identification_details_ucr_numbers.html.erb
+++ b/app/views/notifications/create/add_product_identification_details_ucr_numbers.html.erb
@@ -1,0 +1,31 @@
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_ucr_numbers.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @investigation_product, url: ucr_numbers_notification_create_index_path, method: :patch, data: { controller: "nested-form", nested_form_wrapper_selector_value: ".nested-form-wrapper" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_product_identification_details_ucr_numbers.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
+        </ul>
+      <% end %>
+      <template data-nested-form-target="template">
+        <%= f.fields_for :ucr_numbers, @investigation_product.ucr_numbers.new, child_index: "NEW_RECORD" do |ucr_fields| %>
+          <%= render "ucr_numbers_form", f: ucr_fields %>
+        <% end %>
+      </template>
+      <%= f.fields_for :ucr_numbers do |ucr_fields| %>
+        <%= render "ucr_numbers_form", f: ucr_fields %>
+      <% end %>
+      <div data-nested-form-target="target"></div>
+      <button type="button" data-action="nested-form#add" class="govuk-button govuk-button--secondary opss-nojs-hide">Add UCR number</button>
+      <%= f.govuk_submit "Save" do %>
+        <a href="<%= wizard_path(:add_product_identification_details) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
+++ b/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_safety_and_compliance_details.title"), errors: false) %>
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_product_safety_and_compliance_details.title"), errors: @change_notification_product_safety_compliance_details_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,21 +11,23 @@
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
         <ul class="govuk-list">
-        <% @notification.products.decorate.each do |product| %>
-          <li class="govuk-body-l"><%= product.name_with_brand %></li>
+        <% @notification.investigation_products.decorate.each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
         <% end %>
         </ul>
       <% end %>
-      <%= f.govuk_check_boxes_fieldset :unsafe, multiple: false, legend: { text: "What specific issues make the #{'product'.pluralize(@notification.products.count)} unsafe or non-compliant?", size: "m" } do %>
-        <%= f.govuk_check_box :unsafe, true, false, multiple: false, link_errors: true, label: { text: "Product hazard" } do %>
-          <%= f.govuk_collection_select :primary_hazard, hazards_options, :id, :name, label: { text: "What is the primary hazard?" } %>
-          <%= f.govuk_text_area :primary_hazard_description, label: { text: "Provide additional information about the product hazard" }, hint: { text: "If the product has been involved in an incident include this additional information." }, max_chars: 10_000 %>
-        <% end %>
-        <%= f.govuk_check_box :noncompliant, true, false, multiple: false, label: { text: "Product incomplete markings, labeling or other issues" } do %>
-          <%= f.govuk_text_area :noncompliance_description, label: { text: "Describe the product non-compliance issues" }, max_chars: 10_000 %>
+      <% unless @notification.reported_reason&.safe_and_compliant? %>
+        <%= f.govuk_check_boxes_fieldset :unsafe, multiple: false, legend: { text: "What specific issues make the #{'product'.pluralize(@notification.products.count)} unsafe or non-compliant?", size: "m" }, hint: { text: "Please select all applicable issues." } do %>
+          <%= f.govuk_check_box :unsafe, true, false, multiple: false, link_errors: true, label: { text: "Product hazard" } do %>
+            <%= f.govuk_collection_select :primary_hazard, hazards_options, :id, :name, label: { text: "What is the primary hazard?" } %>
+            <%= f.govuk_text_area :primary_hazard_description, label: { text: "Provide additional information about the product hazard" }, hint: { text: "If the product has been involved in an incident include this additional information." }, max_chars: 10_000 %>
+          <% end %>
+          <%= f.govuk_check_box :noncompliant, true, false, multiple: false, label: { text: "Product incomplete markings, labeling or other issues" } do %>
+            <%= f.govuk_text_area :noncompliance_description, label: { text: "Describe the product non-compliance issues" }, max_chars: 10_000 %>
+          <% end %>
         <% end %>
       <% end %>
-      <%= f.govuk_radio_buttons_fieldset :add_reference_number, legend: { text: "Do you want to add your own reference number?", size: "m" } do %>
+      <%= f.govuk_radio_buttons_fieldset :add_reference_number, legend: { text: "Do you want to add your own reference number?", size: "m" }, hint: { text: "The reference number might be from a different internal system for your notification or a global identifier for multiple systems. It's searchable on the PSD notification search page and can be added or edited later." } do %>
         <%= f.govuk_radio_button :add_reference_number, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_text_field :reference_number, label: { text: "Reference number" } %>
         <% end %>

--- a/app/views/notifications/create/index.html.erb
+++ b/app/views/notifications/create/index.html.erb
@@ -7,8 +7,8 @@
       <%= govuk_inset_text do %>
         <p class="govuk-body">For</p>
         <ul class="govuk-list">
-        <% @notification.products.decorate.each do |product| %>
-          <li class="govuk-body-l"><%= product.name_with_brand %></li>
+        <% @notification.investigation_products.decorate.each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
         <% end %>
         </ul>
         <p class="govuk-body"><a href="<%= wizard_path(:search_for_or_add_a_product) %>?search" class="govuk-link govuk-link--no-visited-state">Add another product</a></p>

--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -21,9 +21,9 @@
           <p class="govuk-body">You have added <%= pluralize(@existing_product_ids.length, "product") %>.
           <%=
             govuk_summary_list do |summary_list|
-              @notification.products.decorate.each do |product|
+              @notification.investigation_products.decorate.each do |investigation_product|
                 summary_list.with_row do |row|
-                  row.with_key(text: product.name_with_brand)
+                  row.with_key(text: investigation_product.product.name_with_brand)
                   row.with_action(text: "Remove", href: "#", visually_hidden_text: "product from notification")
                 end
               end
@@ -31,7 +31,7 @@
           %>
           <%= form_with url: request.fullpath, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
             <%= f.govuk_collection_radio_buttons :add_another_product, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another product?", size: "m" } %>
-            <%= f.govuk_submit("Save and continue") %>
+            <%= f.govuk_submit("Save and complete tasks in this section") %>
           <% end %>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -396,6 +396,14 @@ en:
                 title: Add product safety and compliance details
               add_product_identification_details:
                 title: Add product identification details
+              add_product_identification_details_batch_numbers:
+                title: Add batch numbers
+              add_product_identification_details_customs_codes:
+                title: Add customs codes
+              add_product_identification_details_ucr_numbers:
+                title: Add Unique Consignment Reference (UCR) numbers
+              add_product_identification_details_number_of_affected_units:
+                title: Add the number of units affected
           business_details:
             title: Add the business in the product's supply chain
             tasks:
@@ -833,6 +841,10 @@ en:
               inclusion: Choose whether you want to add your own reference number
             reference_number:
               blank: Enter a reference number
+        number_of_affected_units_form:
+          attributes:
+            affected_units_status:
+              inclusion: Choose how to define the number of units affected
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,14 @@ Rails.application.routes.draw do
         resources :create, only: %i[index show update] do
           collection do
             get "add-product/:product_id", to: "create#add_product", as: "add_product"
+
+            %w[batch_numbers customs_codes ucr_numbers number_of_affected_units].each do |identifier|
+              get "add_product_identification_details/#{identifier}/:investigation_product_id", to: "create#show_#{identifier}", as: identifier
+              patch "add_product_identification_details/#{identifier}/:investigation_product_id", to: "create#update_#{identifier}"
+              put "add_product_identification_details/#{identifier}/:investigation_product_id", to: "create#update_#{identifier}"
+            end
+
+            get "add_product_identification_details/ucr_numbers/:investigation_product_id/:ucr_number_id", to: "create#delete_ucr_number", as: "delete_ucr_number"
           end
         end
       end

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -102,9 +102,15 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
       fill_in "Reference number", with: "123456"
     end
 
-    click_button "Save as draft"
+    click_button "Save and continue"
+
+    click_link "Add batch numbers"
+    fill_in "batch_number", with: "1234, 5678"
+    click_button "Save"
+    click_button "Save and complete tasks in this section"
 
     expect(page).to have_selector(:id, "task-list-1-0-status", text: "Completed")
     expect(page).to have_selector(:id, "task-list-1-1-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-1-2-status", text: "Completed")
   end
 end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2252

## Description

Adds the “add product identification details” task including batch numbers, customs codes, UCR numbers and number of units affected.

Also:

* Fixes display of form submission errors in the body and title of the page
* Hides unsafe/non-compliant checkboxes if the notification as already been marked as “safe and compliant”
* Fixes saving of unsafe/non-compliant data
* Adds a placeholder page for section 3 to allow progress to section 4
* Fixes logic to allow all optional tasks to be enabled simultaneously as well as the next mandatory task

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-01-11 at 16 24 45](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/c37e2f4b-7100-4720-92a2-d2a01ccd7af9)

## Review apps

https://psd-pr-2829.london.cloudapps.digital/
https://psd-pr-2829-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
