### PR TITLE
Notification task list: record a corrective action

### DIFF
--- a/app/decorators/corrective_action_decorator.rb
+++ b/app/decorators/corrective_action_decorator.rb
@@ -26,6 +26,12 @@ class CorrectiveActionDecorator < ApplicationDecorator
     "#{action_name}: #{investigation_product.name}"
   end
 
+  def supporting_information_full_title
+    action_name = other? ? other_action : I18n.t(action, scope: %i[corrective_action attributes actions])
+
+    "#{action_name}: #{investigation_product.product.decorate.name_with_brand}"
+  end
+
   def date_of_activity
     date_decided.to_formatted_s(:govuk)
   end

--- a/app/forms/choose_investigation_products_form.rb
+++ b/app/forms/choose_investigation_products_form.rb
@@ -1,0 +1,8 @@
+class ChooseInvestigationProductsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :investigation_product_ids, default: []
+
+  validates :investigation_product_ids, presence: true
+end

--- a/app/forms/corrective_action_taken_form.rb
+++ b/app/forms/corrective_action_taken_form.rb
@@ -1,0 +1,21 @@
+class CorrectiveActionTakenForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :corrective_action_taken_yes_no, :boolean
+  attribute :corrective_action_taken_no_specific, :string
+  attribute :corrective_action_not_taken_reason, :string
+
+  validates :corrective_action_taken_yes_no, inclusion: { in: [true, false] }
+  validates :corrective_action_taken_no_specific, inclusion: { in: (Investigation.corrective_action_takens.values - %w[yes]) }, unless: -> { corrective_action_taken_yes_no.nil? || corrective_action_taken_yes_no }
+  validates :corrective_action_not_taken_reason, presence: true, if: -> { corrective_action_taken_no_specific == "other" }
+  validates :corrective_action_not_taken_reason, length: { maximum: 100 }
+
+  def corrective_action_taken
+    if corrective_action_taken_yes_no
+      "yes"
+    else
+      corrective_action_taken_no_specific
+    end
+  end
+end

--- a/app/models/corrective_action.rb
+++ b/app/models/corrective_action.rb
@@ -18,6 +18,7 @@ class CorrectiveAction < ApplicationRecord
     seizure_of_goods: "Seizure of goods",
     modification_programme: "Modification programme",
     referred_to_overseas_regulator: "Referred to overseas regulator",
+    product_no_longer_available_for_sale: "Product no longer available for sale"
   }.freeze
 
   belongs_to :investigation
@@ -72,6 +73,8 @@ class CorrectiveAction < ApplicationRecord
         i18n.t(:modification_programme),
       referred_to_overseas_regulator:
         i18n.t(:referred_to_overseas_regulator),
+      product_no_longer_available_for_sale:
+        i18n.t(:product_no_longer_available_for_sale),
       other:
         i18n.t(:other)
     }

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -26,7 +26,14 @@ class Investigation < ApplicationRecord
     other: "other"
   }
 
-  before_validation { trim_line_endings(:user_title, :non_compliant_reason, :hazard_description) }
+  enum corrective_action_taken: {
+    yes: "yes",
+    referred_to_another_authority: "referred_to_another_authority",
+    not_enough_information: "not_enough_information",
+    other: "other"
+  }, _prefix: true
+
+  before_validation { trim_line_endings(:user_title, :non_compliant_reason, :hazard_description, :corrective_action_not_taken_reason) }
 
   validates :type, presence: true # Prevent saving instances of Investigation; must use a subclass instead
 
@@ -34,6 +41,7 @@ class Investigation < ApplicationRecord
   validates :description, length: { maximum: 10_000 }
   validates :non_compliant_reason, length: { maximum: 10_000 }
   validates :hazard_description, length: { maximum: 10_000 }
+  validates :corrective_action_not_taken_reason, length: { maximum: 100 }
 
   has_many :investigation_products, dependent: :destroy
   has_many :products, through: :investigation_products

--- a/app/services/change_notification_corrective_action_taken.rb
+++ b/app/services/change_notification_corrective_action_taken.rb
@@ -1,0 +1,17 @@
+class ChangeNotificationCorrectiveActionTaken
+  include Interactor
+  include EntitiesToNotify
+
+  delegate :notification, :corrective_action_taken, :corrective_action_not_taken_reason, :user, to: :context
+
+  def call
+    context.fail!(error: "No notification supplied") unless notification.is_a?(Investigation)
+    context.fail!(error: "No corrective action taken supplied") unless corrective_action_taken.is_a?(String)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+
+    context.corrective_action_not_taken_reason = nil unless corrective_action_taken == "other"
+
+    notification.assign_attributes(corrective_action_taken:, corrective_action_not_taken_reason:)
+    notification.save!
+  end
+end

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -19,7 +19,7 @@ class UpdateCorrectiveAction
         corrective_action.save!
         update_document_description!
         create_audit_activity_for_corrective_action_updated!
-        send_notification_email
+        send_notification_email unless context.silent
 
         investigation.reindex
       end

--- a/app/views/notifications/create/add_risk_assessments.html.erb
+++ b/app/views/notifications/create/add_risk_assessments.html.erb
@@ -14,7 +14,7 @@
             summary_list.with_row do |row|
               row.with_key(text: risk_assessment.supporting_information_full_title)
               row.with_value(text: risk_assessment.supporting_information_type)
-              row.with_action(text: "Remove", href: remove_with_entity_notification_create_index_path(@notification, entity_id: prism_associated_investigation.id), visually_hidden_text: "risk assessment")
+              row.with_action(text: "Remove", href: remove_with_entity_notification_create_index_path(@notification, step: "add_risk_assessments", entity_id: prism_associated_investigation.id), visually_hidden_text: "risk assessment")
             end
           end
           @existing_risk_assessments.decorate.each do |risk_assessment|

--- a/app/views/notifications/create/add_risk_assessments_legacy.html.erb
+++ b/app/views/notifications/create/add_risk_assessments_legacy.html.erb
@@ -17,7 +17,7 @@
       <% end %>
       <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
       <div class="govuk-form-group<%= assessed_on_error ? ' govuk-form-group--error' : '' %>">
-        <fieldset class="govuk-fieldset" aria-describedby="risk-assessment-form-assessed-on-hint<%= assessed_on_error ? ' isk-assessment-form-assessed-on-error' : '' %>">
+        <fieldset class="govuk-fieldset" aria-describedby="risk-assessment-form-assessed-on-hint<%= assessed_on_error ? ' risk-assessment-form-assessed-on-error' : '' %>">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Date of assessment</legend>
           <div class="govuk-hint" id="risk-assessment-form-assessed-on-hint">For example, 31 1 2020</div>
           <% if assessed_on_error %>

--- a/app/views/notifications/create/record_a_corrective_action.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action.html.erb
@@ -1,0 +1,38 @@
+<% if @manage %>
+  <%= page_title(t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.title"), errors: false) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.corrective_actions.title") %></span>
+        <%= t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.title") %>
+      </h1>
+      <p class="govuk-body">You have added <%= pluralize(@existing_corrective_actions.length, "corrective action") %>.
+      <%=
+        govuk_summary_list do |summary_list|
+          @existing_corrective_actions.decorate.each do |corrective_action|
+            summary_list.with_row do |row|
+              row.with_key(text: corrective_action.supporting_information_full_title)
+              row.with_action(text: "Change", href: with_entity_notification_create_index_path(@notification, entity_id: corrective_action.id), visually_hidden_text: "corrective action")
+              row.with_action(text: "Remove", href: remove_with_entity_notification_create_index_path(@notification, step: "record_a_corrective_action", entity_id: corrective_action.id), visually_hidden_text: "corrective action")
+            end
+          end
+        end
+      %>
+      <%= form_with url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_collection_radio_buttons :add_another_corrective_action, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another corrective action?", size: "m" } %>
+        <%= f.govuk_submit "Continue", name: "final", value: "true" %>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <%= page_title(t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.select_products.title"), errors: @choose_investigation_products_form.errors.any?) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with model: @choose_investigation_products_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_error_summary %>
+        <%= f.govuk_collection_check_boxes :investigation_product_ids, @notification.investigation_products.decorate.map { |ip| OpenStruct.new(id: ip.id, name: ip.product.name_with_brand) }, :id, :name, legend: { text: "<span class=\"govuk-caption-l\">#{t('notifications.create.index.sections.corrective_actions.title')}</span>#{t('notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.select_products.title')}".html_safe, size: "l" }, hint: { text: "Select all that apply." } %>
+        <%= f.govuk_submit "Save and continue" %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/notifications/create/record_a_corrective_action_details.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_details.html.erb
@@ -1,0 +1,110 @@
+<%= page_title(t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.title"), errors: @corrective_action_form.errors.any?) %>
+<% date_decided_error = @corrective_action_form.errors.include?(:date_decided) %>
+<% two_weeks_from_now =  2.weeks.from_now.to_date %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @corrective_action_form, url: @corrective_action&.id.present? ? with_entity_notification_create_index_path(@notification, entity_id: @corrective_action.id) : wizard_path(:record_a_corrective_action, investigation_product_ids: params[:investigation_product_ids]), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.corrective_actions.title") %></span>
+        <%= t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+        <% (@investigation_products&.decorate || [@corrective_action.investigation_product.decorate]).each do |investigation_product| %>
+          <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
+        <% end %>
+        </ul>
+      <% end %>
+      <%= f.hidden_field :has_online_recall_information, value: "has_online_recall_information_not_relevant" %>
+      <%= f.govuk_radio_buttons_fieldset :action, legend: { text: "What action is being taken?", size: "m" } do %>
+        <%= f.govuk_radio_button :action, "removal_of_the_listing_by_the_online_marketplace", label: { text: "Removal of the listing by the online marketplace" }, link_errors: true %>
+        <%= f.govuk_radio_button :action, "import_rejected_at_border", label: { text: "Import rejected at border" } %>
+        <%= f.govuk_radio_button :action, "destruction_of_the_product", label: { text: "Destruction of the product" } %>
+        <%= f.govuk_radio_button :action, "recall_of_the_product_from_end_users", label: { text: "Recall of the product from end users" } do %>
+          <%= f.govuk_radio_buttons_fieldset :has_online_recall_information, legend: { text: "Has the business responsible published product recall information online?" } do %>
+            <%= f.govuk_radio_button :has_online_recall_information, "has_online_recall_information_yes", label: { text: "Yes" }, link_errors: true do %>
+              <%= f.govuk_text_field :online_recall_information, label: { text: "Location of recall information" }, hint: { text: "For example http://www.example.com or https://www.example.com" } %>
+            <% end %>
+            <%= f.govuk_radio_button :has_online_recall_information, "has_online_recall_information_no", label: { text: "No" } %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_radio_button :action, "withdrawal_of_the_product_from_the_market", label: { text: "Withdrawal of the product from the market" }, hint: { text: "For example, removal of the product from sales and distribution channels" } %>
+        <%= f.govuk_radio_button :action, "temporary_ban_on_the_supply_offer_to_supply_and_display_of_the_product", label: { text: "Temporary ban on the supply, offer to supply and display of the product" }, hint: { text: "For example, suspension of the product distribution, sales and display" } %>
+        <%= f.govuk_radio_button :action, "referred_to_overseas_regulator", label: { text: "Referred to an overseas regulator" } %>
+        <%= f.govuk_radio_button :action, "making_the_marketing_of_the_product_subject_to_prior_conditions", label: { text: "Making the marketing of the product subject to prior conditions" } %>
+        <%= f.govuk_radio_button :action, "product_back_into_compliance", label: { text: "Product brought back into compliance" } %>
+        <%= f.govuk_radio_button :action, "warning_consumers_of_the_risks", label: { text: "Warning consumers of the risks" } %>
+        <%= f.govuk_radio_button :action, "ban_on_the_marketing_of_the_product_and_any_accompanying_measures", label: { text: "Ban on the marketing of the product and any accompanying measures" } %>
+        <%= f.govuk_radio_button :action, "marking_the_product_with_appropriate_warnings_on_the_risks", label: { text: "Marking the product with appropriate warnings on the risks" } %>
+        <%= f.govuk_radio_button :action, "seizure_of_goods", label: { text: "Seizure of goods" } %>
+        <%= f.govuk_radio_button :action, "modification_programme", label: { text: "Modification programme" } %>
+        <%= f.govuk_radio_button :action, "product_no_longer_available_for_sale", label: { text: "Product is no longer available for sale" } %>
+      <% end %>
+      <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
+      <div class="govuk-form-group<%= date_decided_error ? ' govuk-form-group--error' : '' %>">
+        <fieldset class="govuk-fieldset" aria-describedby="corrective-action-form-date-decided-hint<%= date_decided_error ? ' corrective-action-form-date-decided-error' : '' %>">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What date did the action come in to effect?</legend>
+          <div class="govuk-hint" id="corrective-action-form-date-decided-hint">This may be in the future. For example, <%= "#{two_weeks_from_now.day} #{two_weeks_from_now.month} #{two_weeks_from_now.year}" %>.</div>
+          <% if date_decided_error %>
+          <p class="govuk-error-message" id="corrective-action-form-date-decided-error">
+            <span class="govuk-visually-hidden">Error: </span><%= @corrective_action_form.errors.full_messages_for(:date_decided).first %>
+          </p>
+          <% end %>
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_day">Day</label>
+                <input id="corrective_action_form_date_decided_day" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][day]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.day %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_month">Month</label>
+                <input id="corrective_action_form_date_decided_month" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][month]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.month %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_year">Year</label>
+                <input id="corrective_action_form_date_decided_year" class="govuk-input govuk-date-input__input govuk-input--width-4<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][year]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.year %>">
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= f.govuk_collection_select :legislation, legislation_options, :id, :name, label: { text: "Under which legislation?", size: "m" }, hint: { text: "Select the relevant legislation from the list." } %>
+      <%= f.govuk_collection_radio_buttons :measure_type, [OpenStruct.new(id: "mandatory", name: "Yes"), OpenStruct.new(id: "voluntary", name: "No, it's voluntary")], :id, :name, legend: { text: "Is the corrective action mandatory?", size: "m" } %>
+      <%= f.govuk_check_boxes_fieldset :geographic_scopes, legend: { text: "In which geographic regions has this corrective action been taken?" } do %>
+        <%= f.govuk_check_box :geographic_scopes, "local", label: { text: "Local" }, hint: { text: "Covers specific areas and nearby border checkpoints." }, link_errors: true %>
+        <%= f.govuk_check_box :geographic_scopes, "great_britain", label: { text: "Great Britain" }, hint: { text: "Covers England, Scotland and Wales." } %>
+        <%= f.govuk_check_box :geographic_scopes, "northern_ireland", label: { text: "Northern Ireland" } %>
+        <%= f.govuk_check_box :geographic_scopes, "eea_wide", label: { text: "European Economic Area (EEA)" }, hint: { text: "Covers EU countries and also Iceland, Liechtenstein and Norway." } %>
+        <%= f.govuk_check_box :geographic_scopes, "eu_wide", label: { text: "European Union (EU)" } %>
+        <%= f.govuk_check_box :geographic_scopes, "worldwide", label: { text: "Worldwide" } %>
+        <%= f.govuk_check_box :geographic_scopes, "unknown", label: { text: "Unknown" } %>
+      <% end %>
+      <%= f.govuk_text_area :details, label: { text: "Further details (optional)", size: "m" }, max_chars: 32_767 %>
+      <%= f.hidden_field :existing_document_file_id %>
+      <%= f.govuk_radio_buttons_fieldset :related_file, legend: { text: "Are there any files related to the action?", size: "m" } do %>
+        <%= f.govuk_radio_button :related_file, true, label: { text: "Yes" }, link_errors: true do %>
+          <% if @corrective_action_form.document.present? %>
+            <p id="current-attachment-details">
+              Currently selected file:
+              <%= link_to "#{@corrective_action_form.document.filename} (opens in new tab)", @corrective_action_form.document, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" %>
+            </p>
+            <%= govuk_details(summary_text: "Replace this file") do %>
+              <%= f.govuk_file_field :document, label: nil, hint: { text: "If you have multiple files, compress them in a zip file." } %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_file_field :document, label: nil, hint: { text: "If you have multiple files, compress them in a zip file." } %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_radio_button :related_file, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit @corrective_action&.id.present? ? "Update corrective action" : "Add corrective action" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/record_a_corrective_action_later.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_later.html.erb
@@ -1,0 +1,14 @@
+<%= page_title(t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.later.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.corrective_actions.title") %></span>
+        <%= t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.later.title") %>
+      </h1>
+      <p class="govuk-body">You have the option to add the corrective action after your initial notification submission.</p>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/record_a_corrective_action_taken.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_taken.html.erb
@@ -1,0 +1,23 @@
+<%= page_title(t("notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.corrective_action_taken.title"), errors: @corrective_action_taken_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @corrective_action_taken_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.hidden_field :corrective_action_taken_yes_no, value: "" %>
+      <%= f.govuk_radio_buttons_fieldset :corrective_action_taken_yes_no, legend: { text: "<span class=\"govuk-caption-l\">#{t('notifications.create.index.sections.corrective_actions.title')}</span>#{t('notifications.create.index.sections.corrective_actions.tasks.record_a_corrective_action.corrective_action_taken.title')}".html_safe, size: "l" } do %>
+        <%= f.govuk_radio_button :corrective_action_taken_yes_no, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :corrective_action_taken_yes_no, false, label: { text: "No" } do %>
+          <%= f.govuk_radio_buttons_fieldset :corrective_action_taken_no_specific, legend: nil do %>
+            <%= f.govuk_radio_button :corrective_action_taken_no_specific, "referred_to_another_authority", label: { text: "I need to refer the issue to another authority" }, link_errors: true %>
+            <%= f.govuk_radio_button :corrective_action_taken_no_specific, "not_enough_information", label: { text: "I don't have enough information to take a corrective action" } %>
+            <%= f.govuk_radio_button :corrective_action_taken_no_specific, "other", label: { text: "I have another reason for not taking a corrective action" } do %>
+              <%= f.govuk_text_field :corrective_action_not_taken_reason, label: { text: "Provide the reason for not taking a corrective action" } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/remove_corrective_action.html.erb
+++ b/app/views/notifications/create/remove_corrective_action.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("Remove corrective action", errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: remove_with_entity_notification_create_index_path(@notification, step: "record_a_corrective_action", entity_id: @corrective_action.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to remove this corrective action from your notification?
+      </h1>
+      <p class="govuk-body">This action will permanently delete the corrective action <strong><%= @corrective_action.decorate.supporting_information_full_title %></strong> from your notification. Please confirm if you wish to proceed.</p>
+      <%= f.govuk_submit "Remove corrective action", warning: true do %>
+        <a href="<%= notification_create_path(@notification, "record_a_corrective_action") %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/remove_prism_risk_assessment.html.erb
+++ b/app/views/notifications/create/remove_prism_risk_assessment.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: remove_with_entity_notification_create_index_path(@notification, entity_id: @prism_associated_investigation.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with url: remove_with_entity_notification_create_index_path(@notification, step: "add_risk_assessments", entity_id: @prism_associated_investigation.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <h1 class="govuk-heading-l">
         Are you sure you want to remove this PRISM risk assessment from your notification?
       </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,12 @@ en:
             tasks:
               record_a_corrective_action:
                 title: Record a corrective action
+                corrective_action_taken:
+                  title: Have you already taken a corrective action for the unsafe product(s)?
+                later:
+                  title: You can record the corrective action later
+                select_products:
+                  title: Select products to record a corrective action
           submit:
             title: Submit notification
             tasks:
@@ -865,6 +871,19 @@ en:
           attributes:
             investigation_product_id:
               blank: Choose a product
+        choose_investigation_products_form:
+          attributes:
+            investigation_product_ids:
+              blank: Choose one or more products
+        corrective_action_taken_form:
+          attributes:
+            corrective_action_taken_yes_no:
+              inclusion: Choose whether a corrective action has been taken
+            corrective_action_taken_no_specific:
+              inclusion: Choose whether a corrective action has been taken
+            corrective_action_not_taken_reason:
+              blank: Enter the reason for not taking a corrective action
+              too_long: The reason for not taking a corrective action must be %{count} characters or less
 
   activerecord:
     models:
@@ -1007,6 +1026,7 @@ en:
         seizure_of_goods: "Seizure of goods"
         modification_programme: "Modification programme"
         referred_to_overseas_regulator: "Referred to an overseas regulator"
+        product_no_longer_available_for_sale: "Product is no longer available for sale"
         other: "Other"
   enter_email_address: "Enter your email address"
   file_added: "The file was added"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,10 +137,16 @@ Rails.application.routes.draw do
 
             get "add_product_identification_details/ucr_numbers/:investigation_product_id/delete/:ucr_number_id", to: "create#delete_ucr_number", as: "delete_ucr_number"
 
-            # These routes need to appear before the `step` scope below to avoid clashing with the
+            # These routes need to appear before the next scope block to avoid clashing with the
             # `:investigation_product_id/:entity_id` routes.
-            get "add_risk_assessments/:entity_id/remove", to: "create#remove_with_entity", as: "remove_with_entity"
-            delete "add_risk_assessments/:entity_id/remove", to: "create#remove_with_entity"
+            scope ":step", constraints: { step: /add_risk_assessments|record_a_corrective_action/ } do
+              get ":entity_id/remove", to: "create#remove_with_entity", as: "remove_with_entity"
+              delete ":entity_id/remove", to: "create#remove_with_entity"
+            end
+
+            get "record_a_corrective_action/:entity_id", to: "create#update_with_entity", as: "with_entity"
+            patch "record_a_corrective_action/:entity_id", to: "create#update_with_entity"
+            put "record_a_corrective_action/:entity_id", to: "create#update_with_entity"
 
             scope ":step", constraints: { step: /add_test_reports|add_risk_assessments/ } do
               get ":investigation_product_id", to: "create#show_with_notification_product", as: "with_product"

--- a/db/migrate/20240124145754_add_corrective_action_taken_to_investigations.rb
+++ b/db/migrate/20240124145754_add_corrective_action_taken_to_investigations.rb
@@ -1,0 +1,10 @@
+class AddCorrectiveActionTakenToInvestigations < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :investigations, bulk: true do |t|
+        t.string :corrective_action_taken
+        t.string :corrective_action_not_taken_reason
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_22_143016) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_24_145754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -289,6 +289,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_143016) do
     t.bigint "ahoy_visit_id"
     t.string "complainant_reference"
     t.boolean "coronavirus_related", default: false
+    t.string "corrective_action_not_taken_reason"
+    t.string "corrective_action_taken"
     t.datetime "created_at", precision: nil, null: false
     t.string "custom_risk_level"
     t.datetime "date_closed", precision: nil

--- a/prism/app/models/prism/evaluation.rb
+++ b/prism/app/models/prism/evaluation.rb
@@ -7,61 +7,61 @@ module Prism
       "minor" => "minor",
       "no" => "no",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :other_hazards, {
       "yes" => "yes",
       "no" => "no",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :level_of_uncertainty, {
       "low" => "low",
       "medium" => "medium",
       "high" => "high",
-    }, prefix: true
+    }, _prefix: true
 
     enum :number_of_products_expected_to_change, {
       "no_changes" => "no_changes",
       "increase" => "increase",
       "fall" => "fall",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :comparable_risk_level, {
       "lower" => "lower",
       "similar" => "similar",
       "higher" => "higher",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :significant_risk_differential, {
       "yes" => "yes",
       "no" => "no",
       "not_applicable" => "not_applicable",
-    }, prefix: true
+    }, _prefix: true
 
     enum :relevant_action_by_others, {
       "yes" => "yes",
       "no" => "no",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :low_likelihood_high_severity, {
       "yes" => "yes",
       "no" => "no",
-    }, prefix: true
+    }, _prefix: true
 
     enum :aimed_at_vulnerable_users, {
       "yes" => "yes",
       "no" => "no",
       "unknown" => "unknown",
-    }, prefix: true
+    }, _prefix: true
 
     enum :designed_to_provide_protective_function, {
       "yes" => "yes",
       "no" => "no",
-    }, prefix: true
+    }, _prefix: true
 
     enum risk_tolerability: {
       "tolerable" => "tolerable",


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/PSD-2330, https://regulatorydelivery.atlassian.net/browse/PSD-2123, https://regulatorydelivery.atlassian.net/browse/PSD-2261

## Description

Adds the “record a corrective action” task.

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
