### PR TITLE
Migrate Ahoy user_id columns to use uuids from bigint - PSD-2384

### DIFF
--- a/db/migrate/20240124120110_change_ahoy_user_ids_to_uuids.rb
+++ b/db/migrate/20240124120110_change_ahoy_user_ids_to_uuids.rb
@@ -1,0 +1,14 @@
+class ChangeAhoyUserIdsToUuids < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_index :ahoy_visits, :user_id
+      remove_index :ahoy_events, :user_id
+
+      remove_column :ahoy_visits, :user_id, :bigint
+      remove_column :ahoy_events, :user_id, :bigint
+
+      add_reference :ahoy_visits, :user, type: :uuid
+      add_reference :ahoy_events, :user, type: :uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_22_143016) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_24_120110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -80,7 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_143016) do
     t.string "name"
     t.jsonb "properties"
     t.datetime "time"
-    t.bigint "user_id"
+    t.uuid "user_id"
     t.bigint "visit_id"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
@@ -98,7 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_143016) do
     t.string "referring_domain"
     t.datetime "started_at"
     t.text "user_agent"
-    t.bigint "user_id"
+    t.uuid "user_id"
     t.string "visit_token"
     t.string "visitor_token"
     t.index ["user_id"], name: "index_ahoy_visits_on_user_id"


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2389

## Description
Migrates the Ahoy tables to use uuids for `user_id` - this column is optional, but we intended to link users to activity. User uses uuid IDs on the table, and cannot be cast to bigint
