### PR TITLE
PSD 2320 rearrange column order on notification extract

### DIFF
--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -110,31 +110,31 @@ private
   def add_header_row(sheet)
     sheet.add_row %w[ID
                      Status
-                     Title
                      Type
+                     Title
                      Description
                      Product_Category
-                     Hazard_Type
+                     Reported_Reason
                      Risk_Level
-                     Case_Owner_Team
+                     Hazard_Type
+                     Unsafe_Reason
+                     Non_Compliant_Reason
                      Products
                      Businesses
                      Corrective_Actions
                      Tests
                      Risk_Assessments
-                     Date_Created
-                     Last_Updated
-                     Date_Closed
-                     Date_Validated
+                     Case_Owner_Team
                      Case_Creator_Team
-                     Notifying_Country
-                     Reported_Reason
                      Notifiers_Reference
+                     Notifying_Country
                      Trading_Standards_Region
                      Regulator_Name
                      OPSS_Internal_Team
-                     Non_Compliant_Reason
-                     Unsafe_Reason]
+                     Date_Created
+                     Last_Updated
+                     Date_Closed
+                     Date_Validated]
   end
 
   def find_cases(ids)
@@ -153,31 +153,31 @@ private
     [
       investigation.pretty_id,
       investigation.is_closed? ? "Closed" : "Open",
-      investigation.title,
       investigation.type,
+      investigation.title,
       restrict_data_for_non_opss_user(investigation.object.description),
       investigation.categories.join(", "),
-      investigation.hazard_type,
+      investigation.reported_reason,
       investigation.risk_level_description,
-      investigation.owner_team&.name,
+      investigation.hazard_type,
+      investigation.hazard_description,
+      investigation.non_compliant_reason,
       product_counts[investigation.id] || 0,
       business_counts[investigation.id] || 0,
       corrective_action_counts[investigation.id] || 0,
       test_counts[investigation.id] || 0,
       risk_assessment_counts[investigation.id] || 0,
+      investigation.owner_team&.name,
+      investigation.creator_user&.team&.name,
+      investigation.complainant_reference,
+      country_from_code(investigation.notifying_country, Country.notifying_countries),
+      team_data.ts_region,
+      team_data.regulator_name,
+      restrict_data_for_non_opss_user((team_data.type == "internal")),
       investigation.created_at,
       investigation.updated_at,
       investigation.date_closed,
       restrict_data_for_non_opss_user(investigation.risk_validated_at),
-      investigation.creator_user&.team&.name,
-      country_from_code(investigation.notifying_country, Country.notifying_countries),
-      investigation.reported_reason,
-      investigation.complainant_reference,
-      team_data.ts_region,
-      team_data.regulator_name,
-      restrict_data_for_non_opss_user((team_data.type == "internal")),
-      investigation.non_compliant_reason,
-      investigation.hazard_description
     ]
   end
 
@@ -191,31 +191,31 @@ private
     [
       investigation.pretty_id,
       investigation.is_closed? ? "Closed" : "Open",
-      "Restricted",
       investigation.type,
       "Restricted",
+      "Restricted",
       investigation.categories.join(", "),
-      investigation.hazard_type,
+      investigation.reported_reason,
       investigation.risk_level_description,
-      investigation.owner_team&.name,
+      investigation.hazard_type,
+      investigation.non_compliant_reason,
+      investigation.hazard_description,
       product_counts[investigation.id] || 0,
       business_counts[investigation.id] || 0,
       corrective_action_counts[investigation.id] || 0,
       test_counts[investigation.id] || 0,
       risk_assessment_counts[investigation.id] || 0,
-      investigation.created_at,
-      investigation.updated_at,
-      investigation.date_closed,
-      investigation.risk_validated_at,
+      investigation.owner_team&.name,
       investigation.creator_user&.team&.name,
-      country_from_code(investigation.notifying_country, Country.notifying_countries),
-      investigation.reported_reason,
       "Restricted",
+      country_from_code(investigation.notifying_country, Country.notifying_countries),
       team_data.ts_region,
       team_data.regulator_name,
       (team_data.type == "internal"),
-      investigation.non_compliant_reason,
-      investigation.hazard_description
+      investigation.created_at,
+      investigation.updated_at,
+      investigation.date_closed,
+      investigation.risk_validated_at
     ]
   end
 end

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
       expect(sheet.cell(2, 2)).to eq(investigation.is_closed? ? "Closed" : "Open")
       expect(sheet.cell(3, 2)).to eq(other_team_investigation.is_closed? ? "Closed" : "Open")
 
-      expect(sheet.cell(1, 3)).to eq "Title"
-      expect(sheet.cell(2, 3)).to eq investigation.title
-      expect(sheet.cell(3, 3)).to eq "Restricted"
+      expect(sheet.cell(1, 3)).to eq "Type"
+      expect(sheet.cell(2, 3)).to eq investigation.type
+      expect(sheet.cell(3, 3)).to eq other_team_investigation.type
 
-      expect(sheet.cell(1, 4)).to eq "Type"
-      expect(sheet.cell(2, 4)).to eq investigation.type
-      expect(sheet.cell(3, 4)).to eq other_team_investigation.type
+      expect(sheet.cell(1, 4)).to eq "Title"
+      expect(sheet.cell(2, 4)).to eq investigation.title
+      expect(sheet.cell(3, 4)).to eq "Restricted"
 
       expect(sheet.cell(1, 5)).to eq "Description"
       expect(sheet.cell(2, 5)).to eq investigation.object.description
@@ -89,90 +89,90 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
       expect(sheet.cell(2, 6)).to eq investigation.categories.presence&.join(", ")
       expect(sheet.cell(3, 6)).to eq other_team_investigation.categories.presence&.join(", ")
 
-      expect(sheet.cell(1, 7)).to eq "Hazard_Type"
-      expect(sheet.cell(2, 7)).to eq investigation.hazard_type
-      expect(sheet.cell(3, 7)).to eq other_team_investigation.hazard_type
+      expect(sheet.cell(1, 7)).to eq "Reported_Reason"
+      expect(sheet.cell(2, 7)).to eq investigation.reported_reason
+      expect(sheet.cell(3, 7)).to eq other_team_investigation.reported_reason
 
       expect(sheet.cell(1, 8)).to eq "Risk_Level"
       expect(sheet.cell(2, 8)).to eq investigation.decorate.risk_level_description
       expect(sheet.cell(3, 8)).to eq other_team_investigation.decorate.risk_level_description
 
-      expect(sheet.cell(1, 9)).to eq "Case_Owner_Team"
-      expect(sheet.cell(2, 9)).to eq investigation.owner_team&.name
-      expect(sheet.cell(3, 9)).to eq other_team_investigation.owner_team&.name
+      expect(sheet.cell(1, 9)).to eq "Hazard_Type"
+      expect(sheet.cell(2, 9)).to eq investigation.hazard_type
+      expect(sheet.cell(3, 9)).to eq other_team_investigation.hazard_type
+
+      expect(sheet.cell(1, 10)).to eq "Unsafe_Reason"
+      expect(sheet.cell(2, 10)).to eq investigation.hazard_description
+      expect(sheet.cell(3, 10)).to eq other_team_investigation.hazard_description
+
+      expect(sheet.cell(1, 11)).to eq "Non_Compliant_Reason"
+      expect(sheet.cell(2, 11)).to eq investigation.non_compliant_reason
+      expect(sheet.cell(3, 11)).to eq other_team_investigation.non_compliant_reason
 
       # TODO: This will be flaky if Faker generates two dupes
-      expect(sheet.cell(1, 10)).to eq "Products"
-      expect(sheet.cell(2, 10)).to eq "0"
-      expect(sheet.cell(3, 10)).to eq "0"
-
-      expect(sheet.cell(1, 11)).to eq "Businesses"
-      expect(sheet.cell(2, 11)).to eq "0"
-      expect(sheet.cell(3, 11)).to eq "0"
-
-      expect(sheet.cell(1, 12)).to eq "Corrective_Actions"
+      expect(sheet.cell(1, 12)).to eq "Products"
       expect(sheet.cell(2, 12)).to eq "0"
       expect(sheet.cell(3, 12)).to eq "0"
 
-      expect(sheet.cell(1, 13)).to eq "Tests"
+      expect(sheet.cell(1, 13)).to eq "Businesses"
       expect(sheet.cell(2, 13)).to eq "0"
       expect(sheet.cell(3, 13)).to eq "0"
 
-      expect(sheet.cell(1, 14)).to eq "Risk_Assessments"
+      expect(sheet.cell(1, 14)).to eq "Corrective_Actions"
       expect(sheet.cell(2, 14)).to eq "0"
       expect(sheet.cell(3, 14)).to eq "0"
 
-      expect(sheet.cell(1, 15)).to eq "Date_Created"
-      expect(sheet.cell(2, 15)).to eq investigation.created_at&.to_s
-      expect(sheet.cell(3, 15)).to eq other_team_investigation.created_at&.to_s
+      expect(sheet.cell(1, 15)).to eq "Tests"
+      expect(sheet.cell(2, 15)).to eq "0"
+      expect(sheet.cell(3, 15)).to eq "0"
 
-      expect(sheet.cell(1, 16)).to eq "Last_Updated"
-      expect(sheet.cell(2, 16)).to eq investigation.updated_at&.to_s
-      expect(sheet.cell(3, 16)).to eq other_team_investigation.updated_at&.to_s
+      expect(sheet.cell(1, 16)).to eq "Risk_Assessments"
+      expect(sheet.cell(2, 16)).to eq "0"
+      expect(sheet.cell(3, 16)).to eq "0"
 
-      expect(sheet.cell(1, 17)).to eq "Date_Closed"
-      expect(sheet.cell(2, 17)).to eq investigation.date_closed&.to_s
-      expect(sheet.cell(3, 17)).to eq other_team_investigation.date_closed&.to_s
+      expect(sheet.cell(1, 17)).to eq "Case_Owner_Team"
+      expect(sheet.cell(2, 17)).to eq investigation.owner_team&.name
+      expect(sheet.cell(3, 17)).to eq other_team_investigation.owner_team&.name
 
-      expect(sheet.cell(1, 18)).to eq "Date_Validated"
-      expect(sheet.cell(2, 18)).to eq investigation.risk_validated_at&.to_s
-      expect(sheet.cell(3, 18)).to eq other_team_investigation.risk_validated_at&.to_s
+      expect(sheet.cell(1, 18)).to eq "Case_Creator_Team"
+      expect(sheet.cell(2, 18)).to eq investigation.creator_user&.team&.name
+      expect(sheet.cell(3, 18)).to eq other_team_investigation.creator_user&.team&.name
 
-      expect(sheet.cell(1, 19)).to eq "Case_Creator_Team"
-      expect(sheet.cell(2, 19)).to eq investigation.creator_user&.team&.name
-      expect(sheet.cell(3, 19)).to eq other_team_investigation.creator_user&.team&.name
+      expect(sheet.cell(1, 19)).to eq "Notifiers_Reference"
+      expect(sheet.cell(2, 19)).to eq investigation.complainant_reference
+      expect(sheet.cell(3, 19)).to eq "Restricted"
 
       expect(sheet.cell(1, 20)).to eq "Notifying_Country"
       expect(sheet.cell(2, 20)).to eq "England"
       expect(sheet.cell(3, 20)).to eq "England"
 
-      expect(sheet.cell(1, 21)).to eq "Reported_Reason"
-      expect(sheet.cell(2, 21)).to eq investigation.reported_reason
-      expect(sheet.cell(3, 21)).to eq other_team_investigation.reported_reason
+      expect(sheet.cell(1, 21)).to eq "Trading_Standards_Region"
+      expect(sheet.cell(2, 21)).to eq "Scotland"
+      expect(sheet.cell(3, 21)).to eq nil
 
-      expect(sheet.cell(1, 22)).to eq "Notifiers_Reference"
-      expect(sheet.cell(2, 22)).to eq investigation.complainant_reference
-      expect(sheet.cell(3, 22)).to eq "Restricted"
+      expect(sheet.cell(1, 22)).to eq "Regulator_Name"
+      expect(sheet.cell(2, 22)).to eq nil
+      expect(sheet.cell(3, 22)).to eq "Department of Agriculture, Environment and Rural Affairs (DAERA)"
 
-      expect(sheet.cell(1, 23)).to eq "Trading_Standards_Region"
-      expect(sheet.cell(2, 23)).to eq "Scotland"
-      expect(sheet.cell(3, 23)).to eq nil
+      expect(sheet.cell(1, 23)).to eq "OPSS_Internal_Team"
+      expect(sheet.cell(2, 23)).to eq "false"
+      expect(sheet.cell(3, 23)).to eq "false"
 
-      expect(sheet.cell(1, 24)).to eq "Regulator_Name"
-      expect(sheet.cell(2, 24)).to eq nil
-      expect(sheet.cell(3, 24)).to eq "Department of Agriculture, Environment and Rural Affairs (DAERA)"
+      expect(sheet.cell(1, 24)).to eq "Date_Created"
+      expect(sheet.cell(2, 24)).to eq investigation.created_at&.to_s
+      expect(sheet.cell(3, 24)).to eq other_team_investigation.created_at&.to_s
 
-      expect(sheet.cell(1, 25)).to eq "OPSS_Internal_Team"
-      expect(sheet.cell(2, 25)).to eq "false"
-      expect(sheet.cell(3, 25)).to eq "false"
+      expect(sheet.cell(1, 25)).to eq "Last_Updated"
+      expect(sheet.cell(2, 25)).to eq investigation.updated_at&.to_s
+      expect(sheet.cell(3, 25)).to eq other_team_investigation.updated_at&.to_s
 
-      expect(sheet.cell(1, 26)).to eq "Non_Compliant_Reason"
-      expect(sheet.cell(2, 26)).to eq investigation.non_compliant_reason
-      expect(sheet.cell(3, 26)).to eq other_team_investigation.non_compliant_reason
+      expect(sheet.cell(1, 26)).to eq "Date_Closed"
+      expect(sheet.cell(2, 26)).to eq investigation.date_closed&.to_s
+      expect(sheet.cell(3, 26)).to eq other_team_investigation.date_closed&.to_s
 
-      expect(sheet.cell(1, 27)).to eq "Unsafe_Reason"
-      expect(sheet.cell(2, 27)).to eq investigation.hazard_description
-      expect(sheet.cell(3, 27)).to eq other_team_investigation.hazard_description
+      expect(sheet.cell(1, 27)).to eq "Date_Validated"
+      expect(sheet.cell(2, 27)).to eq investigation.risk_validated_at&.to_s
+      expect(sheet.cell(3, 27)).to eq other_team_investigation.risk_validated_at&.to_s
     end
     # rubocop:enable RSpec/ExampleLength
 

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 18)).to eq "Date_Validated"
-            expect(exported_data.cell(2, 18)).to eq "Restricted"
+            expect(exported_data.cell(1, 27)).to eq "Date_Validated"
+            expect(exported_data.cell(2, 27)).to eq "Restricted"
           end
         end
 
@@ -96,8 +96,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 25)).to eq "OPSS_Internal_Team"
-            expect(exported_data.cell(2, 25)).to eq "Restricted"
+            expect(exported_data.cell(1, 23)).to eq "OPSS_Internal_Team"
+            expect(exported_data.cell(2, 23)).to eq "Restricted"
           end
         end
       end
@@ -201,10 +201,10 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 9)).to eq "Case_Owner_Team"
+            expect(exported_data.cell(1, 17)).to eq "Case_Owner_Team"
 
             expect(exported_data.cell(2, 1)).to eq case_with_team_owner.pretty_id
-            expect(exported_data.cell(2, 9)).to eq team.name
+            expect(exported_data.cell(2, 17)).to eq team.name
           end
         end
 
@@ -216,8 +216,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 14)).to eq "Risk_Assessments"
-            expect(exported_data.cell(2, 14)).to eq "1"
+            expect(exported_data.cell(1, 16)).to eq "Risk_Assessments"
+            expect(exported_data.cell(2, 16)).to eq "1"
           end
         end
 
@@ -229,10 +229,10 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 15)).to eq "Date_Created"
-            expect(exported_data.cell(1, 16)).to eq "Last_Updated"
-            expect(exported_data.cell(2, 15)).to eq investigation.created_at.strftime("%Y-%m-%d %H:%M:%S %z")
-            expect(exported_data.cell(2, 16)).to eq investigation.updated_at.strftime("%Y-%m-%d %H:%M:%S %z")
+            expect(exported_data.cell(1, 24)).to eq "Date_Created"
+            expect(exported_data.cell(1, 25)).to eq "Last_Updated"
+            expect(exported_data.cell(2, 24)).to eq investigation.created_at.strftime("%Y-%m-%d %H:%M:%S %z")
+            expect(exported_data.cell(2, 25)).to eq investigation.updated_at.strftime("%Y-%m-%d %H:%M:%S %z")
           end
         end
 
@@ -244,8 +244,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 18)).to eq "Date_Validated"
-            expect(exported_data.cell(2, 18)).to eq investigation.risk_validated_at.strftime("%Y-%m-%d %H:%M:%S %z")
+            expect(exported_data.cell(1, 27)).to eq "Date_Validated"
+            expect(exported_data.cell(2, 27)).to eq investigation.risk_validated_at.strftime("%Y-%m-%d %H:%M:%S %z")
           end
         end
 
@@ -268,8 +268,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 21)).to eq "Reported_Reason"
-            expect(exported_data.cell(2, 21)).to eq "unsafe"
+            expect(exported_data.cell(1, 7)).to eq "Reported_Reason"
+            expect(exported_data.cell(2, 7)).to eq "unsafe"
           end
         end
 
@@ -280,8 +280,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
           get generate_case_exports_path
 
           aggregate_failures do
-            expect(exported_data.cell(1, 22)).to eq "Notifiers_Reference"
-            expect(exported_data.cell(2, 22)).to eq "testing"
+            expect(exported_data.cell(1, 19)).to eq "Notifiers_Reference"
+            expect(exported_data.cell(2, 19)).to eq "testing"
           end
         end
 
@@ -295,8 +295,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             get generate_case_exports_path
 
             aggregate_failures do
-              expect(exported_data.cell(1, 19)).to eq "Case_Creator_Team"
-              expect(exported_data.cell(2, 19)).to eq nil
+              expect(exported_data.cell(1, 18)).to eq "Case_Creator_Team"
+              expect(exported_data.cell(2, 18)).to eq nil
             end
           end
         end
@@ -311,8 +311,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             get generate_case_exports_path
 
             aggregate_failures do
-              expect(exported_data.cell(1, 19)).to eq "Case_Creator_Team"
-              expect(exported_data.cell(2, 19)).to eq creator_user.team.name
+              expect(exported_data.cell(1, 18)).to eq "Case_Creator_Team"
+              expect(exported_data.cell(2, 18)).to eq creator_user.team.name
             end
           end
         end
@@ -325,8 +325,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             get generate_case_exports_path
 
             aggregate_failures do
-              expect(exported_data.cell(1, 17)).to eq "Date_Closed"
-              expect(exported_data.cell(2, 17)).to eq nil
+              expect(exported_data.cell(1, 26)).to eq "Date_Closed"
+              expect(exported_data.cell(2, 26)).to eq nil
             end
           end
         end
@@ -340,8 +340,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
             get generate_case_exports_path, params: { case_status: "closed", format: :xlsx }
 
             aggregate_failures do
-              expect(exported_data.cell(1, 17)).to eq "Date_Closed"
-              expect(exported_data.cell(2, 17)).to eq closed_at_date.strftime("%Y-%m-%d %H:%M:%S %z")
+              expect(exported_data.cell(1, 26)).to eq "Date_Closed"
+              expect(exported_data.cell(2, 26)).to eq closed_at_date.strftime("%Y-%m-%d %H:%M:%S %z")
             end
           end
         end
@@ -355,8 +355,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
               get generate_case_exports_path
 
               aggregate_failures do
-                expect(exported_data.cell(1, 3)).to eq "Title"
-                expect(exported_data.cell(2, 3)).to eq investigation.user_title
+                expect(exported_data.cell(1, 4)).to eq "Title"
+                expect(exported_data.cell(2, 4)).to eq investigation.user_title
 
                 expect(exported_data.cell(1, 5)).to eq "Description"
                 expect(exported_data.cell(2, 5)).to eq investigation.description
@@ -374,14 +374,14 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
               get generate_case_exports_path
 
               aggregate_failures do
-                expect(exported_data.cell(1, 3)).to eq "Title"
-                expect(exported_data.cell(2, 3)).to eq "Restricted"
+                expect(exported_data.cell(1, 4)).to eq "Title"
+                expect(exported_data.cell(2, 4)).to eq "Restricted"
 
                 expect(exported_data.cell(1, 5)).to eq "Description"
                 expect(exported_data.cell(2, 5)).to eq "Restricted"
 
-                expect(exported_data.cell(1, 22)).to eq "Notifiers_Reference"
-                expect(exported_data.cell(2, 22)).to eq "Restricted"
+                expect(exported_data.cell(1, 19)).to eq "Notifiers_Reference"
+                expect(exported_data.cell(2, 19)).to eq "Restricted"
               end
             end
           end


### PR DESCRIPTION
## Description

Rearranges column order for notification extract

## Review apps

https://psd-pr-2833.london.cloudapps.digital/
https://psd-pr-2833-support.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
