### PR TITLE
Notification task list: allow product removal

### DIFF
--- a/app/services/remove_product_from_notification.rb
+++ b/app/services/remove_product_from_notification.rb
@@ -20,7 +20,7 @@ class RemoveProductFromNotification
 
     context.activity = create_audit_activity_for_product_removed
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/views/notifications/create/remove_product.html.erb
+++ b/app/views/notifications/create/remove_product.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("Remove product from notification", errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: remove_product_notification_create_index_path(investigation_product_id: @investigation_product.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to remove this product from your notification?
+      </h1>
+      <p class="govuk-body">This action will remove <strong><%= @investigation_product.decorate.product.name_with_brand %></strong> from your notification. Please confirm if you wish to proceed.</p>
+      <%= f.govuk_submit "Remove product", warning: true do %>
+        <a href="<%= notification_create_path(@notification, "search_for_or_add_a_product") %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -19,19 +19,24 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <p class="govuk-body">You have added <%= pluralize(@existing_product_ids.length, "product") %>.
+          <% if @notification.tasks_status["search_for_or_add_a_product"] == "completed" %>
+            <p class="govuk-body">You have completed adding products. If removal of any products is necessary, please delete the current notification and create a new one.</p>
+          <% else %>
+            <p class="govuk-body">Once you complete adding products, you will not be able to subsequently remove any products without deleting the current notification and creating a new one.</p>
+          <% end %>
           <%=
             govuk_summary_list do |summary_list|
               @notification.investigation_products.decorate.each do |investigation_product|
                 summary_list.with_row do |row|
                   row.with_key(text: investigation_product.product.name_with_brand)
-                  row.with_action(text: "Remove", href: "#", visually_hidden_text: "product from notification")
+                  row.with_action(text: "Remove", href: remove_product_notification_create_index_path(investigation_product_id: investigation_product.id), visually_hidden_text: "product from notification") unless @notification.tasks_status["search_for_or_add_a_product"] == "completed"
                 end
               end
             end
           %>
-          <%= form_with url: request.fullpath, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+          <%= form_with url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
             <%= f.govuk_collection_radio_buttons :add_another_product, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another product?", size: "m" } %>
-            <%= f.govuk_submit("Save and complete tasks in this section") %>
+            <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
           <% end %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,8 @@ Rails.application.routes.draw do
         resources :create, only: %i[index show update] do
           collection do
             get "add-product/:product_id", to: "create#add_product", as: "add_product"
+            get "remove-product/:investigation_product_id", to: "create#remove_product", as: "remove_product"
+            delete "remove-product/:investigation_product_id", to: "create#remove_product"
 
             %w[batch_numbers customs_codes ucr_numbers number_of_affected_units].each do |identifier|
               get "add_product_identification_details/#{identifier}/:investigation_product_id", to: "create#show_#{identifier}", as: identifier
@@ -133,7 +135,7 @@ Rails.application.routes.draw do
               put "add_product_identification_details/#{identifier}/:investigation_product_id", to: "create#update_#{identifier}"
             end
 
-            get "add_product_identification_details/ucr_numbers/:investigation_product_id/:ucr_number_id", to: "create#delete_ucr_number", as: "delete_ucr_number"
+            get "add_product_identification_details/ucr_numbers/:investigation_product_id/delete/:ucr_number_id", to: "create#delete_ucr_number", as: "delete_ucr_number"
           end
         end
       end

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -24,7 +24,15 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
   scenario "Creating a notification from an existing product" do
     visit "/notifications/create/from-product/#{existing_product.id}"
 
-    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create\/search_for_or_add_a_product/)
+    expect(page).to have_content("Search for or add a product")
+
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Save and complete tasks in this section"
+
     expect(page).to have_content("Create a product safety notification")
     expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
   end
@@ -66,7 +74,15 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
 
     click_button "Save"
 
-    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create\/search_for_or_add_a_product/)
+    expect(page).to have_content("Search for or add a product")
+
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Save and complete tasks in this section"
+
     expect(page).to have_content("Create a product safety notification")
     expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
   end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2312

## Description

Allows products to be removed from a notification before the “search for or add a product” task has been marked as completed.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2831.london.cloudapps.digital/
https://psd-pr-2831-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
