### PR TITLE
Allow multiple legislation choices for corrective actions

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -326,7 +326,6 @@ private
 
   def bulk_products_create_corrective_action_params
     params.require(:corrective_action_form).permit(
-      :legislation,
       :action,
       :has_online_recall_information,
       :online_recall_information,
@@ -337,9 +336,10 @@ private
       :other_action,
       :further_corrective_action,
       :existing_document_file_id,
+      legislation: [],
       geographic_scopes: [],
       file: %i[file description],
       date_decided: %i[day month year]
-    ).with_defaults(geographic_scopes: [])
+    ).with_defaults(legislation: [], geographic_scopes: [])
   end
 end

--- a/app/controllers/concerns/corrective_actions_concern.rb
+++ b/app/controllers/concerns/corrective_actions_concern.rb
@@ -5,7 +5,6 @@ module CorrectiveActionsConcern
     params.require(:corrective_action).permit(
       :investigation_product_id,
       :business_id,
-      :legislation,
       :action,
       :has_online_recall_information,
       :online_recall_information,
@@ -16,9 +15,10 @@ module CorrectiveActionsConcern
       :other_action,
       :further_corrective_action,
       :existing_document_file_id,
+      legislation: [],
       geographic_scopes: [],
       file: %i[file description],
       date_decided: %i[day month year]
-    ).with_defaults(geographic_scopes: [])
+    ).with_defaults(legislation: [], geographic_scopes: [])
   end
 end

--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -11,6 +11,7 @@ module Investigations
 
     def create
       @corrective_action_form = CorrectiveActionForm.new(corrective_action_params)
+      @corrective_action_form.legislation.reject!(&:blank?)
       @file_blob = @corrective_action_form.document
       return render :new if @corrective_action_form.invalid?(:add_corrective_action)
 
@@ -46,6 +47,7 @@ module Investigations
       @file_blob              = corrective_action.document_blob
 
       @corrective_action_form.assign_attributes(corrective_action_params)
+      @corrective_action_form.legislation.reject!(&:blank?)
       return render :edit if @corrective_action_form.invalid?(:edit_corrective_action)
 
       UpdateCorrectiveAction.call!(

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -797,8 +797,9 @@ module Notifications
     end
 
     def record_a_corrective_action_details_params
-      allowed_params = params.require(:corrective_action_form).permit(:action, :has_online_recall_information, :online_recall_information, :legislation, :business_id, :measure_type, :details, :related_file, :existing_document_file_id, :document, date_decided: %i[day month year], geographic_scopes: [])
+      allowed_params = params.require(:corrective_action_form).permit(:action, :has_online_recall_information, :online_recall_information, :business_id, :measure_type, :details, :related_file, :existing_document_file_id, :document, date_decided: %i[day month year], legislation: [], geographic_scopes: [])
       # The form builder inserts an empty hidden field that needs to be removed before validation and saving
+      allowed_params[:legislation].reject!(&:blank?)
       allowed_params[:geographic_scopes].reject!(&:blank?)
       allowed_params
     end

--- a/app/decorators/audit_activity/corrective_action/add_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/add_decorator.rb
@@ -15,7 +15,9 @@ class AuditActivity::CorrectiveAction::AddDecorator < AuditActivity::CorrectiveA
   end
 
   def legislation
-    metadata.dig("corrective_action", "legislation")
+    return [] unless (legislation = metadata.dig("corrective_action", "legislation"))
+
+    legislation.to_sentence
   end
 
   def details

--- a/app/decorators/audit_activity/corrective_action/base_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/base_decorator.rb
@@ -2,7 +2,7 @@ class AuditActivity::CorrectiveAction::BaseDecorator < ActivityDecorator
   include Investigations::CorrectiveActionsHelper
 
   decorates_association :business, with: BusinessDecorator
-  delegate :details, :geographic_scope, :duration, :measure_type, :date_decided, :legislation, :geographic_scope, to: :corrective_action
+  delegate :details, :duration, :measure_type, :date_decided, :legislation, :geographic_scope, to: :corrective_action
 
   delegate :trading_name, to: :business
 

--- a/app/decorators/audit_activity/corrective_action/update_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/update_decorator.rb
@@ -15,7 +15,9 @@ class AuditActivity::CorrectiveAction::UpdateDecorator < AuditActivity::Correcti
   end
 
   def new_legislation
-    metadata.dig("updates", "legislation", 1)
+    return unless (legislation = metadata.dig("updates", "legislation", 1))
+
+    legislation.to_sentence
   end
 
   def new_online_recall_information

--- a/app/decorators/corrective_action_decorator.rb
+++ b/app/decorators/corrective_action_decorator.rb
@@ -4,6 +4,10 @@ class CorrectiveActionDecorator < ApplicationDecorator
 
   MEDIUM_TITLE_TEXT_SIZE_THRESHOLD = 62
 
+  def legislation
+    object.legislation.to_sentence
+  end
+
   def geographic_scopes
     object.geographic_scopes.map { |geographic_scope|
       I18n.t(geographic_scope, scope: %i[corrective_action attributes geographic_scopes])

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -11,7 +11,7 @@ class CorrectiveActionForm
   attribute :date_decided, :govuk_date
   attribute :investigation_product_id, :integer
   attribute :business_id, :integer
-  attribute :legislation
+  attribute :legislation, default: []
   attribute :action
   attribute :details
   attribute :related_file

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -119,7 +119,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     )
   end
 
-  def govuk_select(attribute, label:, items:, label_classes: "", hint: nil)
+  def govuk_select(attribute, label:, items:, label_classes: "", hint: nil, include_blank: false, multiple: false)
     if object.errors.include?(attribute)
       error_message = {
         text: object.errors.full_messages_for(attribute).first
@@ -132,16 +132,18 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
 
     # Set item as selected if the value matches the method from the model
     @items.each_with_index do |item, _index|
-      item[:selected] = true if object.public_send(attribute).to_s == item[:value].to_s
+      item[:selected] = true if (multiple && object.public_send(attribute).include?(item[:value].to_s)) || object.public_send(attribute).to_s == item[:value].to_s
     end
 
     @template.govukSelect(
       id: attribute.to_s,
-      name: input_name(attribute),
+      name: input_name(attribute, multiple:),
       label: { text: label, classes: label_classes.to_s },
       hint:,
       items: @items,
-      errorMessage: error_message
+      errorMessage: error_message,
+      include_blank:,
+      attributes: { multiple: }
     )
   end
 
@@ -260,7 +262,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
 
 private
 
-  def input_name(attribute)
-    "#{@object_name}[#{attribute}]"
+  def input_name(attribute, multiple: false)
+    "#{@object_name}[#{attribute}]#{multiple ? '[]' : ''}"
   end
 end

--- a/app/views/investigations/corrective_actions/_form.html.erb
+++ b/app/views/investigations/corrective_actions/_form.html.erb
@@ -32,15 +32,16 @@ hint: "This may be in the future. For example, #{two_weeks_from_now.day} #{two_w
   <% end %>
 <% end %>
 
-<%= govukSelect(
-  choices: relevant_legislation,
-  key: :legislation,
-  id: "legislation",
-  form: form,
-  is_autocomplete: true,
-  show_all_values: true,
-  label: { text: "Under which legislation?", classes: "govuk-label--m" }
-) %>
+<%= form.govuk_select :legislation,
+  label: "Under which legislation?",
+  label_classes: "govuk-label--m",
+  items: [{ text: "", value: "" }] + Rails.application.config.legislation_constants["legislation"].sort.map { |legislation| { text: legislation, value: legislation }},
+  include_blank: true,
+  multiple: true
+%>
+<%= javascript_tag type: "module", nonce: true do -%>
+  window.callAutocompleteWhenReady("legislation", { showAllValues: true })
+<% end -%>
 <% if allow_business_linking %>
   <%= govukFieldset(legend: { text: "Which business is responsible?", classes: "govuk-fieldset__legend--m" }) do %>
     <div class="govuk-form-group <%= "govuk-form-group--error" if corrective_action.errors[:business].any? %>">

--- a/app/views/notifications/create/record_a_corrective_action_details.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_details.html.erb
@@ -75,7 +75,7 @@
           </div>
         </fieldset>
       </div>
-      <%= f.govuk_select :legislation, options_for_select([""] + Rails.application.config.legislation_constants["legislation"], @corrective_action_form.legislation), label: { text: "Under which legislation?", size: "m" }, hint: { text: "Search applicable legislation and choose the ones you feel are relevant." }, multiple: true %>
+      <%= f.govuk_select :legislation, options_for_select([""] + Rails.application.config.legislation_constants["legislation"].sort, @corrective_action_form.legislation), label: { text: "Under which legislation?", size: "m" }, hint: { text: "Search applicable legislation and choose the ones you feel are relevant." }, multiple: true %>
       <%= f.govuk_collection_radio_buttons :business_id, @notification.investigation_businesses.decorate.map { |ib| OpenStruct.new(id: ib.business.id, name: "#{ib.business.trading_name} (#{ib.pretty_relationship})") }, :id, :name, legend: { text: "Which business is responsible?", size: "m" }, hint: { text: "Only businesses already added to the notification are listed." } %>
       <%= f.govuk_collection_radio_buttons :measure_type, [OpenStruct.new(id: "mandatory", name: "Yes"), OpenStruct.new(id: "voluntary", name: "No, it's voluntary")], :id, :name, legend: { text: "Is the corrective action mandatory?", size: "m" } %>
       <%= f.govuk_check_boxes_fieldset :geographic_scopes, legend: { text: "In which geographic regions has this corrective action been taken?" }, data: { controller: "dynamic-checkbox-states" } do %>

--- a/app/views/notifications/create/record_a_corrective_action_details.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_details.html.erb
@@ -75,7 +75,7 @@
           </div>
         </fieldset>
       </div>
-      <%= f.govuk_collection_select :legislation, legislation_options, :id, :name, label: { text: "Under which legislation?", size: "m" }, hint: { text: "Select the relevant legislation from the list." } %>
+      <%= f.govuk_select :legislation, options_for_select([""] + Rails.application.config.legislation_constants["legislation"], @corrective_action_form.legislation), label: { text: "Under which legislation?", size: "m" }, hint: { text: "Search applicable legislation and choose the ones you feel are relevant." }, multiple: true %>
       <%= f.govuk_collection_radio_buttons :business_id, @notification.investigation_businesses.decorate.map { |ib| OpenStruct.new(id: ib.business.id, name: "#{ib.business.trading_name} (#{ib.pretty_relationship})") }, :id, :name, legend: { text: "Which business is responsible?", size: "m" }, hint: { text: "Only businesses already added to the notification are listed." } %>
       <%= f.govuk_collection_radio_buttons :measure_type, [OpenStruct.new(id: "mandatory", name: "Yes"), OpenStruct.new(id: "voluntary", name: "No, it's voluntary")], :id, :name, legend: { text: "Is the corrective action mandatory?", size: "m" } %>
       <%= f.govuk_check_boxes_fieldset :geographic_scopes, legend: { text: "In which geographic regions has this corrective action been taken?" }, data: { controller: "dynamic-checkbox-states" } do %>
@@ -107,5 +107,9 @@
       <% end %>
       <%= f.govuk_submit @corrective_action&.id.present? ? "Update corrective action" : "Add corrective action" %>
     <% end %>
+    <%= javascript_tag type: "module", nonce: true do -%>
+      window.callAutocompleteWhenReady("corrective-action-form-legislation-field", { showAllValues: true })
+      window.callAutocompleteWhenReady("corrective-action-form-legislation-field-error", { showAllValues: true })
+    <% end -%>
   </div>
 </div>

--- a/db/migrate/20240129110857_change_corrective_actions_legislation_to_array.rb
+++ b/db/migrate/20240129110857_change_corrective_actions_legislation_to_array.rb
@@ -1,4 +1,5 @@
 class ChangeCorrectiveActionsLegislationToArray < ActiveRecord::Migration[7.0]
+  # rubocop:disable Rails/BulkChangeTable
   def up
     change_column :corrective_actions, :legislation, :string, array: true, using: "(string_to_array(legislation, ''))"
     change_column_default :corrective_actions, :legislation, []
@@ -8,4 +9,5 @@ class ChangeCorrectiveActionsLegislationToArray < ActiveRecord::Migration[7.0]
     change_column :corrective_actions, :legislation, :string, using: "(array_to_string(legislation, ','))"
     change_column_default :corrective_actions, :legislation, nil
   end
+  # rubocop:enable Rails/BulkChangeTable
 end

--- a/db/migrate/20240129110857_change_corrective_actions_legislation_to_array.rb
+++ b/db/migrate/20240129110857_change_corrective_actions_legislation_to_array.rb
@@ -1,0 +1,11 @@
+class ChangeCorrectiveActionsLegislationToArray < ActiveRecord::Migration[7.0]
+  def up
+    change_column :corrective_actions, :legislation, :string, array: true, using: "(string_to_array(legislation, ''))"
+    change_column_default :corrective_actions, :legislation, []
+  end
+
+  def down
+    change_column :corrective_actions, :legislation, :string, using: "(array_to_string(legislation, ','))"
+    change_column_default :corrective_actions, :legislation, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_24_145754) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_110857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_145754) do
     t.enum "has_online_recall_information", enum_type: "has_online_recall_information"
     t.integer "investigation_id"
     t.bigint "investigation_product_id"
-    t.string "legislation"
+    t.string "legislation", default: [], array: true
     t.string "measure_type"
     t.string "online_recall_information"
     t.text "other_action"

--- a/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
+++ b/prism/app/views/prism/tasks/define/add_details_about_products_in_use_and_safety.html.erb
@@ -22,16 +22,16 @@
       <% end %>
       <%= f.govuk_select(
         :safety_legislation_standards,
-        options_for_select([""] + Rails.application.config.legislation_constants["legislation"] + ["Not yet determined"], @product_market_detail.safety_legislation_standards),
+        options_for_select([""] + Rails.application.config.legislation_constants["legislation"].sort + ["Not yet determined"], @product_market_detail.safety_legislation_standards),
         label: { text: "Product safety legislation", size: "m" },
         hint: { text: "Search applicable safety legislation and choose the ones you feel are relevant to your product." },
         multiple: true
       ) %>
       <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
       <% content_for :extra_javascript do %>
-        <%= javascript_tag nonce: true do -%>
-          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field")
-          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field-error")
+        <%= javascript_tag type: "module", nonce: true do -%>
+          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field", { showAllValues: true })
+          window.callAutocompleteWhenReady("product-market-detail-safety-legislation-standards-field-error", { showAllValues: true })
         <% end -%>
       <% end %>
     <% end %>

--- a/spec/decorators/audit_activity/corrective_action/add_decorator_spec.rb
+++ b/spec/decorators/audit_activity/corrective_action/add_decorator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AuditActivity::CorrectiveAction::AddDecorator, :with_stubbed_mail
 
   describe "#legislation" do
     it "returns the legislation" do
-      expect(decorated_activity.legislation).to eq(corrective_action.legislation)
+      expect(decorated_activity.legislation).to eq(corrective_action.legislation.to_sentence)
     end
   end
 

--- a/spec/decorators/audit_activity/corrective_action/update_decorator_spec.rb
+++ b/spec/decorators/audit_activity/corrective_action/update_decorator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AuditActivity::CorrectiveAction::UpdateDecorator, :with_stubbed_m
         action: new_summary,
         investigation_product_id: corrective_action.investigation_product_id,
         measure_type: new_measure_type,
-        legislation: new_legislation,
+        legislation: [new_legislation],
         has_online_recall_information: new_has_online_recall_information,
         online_recall_information: new_online_recall_information,
         geographic_scopes: new_geographic_scopes,

--- a/spec/factories/corrective_actions.rb
+++ b/spec/factories/corrective_actions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     investigation_product
     action { (CorrectiveAction.actions.keys - %w[other]).sample }
     date_decided { Faker::Date.backward(days: 14) }
-    legislation { Rails.application.config.legislation_constants["legislation"].sample }
+    legislation { [Rails.application.config.legislation_constants["legislation"].sample] }
     measure_type { CorrectiveAction::MEASURE_TYPES.sample }
     duration { CorrectiveAction::DURATION_TYPES.sample }
     geographic_scopes { CorrectiveAction::GEOGRAPHIC_SCOPES[0..-2] }

--- a/spec/features/edit_corrective_action_spec.rb
+++ b/spec/features/edit_corrective_action_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Edit corrective action", :with_stubbed_mailer, :with_stubbed_notify, :with_stubbed_antivirus do
   include_context "with corrective action setup for updates"
+  let(:existing_legislation) { corrective_action.legislation.first }
   let(:has_online_recall_information) { "has_online_recall_information_yes" }
 
   before do

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -271,6 +271,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
       fill_in "Year", with: "2024"
     end
 
+    select "ATEX 2016", from: "Under which legislation?"
     select "Consumer Protection Act 1987", from: "Under which legislation?"
 
     within_fieldset "Which business is responsible?" do

--- a/spec/services/add_corrective_action_to_notification_spec.rb
+++ b/spec/services/add_corrective_action_to_notification_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AddCorrectiveActionToNotification, :with_stubbed_mailer, :with_te
     expect(result.corrective_action).not_to be_new_record
     expect(result.corrective_action)
       .to have_attributes(
-        investigation: notification, date_decided:, business_id: business.id, details:, legislation:, measure_type:,
+        investigation: notification, date_decided:, business_id: business.id, details:, legislation: [legislation], measure_type:,
         duration:, geographic_scopes:, other_action:, action:, investigation_product_id: investigation_product.id,
         online_recall_information:, has_online_recall_information:
       )

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -144,7 +144,7 @@ module PageExpectations
 
     expect(page).to have_summary_item(key: "Event date", value: new_date_decided.to_formatted_s(:govuk))
     expect(page).to have_summary_item(key: "Product",             value: "#{product_two.name} (#{product_two.psd_ref})")
-    expect(page).to have_summary_item(key: "Legislation",         value: new_legislation)
+    expect(page).to have_summary_item(key: "Legislation",         value: [existing_legislation, new_legislation].sort.to_sentence)
     expect(page).to have_summary_item(key: "Type of action",      value: new_measure_type.upcase_first)
     expect(page).to have_summary_item(key: "Duration of measure", value: CorrectiveAction.human_attribute_name("duration.#{new_duration}"))
     expected_geographic_scopes_text =

--- a/spec/support/shared_contexts/add_corrective_action_context.rb
+++ b/spec/support/shared_contexts/add_corrective_action_context.rb
@@ -8,7 +8,7 @@ RSpec.shared_context "with add corrective action setup" do
   let(:action_key) { (CorrectiveAction.actions.keys - %w[other]).sample }
   let(:action) { CorrectiveAction.actions[action_key] }
   let(:date_decided) { Date.parse("2020-05-01") }
-  let(:legislation) { "General Product Safety Regulations 2005" }
+  let(:legislation) { ["General Product Safety Regulations 2005"] }
   let(:has_online_recall_information) { "has_online_recall_information_yes" }
   let(:online_recall_information) { Faker::Internet.url(host: "example.com") }
   let(:details) { "Urgent action following consumer reports" }

--- a/spec/support/shared_contexts/add_corrective_action_context.rb
+++ b/spec/support/shared_contexts/add_corrective_action_context.rb
@@ -30,7 +30,7 @@ RSpec.shared_context "with add corrective action setup" do
       action: action_key,
       other_action:,
       date_decided:,
-      legislation:,
+      legislation: [legislation],
       has_online_recall_information:,
       online_recall_information:,
       details:,

--- a/spec/support/shared_contexts/add_corrective_action_context.rb
+++ b/spec/support/shared_contexts/add_corrective_action_context.rb
@@ -8,7 +8,7 @@ RSpec.shared_context "with add corrective action setup" do
   let(:action_key) { (CorrectiveAction.actions.keys - %w[other]).sample }
   let(:action) { CorrectiveAction.actions[action_key] }
   let(:date_decided) { Date.parse("2020-05-01") }
-  let(:legislation) { ["General Product Safety Regulations 2005"] }
+  let(:legislation) { "General Product Safety Regulations 2005" }
   let(:has_online_recall_information) { "has_online_recall_information_yes" }
   let(:online_recall_information) { Faker::Internet.url(host: "example.com") }
   let(:details) { "Urgent action following consumer reports" }


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2123

## Description

Updates the existing corrective actions add/edit flow, bulk products uploads and the notification task list to allow choosing multiple legislations.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2863.london.cloudapps.digital/
https://psd-pr-2863-support.london.cloudapps.digital/
https://psd-pr-2863-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
