### PR TITLE
Disable mutually-exclusive geographic scopes when editing

### DIFF
--- a/app/javascript/controllers/dynamic_checkbox_states_controller.js
+++ b/app/javascript/controllers/dynamic_checkbox_states_controller.js
@@ -3,9 +3,11 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  update (event) {
-    event.preventDefault()
+  connect () {
+    this.update()
+  }
 
+  update () {
     // Get a list of all the checkboxes that need to be disabled by referencing all the checkboxes that are currently checked
     const targets = [].concat(...Array.from(this.element.querySelectorAll('input[type=checkbox]:checked')).map((el) => el.dataset.dynamicCheckboxStatesDisableTargets.split(',')))
     const uniqueTargets = new Set(targets)


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2123

## Description

Runs the JavsScript to disable mutually-exclusive geographic scopes when editing corrective actions as well as when adding new corrective actions.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
