### PR TITLE
Remove autocomplete fields

### DIFF
--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -147,35 +147,6 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     )
   end
 
-  def govuk_autocomplete(attribute, label:, label_classes: "", items: nil, choices: nil, hint: nil)
-    if object.errors.include?(attribute)
-      error_message = {
-        text: object.errors.full_messages_for(attribute).first
-      }
-    end
-
-    hint = { text: hint } if hint
-
-    @items = items || choices.map { |choice| { value: choice, text: choice } }
-    @items.unshift(value: nil, text: "")
-
-    # Set item as selected if the value matches the method from the model
-    @items.each_with_index do |item, _index|
-      item[:selected] = true if object.public_send(attribute).to_s == item[:value].to_s
-    end
-
-    @template.govukSelect(
-      id: attribute.to_s,
-      name: input_name(attribute),
-      label: { text: label, classes: label_classes.to_s },
-      hint:,
-      items: @items,
-      errorMessage: error_message,
-      show_all_values: true,
-      is_autocomplete: true
-    )
-  end
-
   def govuk_checkboxes(attribute, legend:, items:, legend_classes: "govuk-fieldset__legend--m", hint: nil)
     if object.errors.include?(attribute)
       error_message = {

--- a/app/helpers/investigations/user_filters_helper.rb
+++ b/app/helpers/investigations/user_filters_helper.rb
@@ -9,7 +9,7 @@ module Investigations::UserFiltersHelper
       form:,
       items: entities.map { |e| { text: e.display_name(viewer: current_user), value: e.id, selected: form.object.teams_with_access_other_id == e.id } },
       label: { text: "Person or team name" },
-      is_autocomplete: true
+      include_blank: true
     )
   end
 
@@ -19,7 +19,7 @@ module Investigations::UserFiltersHelper
       form:,
       items: entities.map { |e| { text: e.display_name(viewer: current_user), value: e.id } },
       label: { text: "Person or team name" },
-      is_autocomplete: true
+      include_blank: true
     )
   end
 
@@ -30,7 +30,7 @@ module Investigations::UserFiltersHelper
       form:,
       items: other_teams.map { |e| { text: e.display_name(viewer: current_user), value: e.id, selected: form.object.teams_with_access_other_id == e.id } },
       label: { text: "Team name" },
-      is_autocomplete: true
+      include_blank: true
     )
   end
 
@@ -40,7 +40,7 @@ module Investigations::UserFiltersHelper
       form:,
       items: entities.map { |e| { text: e.display_name(viewer: current_user), value: e.id, selected: form.object.created_by.id == e.id } },
       label: { text: "Name" },
-      is_autocomplete: true
+      include_blank: true
     )
   end
 end

--- a/app/views/investigations/_case_hazard_type_filter.html.erb
+++ b/app/views/investigations/_case_hazard_type_filter.html.erb
@@ -3,6 +3,5 @@
   form: form,
   items: [{ text: "All", value: "", attributes: { class: "govuk-!-font-size-16" }}] + hazard_types.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
   label: { text: "Hazard type" },
-  formGroup: { classes: "govuk-!-margin-right-1" },
-  is_autocomplete: false
+  formGroup: { classes: "govuk-!-margin-right-1" }
 ) %>

--- a/app/views/investigations/_why_reporting_form_unsafe_details.html.erb
+++ b/app/views/investigations/_why_reporting_form_unsafe_details.html.erb
@@ -4,11 +4,9 @@
         items: hazard_types.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
         key: :hazard_type,
         form: form,
-        show_all_values: true,
         aria_describedby: "hazard-type-category-hint", label: { text: "What is the primary hazard?" },
         id: "hazard_type",
-        include_blank: true,
-        is_autocomplete: false
+        include_blank: true
   ) %>
 </div>
 <%= govukTextarea(

--- a/app/views/investigations/accident_or_incidents/_form.html.erb
+++ b/app/views/investigations/accident_or_incidents/_form.html.erb
@@ -5,7 +5,7 @@
   <p class="govuk-body"><%= investigation.products.first.name %></p>
   <%= form.hidden_field :investigation_product_id, value: investigation.investigation_products.first.id %>
 <% else %>
-  <%= form.govuk_autocomplete :investigation_product_id, label: "Which product was involved?", label_classes: "govuk-label--m", items: investigation.investigation_products.map { |investigation_product| { text: "#{investigation_product.name} (#{investigation_product.psd_ref})", value: investigation_product.id } } %>
+  <%= form.govuk_select :investigation_product_id, label: "Which product was involved?", label_classes: "govuk-label--m", items: [{ text: "", value: "" }] + investigation.investigation_products.map { |investigation_product| { text: "#{investigation_product.name} (#{investigation_product.psd_ref})", value: investigation_product.id } } %>
 <% end %>
 
 <% other = capture do %>

--- a/app/views/investigations/ownership/_owner_form.html.erb
+++ b/app/views/investigations/ownership/_owner_form.html.erb
@@ -7,8 +7,7 @@
   form: form,
   key: :select_team_member,
   items: @team_members,
-  label: "Select team member",
-  show_all_values: true
+  label: "Select team member"
   %>
   <% end %>
 
@@ -36,8 +35,7 @@
       form: form,
       key: :select_other_team,
       items: @other_teams,
-      label: "Select other team name",
-      show_all_values: true
+      label: "Select other team name"
     %>
   <% end %>
   <% items.push text: "Other team", value: "other_team", conditional: { html: other_teams } %>

--- a/app/views/investigations/ownership/_owner_selection.html.erb
+++ b/app/views/investigations/ownership/_owner_selection.html.erb
@@ -10,11 +10,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govukSelect(
       key: key,
-      show_all_values: local_assigns[:show_all_values],
       items: actual_items,
       form: form,
       label: { text: label, classes: "govuk-visually-hidden" },
-      is_autocomplete: true
+      include_blank: true
     ) %>
   </div>
 </div>

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -23,7 +23,6 @@
         key: :investigation_product_id,
         id: "investigation_product",
         form: form,
-        show_all_values: true,
         label: { text: "Which product was tested?", classes: "govuk-label--m" },
         hint: { html: span_html },
       ) %>
@@ -37,7 +36,6 @@
   id: "legislation",
   form: form,
   include_blank: true,
-  show_all_values: true,
   label: { text: "Under which legislation?", classes: "govuk-label--m" },
   hint: { text: "Select the relevant legislation from the list." },
 ) %>

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -12,8 +12,7 @@
       form: form,
       items: [{ text: "All", value: "", attributes: { class: "govuk-!-font-size-16" }}] + product_categories.map {|type| {text: type, value: type, attributes: {class: "govuk-!-font-size-16"}}},
       label: { text: "Category" },
-      formGroup: { classes: "govuk-!-margin-right-1" },
-      is_autocomplete: false
+      formGroup: { classes: "govuk-!-margin-right-1" }
     ) %>
 
     <% if policy(Product).can_view_retired_products? %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -5,7 +5,6 @@
   choices: product_categories,
   key: :category,
   form: form,
-  show_all_values: true,
   include_blank: true,
   id: "category",
   aria_describedby: "report-product-category-hint",


### PR DESCRIPTION
## Description

Removes autocomplete from most `<select>` elements since they function just as well when a standard element and don’t have enough values to justify a custom autocomplete element.

Autocomplete elements are now only used for `<select>` elements that allow multiple choices since the default user experience for these is unintuitive.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2865.london.cloudapps.digital/
https://psd-pr-2865-support.london.cloudapps.digital/
https://psd-pr-2865-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
