### PR TITLE
Notification task lisk: add overseas regulator question

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -216,10 +216,18 @@ module Notifications
               silent: true
             )
           end
+          ChangeNotificationOverseasRegulator.call!(
+            notification: @notification,
+            is_from_overseas_regulator: add_product_safety_and_compliance_details_params[:is_from_overseas_regulator],
+            overseas_regulator_country: add_product_safety_and_compliance_details_params[:overseas_regulator_country],
+            user: current_user,
+            silent: true
+          )
           ChangeNotificationReferenceNumber.call!(
             notification: @notification,
             reference_number: add_product_safety_and_compliance_details_params[:add_reference_number] ? add_product_safety_and_compliance_details_params[:reference_number] : nil,
-            user: current_user
+            user: current_user,
+            silent: true
           )
         else
           return render_wizard
@@ -738,7 +746,7 @@ module Notifications
     end
 
     def add_product_safety_and_compliance_details_params
-      params.require(:change_notification_product_safety_compliance_details_form).permit(:unsafe, :noncompliant, :primary_hazard, :primary_hazard_description, :noncompliance_description, :add_reference_number, :reference_number, :draft)
+      params.require(:change_notification_product_safety_compliance_details_form).permit(:unsafe, :noncompliant, :primary_hazard, :primary_hazard_description, :noncompliance_description, :is_from_overseas_regulator, :overseas_regulator_country, :add_reference_number, :reference_number, :draft)
     end
 
     def number_of_affected_units_params

--- a/app/forms/change_notification_product_safety_compliance_details_form.rb
+++ b/app/forms/change_notification_product_safety_compliance_details_form.rb
@@ -8,6 +8,8 @@ class ChangeNotificationProductSafetyComplianceDetailsForm
   attribute :primary_hazard, :string
   attribute :primary_hazard_description, :string
   attribute :noncompliance_description, :string
+  attribute :is_from_overseas_regulator, :boolean
+  attribute :overseas_regulator_country, :string
   attribute :add_reference_number, :boolean
   attribute :reference_number, :string
   attribute :safe_and_compliant, :boolean # Whether the notification has already been marked as "safe and compliant"
@@ -16,6 +18,8 @@ class ChangeNotificationProductSafetyComplianceDetailsForm
   validate :at_least_one_of_unsafe_or_noncompliant, unless: -> { safe_and_compliant }
   validates :primary_hazard, :primary_hazard_description, presence: true, if: -> { unsafe }, unless: -> { safe_and_compliant }
   validates :noncompliance_description, presence: true, if: -> { noncompliant }, unless: -> { safe_and_compliant }
+  validates :is_from_overseas_regulator, inclusion: [true, false]
+  validates :overseas_regulator_country, inclusion: { in: Country.overseas_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
   validates :add_reference_number, inclusion: [true, false]
   validates :reference_number, presence: true, if: -> { add_reference_number }
   validates :primary_hazard_description, :noncompliance_description, length: { maximum: 10_000 }

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -58,6 +58,13 @@ module Notifications
         end
     end
 
+    def countries_options
+      [OpenStruct.new(id: "", name: "")] +
+        Country.overseas_countries.map do |country|
+          OpenStruct.new(id: country[1], name: country[0])
+        end
+    end
+
     def number_of_affected_units(affected_units_status, number_of_affected_units)
       case affected_units_status
       when "exact"

--- a/app/services/change_notification_overseas_regulator.rb
+++ b/app/services/change_notification_overseas_regulator.rb
@@ -16,7 +16,7 @@ class ChangeNotificationOverseasRegulator
       create_audit_activity_for_overseas_regulator_changed
     end
 
-    send_notification_email(notification, user)
+    send_notification_email(notification, user) unless context.silent
   end
 
 private

--- a/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
+++ b/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
@@ -27,6 +27,12 @@
           <% end %>
         <% end %>
       <% end %>
+      <%= f.govuk_radio_buttons_fieldset :is_from_overseas_regulator, legend: { text: "Was the safety issue reported by an overseas regulator?", size: "m" } do %>
+        <%= f.govuk_radio_button :is_from_overseas_regulator, true, label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_collection_select :overseas_regulator_country, countries_options, :id, :name, label: { text: "Country" } %>
+        <% end %>
+        <%= f.govuk_radio_button :is_from_overseas_regulator, false, label: { text: "No" } %>
+      <% end %>
       <%= f.govuk_radio_buttons_fieldset :add_reference_number, legend: { text: "Do you want to add your own reference number?", size: "m" }, hint: { text: "The reference number might be from a different internal system for your notification or a global identifier for multiple systems. It's searchable on the PSD notification search page and can be added or edited later." } do %>
         <%= f.govuk_radio_button :add_reference_number, true, label: { text: "Yes" }, link_errors: true do %>
           <%= f.govuk_text_field :reference_number, label: { text: "Reference number" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -859,6 +859,10 @@ en:
             noncompliance_description:
               blank: Enter a description of the product non-compliance issues
               too_long: Description of the product non-compliance issues must be %{count} characters or less
+            is_from_overseas_regulator:
+              inclusion: Choose whether the safety issue was reported by an overseas regulator
+            overseas_regulator_country:
+              inclusion: Choose the country of the overseas regulator
             add_reference_number:
               inclusion: Choose whether you want to add your own reference number
             reference_number:

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -116,6 +116,11 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
       fill_in "Provide additional information about the product hazard", with: "Fake description"
     end
 
+    within_fieldset "Was the safety issue reported by an overseas regulator?" do
+      choose "Yes"
+      select "France", from: "Country"
+    end
+
     within_fieldset "Do you want to add your own reference number?" do
       choose "Yes"
       fill_in "Reference number", with: "123456"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2355

## Description

Adds a new question “Was the safety issue reported by an overseas regulator?” to the “Add product safety and compliance details” task.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-01-30 at 11 51 03](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/afcd7de4-d23c-4268-81d3-b612151cd352)

## Review apps

https://psd-pr-2868.london.cloudapps.digital/
https://psd-pr-2868-support.london.cloudapps.digital/
https://psd-pr-2868-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
