### PR TITLE
Remove last_activity_at_approx updating, replace with devise built in last_sign_in_at

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
   before_action :check_current_user_status
-  before_action :set_user_last_activity_time
   before_action :ensure_secondary_authentication
   before_action :require_secondary_authentication
   before_action :set_sentry_context

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,12 +36,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def set_user_last_activity_time
-    return unless user_signed_in?
-
-    current_user.update_last_activity_time!
-  end
-
   def has_accepted_declaration
     return unless user_signed_in?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ApplicationRecord
                        :invited_at, :keycloak_created_at, :last_sign_in_at, :locked_at, :mobile_number_verified,
                        :organisation_id, :remember_created_at, :second_factor_attempts_locked_at,
                        :secondary_authentication_operation, :sign_in_count, :team_id, :updated_at,
-                       :last_activity_at_approx, :locked_reason
+                       :last_sign_in_at, :locked_reason
 
   # Active users are those with current access to the service (ie have set up an account and haven't been deleted)
   # and who have accepted the user declaration
@@ -73,7 +73,7 @@ class User < ApplicationRecord
   end
 
   def self.inactive
-    active.where(arel_table[:last_activity_at_approx].lt(INACTIVE_THRESHOLD.ago))
+    active.where(arel_table[:last_sign_in_at].lt(INACTIVE_THRESHOLD.ago))
   end
 
   def self.lock_inactive_users!
@@ -238,8 +238,8 @@ class User < ApplicationRecord
   end
 
   def update_last_activity_time!
-    if !last_activity_at_approx || (last_activity_at_approx < LAST_ACTIVITY_TIME_UPDATE_THRESHOLD.ago)
-      self.last_activity_at_approx = Time.zone.now
+    if !last_sign_in_at || (last_sign_in_at < LAST_ACTIVITY_TIME_UPDATE_THRESHOLD.ago)
+      self.last_sign_in_at = Time.zone.now
       save!(validate: false)
     end
   end

--- a/report_portal/app/controllers/report_portal/application_controller.rb
+++ b/report_portal/app/controllers/report_portal/application_controller.rb
@@ -30,7 +30,5 @@ module ReportPortal
         redirect_to "/"
       end
     end
-
-
   end
 end

--- a/report_portal/app/controllers/report_portal/application_controller.rb
+++ b/report_portal/app/controllers/report_portal/application_controller.rb
@@ -8,7 +8,6 @@ module ReportPortal
     before_action :authenticate_user!
     before_action :set_paper_trail_whodunnit
     before_action :check_current_user_status
-    before_action :set_user_last_activity_time
     before_action :ensure_secondary_authentication
     before_action :require_secondary_authentication
     before_action :set_sentry_context

--- a/report_portal/app/controllers/report_portal/application_controller.rb
+++ b/report_portal/app/controllers/report_portal/application_controller.rb
@@ -32,10 +32,6 @@ module ReportPortal
       end
     end
 
-    def set_user_last_activity_time
-      return unless user_signed_in?
 
-      current_user.update_last_activity_time!
-    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -390,27 +390,27 @@ RSpec.describe User do
   describe ".inactive" do
     subject(:users) { described_class.inactive }
 
-    let!(:user) { create(:user, trait, last_activity_at_approx:) }
+    let!(:user) { create(:user, trait, last_sign_in_at:) }
     let(:trait) { :activated }
 
-    context "when last_activity_at_approx is nil" do
-      let(:last_activity_at_approx) { nil }
+    context "when last_sign_in_at is nil" do
+      let(:last_sign_in_at) { nil }
 
       it "is not included in the results" do
         expect(users).not_to include(user)
       end
     end
 
-    context "when last_activity_at_approx is within 3 months" do
-      let(:last_activity_at_approx) { 2.months.ago }
+    context "when last_sign_in_at is within 3 months" do
+      let(:last_sign_in_at) { 2.months.ago }
 
       it "is not included in the results" do
         expect(users).not_to include(user)
       end
     end
 
-    context "when last_activity_at_approx is more than 3 months ago" do
-      let(:last_activity_at_approx) { 4.months.ago }
+    context "when last_sign_in_at is more than 3 months ago" do
+      let(:last_sign_in_at) { 4.months.ago }
 
       context "when user is activated" do
         it "is included in the results" do
@@ -437,8 +437,8 @@ RSpec.describe User do
   end
 
   describe ".lock_inactive_users!", :with_stubbed_mailer do
-    let!(:inactive_user) { create(:user, :activated, last_activity_at_approx: 5.months.ago) }
-    let!(:active_user) { create(:user, :activated, last_activity_at_approx: 1.day.ago) }
+    let!(:inactive_user) { create(:user, :activated, last_sign_in_at: 5.months.ago) }
+    let!(:active_user) { create(:user, :activated, last_sign_in_at: 1.day.ago) }
     let!(:invited_user) { create(:user, :invited) }
 
     before { described_class.lock_inactive_users! }
@@ -461,40 +461,6 @@ RSpec.describe User do
 
     it "does not send emails with unlock instructions immediately" do
       expect(delivered_emails).to be_empty
-    end
-  end
-
-  describe "#update_last_activity_time!" do
-    subject(:user) { create(:user, last_activity_at_approx:) }
-
-    context "when last_activity_at_approx is nil" do
-      let(:last_activity_at_approx) { nil }
-
-      it "updates last_activity_at_approx" do
-        freeze_time do
-          expect { user.update_last_activity_time! }.to change(user, :last_activity_at_approx).from(nil).to(Time.zone.now)
-        end
-      end
-    end
-
-    context "when last_activity_at_approx is within 5 minutes" do
-      let(:last_activity_at_approx) { 3.minutes.ago }
-
-      it "does not update last_activity_at_approx" do
-        freeze_time do
-          expect { user.update_last_activity_time! }.not_to change(user, :last_activity_at_approx)
-        end
-      end
-    end
-
-    context "when last_activity_at_approx is more than 5 minutes ago" do
-      let(:last_activity_at_approx) { 10.minutes.ago }
-
-      it "updates last_activity_at_approx" do
-        freeze_time do
-          expect { user.update_last_activity_time! }.to change(user, :last_activity_at_approx).from(last_activity_at_approx).to(Time.zone.now)
-        end
-      end
     end
   end
 

--- a/support_portal/app/controllers/support_portal/application_controller.rb
+++ b/support_portal/app/controllers/support_portal/application_controller.rb
@@ -36,10 +36,5 @@ module SupportPortal
       end
     end
 
-    def set_user_last_activity_time
-      return unless user_signed_in?
-
-      current_user.update_last_activity_time!
-    end
   end
 end

--- a/support_portal/app/controllers/support_portal/application_controller.rb
+++ b/support_portal/app/controllers/support_portal/application_controller.rb
@@ -11,7 +11,6 @@ module SupportPortal
     before_action :authenticate_user!
     before_action :set_paper_trail_whodunnit
     before_action :check_current_user_status
-    before_action :set_user_last_activity_time
     before_action :ensure_secondary_authentication
     before_action :require_secondary_authentication
     before_action :set_sentry_context

--- a/support_portal/app/controllers/support_portal/application_controller.rb
+++ b/support_portal/app/controllers/support_portal/application_controller.rb
@@ -34,6 +34,5 @@ module SupportPortal
         redirect_to "/"
       end
     end
-
   end
 end


### PR DESCRIPTION
Removed update_last_activity_time! method from all three application controllers.
Changed all instances(excluding schemas and rollup) of last_activity_at_approx, to last_sign_in_at.
Removed test from user_spec.rb
