### PR TITLE
Notification task list: add supporting images and documents

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -115,6 +115,13 @@ $govuk-global-styles: true;
   margin-left: govuk-spacing(2);
 }
 
+// Make sure the action column of a summary list used for lists of files
+// containing both file names and titles is wide enough to accommodate
+// both view and delete links
+.opss-file-list .govuk-summary-list__actions {
+  width: 25%;
+}
+
 // TODO: get rid of these
 .right {
   float: right;

--- a/app/decorators/test/result_decorator.rb
+++ b/app/decorators/test/result_decorator.rb
@@ -36,7 +36,7 @@ class Test < ApplicationRecord
     end
 
     def date_of_activity
-      date.to_formatted_s(:govuk)
+      date&.to_formatted_s(:govuk)
     end
 
     def date_of_activity_for_sorting

--- a/app/views/notifications/create/add_supporting_documents.html.erb
+++ b/app/views/notifications/create/add_supporting_documents.html.erb
@@ -1,0 +1,41 @@
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_supporting_documents.title"), errors: @document_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @document_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+        <%= t("notifications.create.index.sections.evidence.tasks.add_supporting_documents.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+        <% @notification.investigation_products.decorate.each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
+        <% end %>
+        </ul>
+      <% end %>
+      <p class="govuk-body">To provide proof of the product hazard or accident, you can upload supporting documents with your notification.</p>
+      <%= f.govuk_text_field :title, label: { text: "Document title", size: "s" } %>
+      <%= f.govuk_file_field :document, label: nil, hint: { text: "Maximum file size: 100MB." } %>
+      <%= f.govuk_submit "Upload document", secondary: true %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <% if @notification.generic_supporting_information_attachments.present? %>
+        <%=
+          govuk_summary_list(classes: "opss-file-list") do |summary_list|
+            @notification.generic_supporting_information_attachments.each do |document_upload|
+              summary_list.with_row do |row|
+                row.with_key(text: document_upload.filename)
+                row.with_value(text: document_upload.title)
+                row.with_action(text: "View", href: url_for(document_upload), visually_hidden_text: "supporting document", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
+                row.with_action(text: "Remove", href: remove_upload_notification_create_index_path(@notification, step: "add_supporting_documents", upload_id: document_upload.id), visually_hidden_text: "supporting document")
+              end
+            end
+          end
+        %>
+      <% end %>
+      <%= f.govuk_submit "Finish uploading documents", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_supporting_images.html.erb
+++ b/app/views/notifications/create/add_supporting_images.html.erb
@@ -1,0 +1,40 @@
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_supporting_images.title"), errors: @image_upload.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @image_upload, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+        <%= t("notifications.create.index.sections.evidence.tasks.add_supporting_images.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+        <% @notification.investigation_products.decorate.each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
+        <% end %>
+        </ul>
+      <% end %>
+      <p class="govuk-body">To provide visual evidence of the product hazard or incident/accident, you can upload either a single image or multiple images to the notification.</p>
+      <%= f.hidden_field :file_upload, value: "" %>
+      <%= f.govuk_file_field :file_upload, label: nil, hint: { text: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF. Maximum file size: 100MB." } %>
+      <%= f.govuk_submit "Upload image", secondary: true %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <% if @notification.image_uploads.present? %>
+        <%=
+          govuk_summary_list do |summary_list|
+            @notification.image_uploads.each do |image_upload|
+              summary_list.with_row do |row|
+                row.with_key(text: image_upload.file_upload.filename)
+                row.with_action(text: "View", href: url_for(image_upload.file_upload), visually_hidden_text: "supporting image", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
+                row.with_action(text: "Remove", href: remove_upload_notification_create_index_path(@notification, step: "add_supporting_images", upload_id: image_upload.id), visually_hidden_text: "supporting image")
+              end
+            end
+          end
+        %>
+      <% end %>
+      <%= f.govuk_submit "Finish uploading images", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/remove_test_report.html.erb
+++ b/app/views/notifications/create/remove_test_report.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-l">
         Are you sure you want to remove this test report from your notification?
       </h1>
-      <p class="govuk-body">This action will remove the test report from <strong><%= @investigation_product.decorate.product.name_with_brand %></strong> from your notification. Please confirm if you wish to proceed.</p>
+      <p class="govuk-body">This action will remove the test report for <strong><%= @investigation_product.decorate.product.name_with_brand %></strong> from your notification. Please confirm if you wish to proceed.</p>
       <%= f.govuk_submit "Remove test report", warning: true do %>
         <a href="<%= notification_create_path(@notification, "add_test_reports") %>" class="govuk-link">Cancel</a>
       <% end %>

--- a/app/views/notifications/create/remove_upload.html.erb
+++ b/app/views/notifications/create/remove_upload.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("Remove #{@type}", errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: remove_upload_notification_create_index_path(@notification, step: params[:step], upload_id: @upload.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to remove this <%= @type %> from your notification?
+      </h1>
+      <p class="govuk-body">This action will remove <strong><%= @upload.try(:file_upload) ? @upload.file_upload.filename : @upload.filename %></strong> from your notification. Please confirm if you wish to proceed.</p>
+      <%= f.govuk_submit "Remove #{@type}", warning: true do %>
+        <a href="<%= notification_create_path(@notification, params[:step]) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,11 @@ Rails.application.routes.draw do
               get ":investigation_product_id/:test_result_id/remove", to: "create#remove_with_notification_product", as: "remove_with_product_and_test_result"
               delete ":investigation_product_id/:test_result_id/remove", to: "create#remove_with_notification_product"
             end
+
+            scope ":step", constraints: { step: /add_supporting_images|add_supporting_documents/ } do
+              get ":upload_id/remove", to: "create#remove_upload", as: "remove_upload"
+              delete ":upload_id/remove", to: "create#remove_upload"
+            end
           end
         end
       end

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
   let(:new_product_attributes) do
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
   end
+  let(:image_file) { Rails.root.join "test/fixtures/files/testImage.png" }
+  let(:text_file) { Rails.root.join "test/fixtures/files/attachment_filename.txt" }
 
   before do
     sign_in(user)
@@ -128,5 +130,74 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_selector(:id, "task-list-1-0-status", text: "Completed")
     expect(page).to have_selector(:id, "task-list-1-1-status", text: "Completed")
     expect(page).to have_selector(:id, "task-list-1-2-status", text: "Completed")
+
+    # TODO(ruben): add to this once the pages are complete
+    click_link "Add the type and details of the business"
+    click_button "Save and complete tasks in this section"
+
+    expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")
+
+    # Ensure that all of section 4 and the first task of section are enabled once section 3 is completed
+    expect(page).to have_selector(:id, "task-list-3-0-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-1-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-2-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-3-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-4-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-4-0-status", text: "Not yet started")
+
+    click_link "Add test reports"
+    choose "Yes"
+    click_button "Save and continue"
+
+    fill_in "What is the trading standards officer sample reference number?", with: "12345678"
+    fill_in "Day", with: "12"
+    fill_in "Month", with: "5"
+    fill_in "Year", with: "2023"
+    click_button "Save and continue"
+
+    select "ATEX 2016", from: "Under which legislation?"
+    fill_in "Which standard was the product tested against?", with: "EN71"
+    fill_in "Day", with: "12"
+    fill_in "Month", with: "5"
+    fill_in "Year", with: "2023"
+
+    within_fieldset "What was the result?" do
+      choose "Fail"
+      fill_in "How the product failed", with: "Because it did"
+    end
+
+    attach_file "Test report attachment", image_file
+    click_button "Add test report"
+
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-3-0-status", text: "Completed")
+
+    click_link "Add supporting images"
+
+    attach_file "image_upload[file_upload]", image_file
+    click_button "Upload image"
+
+    expect(page).to have_content("Supporting image uploaded successfully")
+
+    click_button "Finish uploading images"
+
+    expect(page).to have_selector(:id, "task-list-3-1-status", text: "Completed")
+
+    click_link "Add supporting documents"
+
+    fill_in "Document title", with: "Fake title"
+    attach_file "document_form[document]", text_file
+    click_button "Upload document"
+
+    expect(page).to have_content("Supporting document uploaded successfully")
+
+    click_button "Finish uploading documents"
+
+    expect(page).to have_selector(:id, "task-list-3-2-status", text: "Completed")
   end
 end


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/PSD-2258 and https://regulatorydelivery.atlassian.net/browse/PSD-2331

## Description

Adds the “add supporting images” and “add supporting documents” tasks.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-01-18 at 11 52 05](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/f7698afa-cf5c-49f6-97e3-ad3a6c909d6a)

![Screenshot 2024-01-18 at 11 52 12](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/09c9f2ea-3fc9-450d-8aa3-227f1d9cf3cd)

![Screenshot 2024-01-19 at 11 50 21](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/2fd8555a-1d8f-4e79-89d0-b4eb6e24403f)

![Screenshot 2024-01-19 at 11 50 30](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/99cbba0b-18f7-4c37-bc8d-35f261b3041f)

## Review apps

https://psd-pr-2845.london.cloudapps.digital/
https://psd-pr-2845-support.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
