### PR TITLE
2300 2337 remove type filter for non-opss users

### DIFF
--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -22,6 +22,8 @@ module InvestigationsHelper
       wheres[:type] = "Investigation::Enquiry"
     end
 
+    wheres[:type] = "Investigation::Notification" unless user.is_opss?
+
     if @search.priority == "serious_and_high_risk_level_only"
       wheres[:risk_level] = %i[serious high]
     end
@@ -132,7 +134,11 @@ module InvestigationsHelper
 
     wheres = {}
 
-    case_types = CASE_TYPES.map { |type| "Investigation::#{type.capitalize}" if @search.send(type) }.compact
+    case_types =  if user.is_opss?
+                    CASE_TYPES.map { |type| "Investigation::#{type.capitalize}" if @search.send(type) }.compact
+                  else
+                    ["Investigation::Notification"]
+                  end
     wheres[:type] = case_types unless case_types.empty?
 
     risk_levels = []

--- a/app/views/notifications/_filters.html.erb
+++ b/app/views/notifications/_filters.html.erb
@@ -26,9 +26,13 @@
     <%= govuk_details(summary_text: "Created by", classes: "opss-details--plain", id: "cases-created-by") do %>
       <%= render "notifications/case_creator_checkboxes", form: form %>
     <% end %>
-    <%= govuk_details(summary_text: "Notification type", classes: "opss-details--plain", id: "case-type") do %>
-      <%= render "notifications/case_type_checkboxes", form: form %>
+
+    <% if current_user.is_opss? %>
+      <%= govuk_details(summary_text: "Type", classes: "opss-details--plain", id: "case-type") do %>
+        <%= render "notifications/case_type_checkboxes", form: form %>
+      <% end %>
     <% end %>
+
     <%= govuk_details(summary_text: "Notification hazard type", classes: "opss-details--plain", id: "case-hazard-type") do %>
       <%= render "notifications/case_hazard_type_checkboxes", form: form %>
     <% end %>

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -8,18 +8,18 @@ RSpec.feature "Investigation listing", :with_opensearch, :with_stubbed_mailer, t
     }
   end
 
-  let!(:investigation_last_updated_3_days_ago) { create(:allegation, description: "Electric skateboard investigation").decorate }
-  let!(:investigation_last_updated_2_days_ago) { create(:allegation, description: "FastToast toaster investigation").decorate }
-  let!(:investigation_last_updated_1_days_ago) { create(:allegation, description: "Counterfeit chargers investigation").decorate }
+  let!(:investigation_last_updated_3_days_ago) { create(:notification, description: "Electric skateboard investigation").decorate }
+  let!(:investigation_last_updated_2_days_ago) { create(:notification, description: "FastToast toaster investigation").decorate }
+  let!(:investigation_last_updated_1_days_ago) { create(:notification, description: "Counterfeit chargers investigation").decorate }
 
   before do
     allow(AuditActivity::Investigation::Base).to receive(:from)
-    create_list :project, 18
+    create_list :notification, 18
 
+    Investigation::Notification.update_all(updated_at: 4.days.ago)
     investigation_last_updated_3_days_ago.update!(updated_at: 3.days.ago)
     investigation_last_updated_2_days_ago.update!(updated_at: 2.days.ago)
     investigation_last_updated_1_days_ago.update!(updated_at: 1.day.ago)
-    Investigation::Project.update_all(updated_at: 4.days.ago)
   end
 
   scenario "lists cases correctly sorted" do

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
   let(:other_user)        { create(:user, :activated, has_viewed_introduction: true) }
   let(:brand)             { Faker::Appliance.brand }
   let(:country_of_origin) { "France" }
-  let(:investigation)     { create(:allegation, creator: user) }
+  let(:investigation)     { create(:notification, creator: user) }
   let(:product) do
     create(:product,
            authenticity: "counterfeit",

--- a/spec/features/editing_business_details_spec.rb
+++ b/spec/features/editing_business_details_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch do
   let(:user)     { create(:user, :activated) }
   let(:business) { create(:business, trading_name: "OldCo") }
-  let!(:investigation) { create(:allegation, businesses: [business]) }
+  let!(:investigation) { create(:notification, businesses: [business]) }
 
   before do
     create(:contact, business:)

--- a/spec/features/filter_notifications_spec.rb
+++ b/spec/features/filter_notifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
   let(:organisation)          { create(:organisation) }
   let(:team)                  { create(:team, organisation:) }
   let(:other_team)            { create(:team, organisation:, name: "other team") }
-  let(:user)                  { create(:user, :activated, organisation:, team:, has_viewed_introduction: true) }
+  let(:user)                  { create(:user, :activated, :opss_user, organisation:, team:, has_viewed_introduction: true) }
   let(:other_user_same_team)  { create(:user, :activated, name: "other user same team", organisation:, team:) }
   let(:yet_another_user_same_team) { create(:user, :activated, name: "yet another user same team", organisation:, team: other_team) }
   let(:other_user_other_team) { create(:user, :activated, name: "other user other team", organisation:, team: other_team) }
@@ -388,8 +388,19 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
     end
 
     describe "notification type" do
+      context "with a non OPSS user" do
+        let(:user) { create(:user, :activated, organisation:, team:, has_viewed_introduction: true) }
+
+        scenario "filter should be unavailable" do
+          expect(page).not_to have_listed_case(allegation.pretty_id)
+          expect(page).to have_listed_case(notification.pretty_id)
+          expect(page).not_to have_listed_case(project.pretty_id)
+          expect(page).not_to have_listed_case(enquiry.pretty_id)
+          expect(page).not_to have_css("details#case-type", text: "Type")
+        end
+      end
+
       context "with an OPSS user" do
-        let(:user) { create(:user, :activated, :opss_user, organisation:, team:, has_viewed_introduction: true) }
 
         scenario "filtering for projects" do
           within_fieldset "Type" do

--- a/spec/features/filter_notifications_spec.rb
+++ b/spec/features/filter_notifications_spec.rb
@@ -401,7 +401,6 @@ RSpec.feature "Notification filtering", :with_opensearch, :with_stubbed_mailer, 
       end
 
       context "with an OPSS user" do
-
         scenario "filtering for projects" do
           within_fieldset "Type" do
             choose "Project"

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Searching notifications", :with_opensearch, :with_stubbed_mailer, type: :feature do
-  let(:user) { create :user, :activated, has_viewed_introduction: true }
+  let(:user) { create :user, :activated, :opss_user, has_viewed_introduction: true }
 
   let(:product) do
     create(:product,

--- a/spec/features/search_notifications_spec.rb
+++ b/spec/features/search_notifications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Searching notifications", :with_opensearch, :with_stubbed_mailer, type: :feature do
-  let(:user) { create :user, :activated, :can_access_new_search, has_viewed_introduction: true }
+  let(:user) { create :user, :activated, :can_access_new_search, :opss_user, has_viewed_introduction: true }
 
   let(:product) do
     create(:product,

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         end
 
         it "restricts the description" do
-          create(:allegation, description: "=A1")
+          create(:notification, description: "=A1")
           Investigation.reindex
 
           get generate_case_exports_path, params: { q: "A1" }
@@ -76,7 +76,7 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
         end
 
         it "restricts risk_validated_at" do
-          create(:allegation, risk_validated_at: Date.current)
+          create(:notification, risk_validated_at: Date.current)
 
           Investigation.reindex
 


### PR DESCRIPTION
## Description

Remove type filter for non-opss users

## Screen-shots or screen-capture of UI changes
![Screenshot 2024-01-15 at 12-10-34 All notifications – Search - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/65005be4-2084-499e-bc7b-4b13ddfefa63)


## Review apps

https://psd-pr-2832.london.cloudapps.digital/
https://psd-pr-2832-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
