### PR TITLE
Feature/psd 1948 1949 business filters

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -98,6 +98,7 @@ private
       :category,
       :retired_status,
       *Business::BUSINESS_TYPES.map(&:to_sym),
+      *Country.all.map { |country| country[0].parameterize.underscore.to_sym },
       :page_name
     )
   end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -90,7 +90,16 @@ private
   end
 
   def query_params
-    params.permit(:q, :sort_by, :sort_dir, :direction, :category, :retired_status, :page_name)
+    params.permit(
+      :q,
+      :sort_by,
+      :sort_dir,
+      :direction,
+      :category,
+      :retired_status,
+      *Business::BUSINESS_TYPES.map(&:to_sym),
+      :page_name
+    )
   end
 
   def update_business

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -25,6 +25,17 @@ module BusinessesHelper
 
     query = query.where(investigation_businesses: { relationship: business_types }) unless business_types.empty?
 
+    selected_countries = []
+
+    Country.all.each do |country|
+      selected_countries << country[1] if @search.send(country[0].parameterize.underscore)
+    end
+
+    unless selected_countries.empty?
+      primary_location_ids = Business.all.map(&:primary_location).compact.pluck(:id)
+      query = query.where(locations: { id: primary_location_ids, country: selected_countries })
+    end
+
     case @search.case_owner
     when "me"
       query = query.where(users: { id: user.id })
@@ -41,11 +52,11 @@ module BusinessesHelper
   def child_records(for_export)
     return %i[investigations locations contacts] if for_export
 
-    [:online_marketplace, { investigations: %i[owner_user owner_team] }]
+    [:online_marketplace, :locations, { investigations: %i[owner_user owner_team] }]
   end
 
   def business_export_params
-    params.permit(:q)
+    params.permit(:q, *Business::BUSINESS_TYPES.map(&:to_sym), *Country.all.map { |country| country[0].parameterize.underscore.to_sym })
   end
 
   def sorting_params

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -17,6 +17,14 @@ module BusinessesHelper
 
     query = query.where(investigations: { is_closed: false }) if @search.case_status == "open_only"
 
+    business_types = []
+
+    Business::BUSINESS_TYPES.each do |business_type|
+      business_types << business_type if @search.send(business_type)
+    end
+
+    query = query.where(investigation_businesses: { relationship: business_types }) unless business_types.empty?
+
     case @search.case_owner
     when "me"
       query = query.where(users: { id: user.id })

--- a/app/helpers/countries_helper.rb
+++ b/app/helpers/countries_helper.rb
@@ -14,6 +14,6 @@ module CountriesHelper
   end
 
   def all_countries_with_uk_first
-    Country::UNITED_KINGDOM + all_countries
+    Country::UNITED_KINGDOM + (all_countries - Country::UNITED_KINGDOM)
   end
 end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -55,6 +55,9 @@ class SearchParams
   Business::BUSINESS_TYPES.each do |business_type|
     attribute business_type.parameterize.underscore.to_sym, :boolean
   end
+  Country.all.each do |country|
+    attribute country[0].parameterize.underscore.to_sym, :boolean
+  end
 
   def selected_sort_by
     if sort_by.blank?

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -52,6 +52,9 @@ class SearchParams
   Rails.application.config.hazard_constants["hazard_type"].each do |type|
     attribute type.parameterize.underscore.to_sym, :boolean
   end
+  Business::BUSINESS_TYPES.each do |business_type|
+    attribute business_type.parameterize.underscore.to_sym, :boolean
+  end
 
   def selected_sort_by
     if sort_by.blank?

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -3,6 +3,10 @@ class Business < ApplicationRecord
   include Documentable
   include AttachmentConcern
 
+  BUSINESS_TYPES = %w[
+    retailer online_seller online_marketplace manufacturer exporter importer fulfillment_house distributor authorised_representative responsible_person
+  ].freeze
+
   validates :trading_name, presence: true
 
   has_many_attached :documents

--- a/app/views/businesses/_business_locations_checkboxes.html.erb
+++ b/app/views/businesses/_business_locations_checkboxes.html.erb
@@ -1,0 +1,5 @@
+<%= govukCheckboxes(
+  key: "",
+  form: form,
+  items: all_countries_with_uk_first.map { |country| { key: country[0].parameterize.underscore.to_sym, text: country[0], value: true } }
+) %>

--- a/app/views/businesses/_business_type_checkboxes.html.erb
+++ b/app/views/businesses/_business_type_checkboxes.html.erb
@@ -1,0 +1,6 @@
+
+<%= govukCheckboxes(
+  key: "",
+  form: form,
+  items: Business::BUSINESS_TYPES.map { |business_type| { key: business_type.to_s, text: t("investigations.business_types.new.types.#{business_type}.label") , value: true } }
+) %>

--- a/app/views/businesses/_filters.html.erb
+++ b/app/views/businesses/_filters.html.erb
@@ -4,25 +4,32 @@
   </a>
   <%= render 'businesses/secondary_nav' %>
 
-  <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
+  <% if ["team_businesses", "your_businesses"].exclude?(@page_name) && current_user.is_opss? %>
 
-  <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
+    <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
 
-  <%= govuk_details(summary_text: "Business Type", classes: "opss-details--plain", id: "business-type") do %>
-    <%= render "businesses/business_type_checkboxes", form: form %>
-  <% end %>
+    <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
 
-  <div class="govuk-button-group">
+    <%= govuk_details(summary_text: "Business Type", classes: "opss-details--plain", id: "business-type") do %>
+      <%= render "businesses/business_type_checkboxes", form: form %>
+    <% end %>
+
+    <%= govuk_details(summary_text: "Primary Location", classes: "opss-details--plain", id: "business-location") do %>
+      <%= render "businesses/business_locations_checkboxes", form: form %>
+    <% end %>
+
+    <div class="govuk-button-group">
       <%= form.submit "Apply", name: nil, class: "govuk-button" %>
       <%= link_to "Reset", businesses_path, class: "govuk-link govuk-link--no-visited-state" %>
     </div>
 
-  <% if @businesses.any? && policy(Business).export? && ["team_businesses", "your_businesses"].exclude?(@page_name) %>
-    <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
-      <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
-        Request this list as a downloadable <br class="opss-br-desktop">
-        <%= link_to(generate_business_exports_path(params: business_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
-      </p>
-    </div>
+    <% if @businesses.any? && policy(Business).export? && ["team_businesses", "your_businesses"].exclude?(@page_name) %>
+      <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+        <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
+          Request this list as a downloadable <br class="opss-br-desktop">
+          <%= link_to(generate_business_exports_path(params: business_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
+        </p>
+      </div>
+    <% end %>
   <% end %>
 </section>

--- a/app/views/businesses/_filters.html.erb
+++ b/app/views/businesses/_filters.html.erb
@@ -1,0 +1,28 @@
+<section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
+  <a href="#page-content" class="govuk-skip-link opss-skip-link">
+    Skip to the main content
+  </a>
+  <%= render 'businesses/secondary_nav' %>
+
+  <h2 class="govuk-heading-s">Filters<span class="govuk-visually-hidden">:</span></h2>
+
+  <%= govuk_skip_link(text: "Skip to results", href: "#page-content") %>
+
+  <%= govuk_details(summary_text: "Business Type", classes: "opss-details--plain", id: "business-type") do %>
+    <%= render "businesses/business_type_checkboxes", form: form %>
+  <% end %>
+
+  <div class="govuk-button-group">
+      <%= form.submit "Apply", name: nil, class: "govuk-button" %>
+      <%= link_to "Reset", businesses_path, class: "govuk-link govuk-link--no-visited-state" %>
+    </div>
+
+  <% if @businesses.any? && policy(Business).export? && ["team_businesses", "your_businesses"].exclude?(@page_name) %>
+    <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
+      <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
+        Request this list as a downloadable <br class="opss-br-desktop">
+        <%= link_to(generate_business_exports_path(params: business_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
+      </p>
+    </div>
+  <% end %>
+</section>

--- a/app/views/businesses/index.html.erb
+++ b/app/views/businesses/index.html.erb
@@ -4,19 +4,7 @@
 
 <%= form_with(model: @search, scope: "", url: businesses_path, method: :get, html: { role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
-
-    <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
-      <%= render 'businesses/secondary_nav' %>
-
-      <% if @businesses.any? && policy(Business).export? && ["team_businesses", "your_businesses"].exclude?(@page_name) %>
-        <div class="govuk-!-padding-top-2 govuk-!-padding-right-0 govuk-!-padding-bottom-1 govuk-!-margin-bottom-3 opss-desktop-margin-bottom-220px opss-full-height__col--bottom opss-right-box-arrow">
-          <p class="govuk-body govuk-!-padding-bottom-1 govuk-!-margin-bottom-0 govuk-!-font-size-14">
-            Request this list as a downloadable <br class="opss-br-desktop">
-            <%= link_to(generate_business_exports_path(params: business_export_params), class: "govuk-link govuk-link--no-visited-state") do -%><abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet)<%- end -%> file.
-          </p>
-        </div>
-      <% end %>
-    </section>
+    <%= render 'businesses/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">
       <% if ["team_businesses", "your_businesses"].exclude?(@page_name) %>
         <div class="govuk-grid-row">

--- a/spec/factories/businesses.rb
+++ b/spec/factories/businesses.rb
@@ -4,4 +4,40 @@ FactoryBot.define do
     legal_name { Faker::Restaurant.name }
     trading_name { Faker::Restaurant.name }
   end
+
+  trait :online_marketplace do
+    transient do
+      notification_to_add { create(:notification) }
+      business_relationship { "online_marketplace" }
+    end
+
+    after(:create) do |business, evaluator|
+      AddBusinessToNotification.call!(notification: evaluator.notification_to_add, business:, relationship: evaluator.business_relationship, user: evaluator.notification_to_add.owner)
+      business.reload # This ensures notification.businesses returns business_to_add
+    end
+  end
+
+  trait :manufacturer do
+    transient do
+      notification_to_add { create(:notification) }
+      business_relationship { "manufacturer" }
+    end
+
+    after(:create) do |business, evaluator|
+      AddBusinessToNotification.call!(notification: evaluator.notification_to_add, business:, relationship: evaluator.business_relationship, user: evaluator.notification_to_add.owner)
+      business.reload # This ensures notification.businesses returns business_to_add
+    end
+  end
+
+  trait :retailer do
+    transient do
+      notification_to_add { create(:notification) }
+      business_relationship { "retailer" }
+    end
+
+    after(:create) do |business, evaluator|
+      AddBusinessToNotification.call!(notification: evaluator.notification_to_add, business:, relationship: evaluator.business_relationship, user: evaluator.notification_to_add.owner)
+      business.reload # This ensures notification.businesses returns business_to_add
+    end
+  end
 end

--- a/spec/features/businesses_spec.rb
+++ b/spec/features/businesses_spec.rb
@@ -1,13 +1,17 @@
 require "rails_helper"
 
 RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
-  let(:user)            { create :user, :activated, has_viewed_introduction: true }
+  let(:user)            { create :user, :opss_user, :activated, has_viewed_introduction: true }
+  let(:non_opss_user)            { create :user, :activated, has_viewed_introduction: true }
   let!(:business_one)   { create(:business, :online_marketplace, trading_name: "great value", created_at: 1.day.ago) }
   let!(:business_two)   { create(:business, :retailer, trading_name: "mediocre stuff", created_at: 2.days.ago) }
   let!(:business_three) { create(:business, :manufacturer, trading_name: "pretty bad", created_at: 3.days.ago) }
 
   before do
     create_list :business, 18, created_at: 4.days.ago
+    create(:location, country: "country:GB", business: business_one)
+    create(:location, country: "country:FR", business: business_two)
+    create(:location, country: "country:AU", business: business_three)
     business_one
     business_two
     business_three
@@ -103,5 +107,52 @@ RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
     expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
     expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
     expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+  end
+
+  scenario "search by primary location" do
+    visit all_businesses_path
+    expect(page).to have_css("h2", text: "Filters")
+
+    find("details#business-location").click
+    check "United Kingdom"
+    check "France"
+    check "Australia"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-location").click
+    uncheck "Australia"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).not_to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-location").click
+    uncheck "France"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).not_to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).not_to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-location").click
+    uncheck "United Kingdom"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+  end
+
+  scenario "non-opss user should not be able to see filters" do
+    sign_out
+    sign_in(non_opss_user)
+    visit all_businesses_path
+
+    expect(page).not_to have_css("h2", text: "Filters")
   end
 end

--- a/spec/features/businesses_spec.rb
+++ b/spec/features/businesses_spec.rb
@@ -2,12 +2,15 @@ require "rails_helper"
 
 RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
   let(:user)            { create :user, :activated, has_viewed_introduction: true }
-  let!(:business_one)   { create(:business, trading_name: "great value",    created_at: 1.day.ago) }
-  let!(:business_two)   { create(:business, trading_name: "mediocre stuff", created_at: 2.days.ago) }
-  let!(:business_three) { create(:business, trading_name: "pretty bad",     created_at: 3.days.ago) }
+  let!(:business_one)   { create(:business, :online_marketplace, trading_name: "great value", created_at: 1.day.ago) }
+  let!(:business_two)   { create(:business, :retailer, trading_name: "mediocre stuff", created_at: 2.days.ago) }
+  let!(:business_three) { create(:business, :manufacturer, trading_name: "pretty bad", created_at: 3.days.ago) }
 
   before do
     create_list :business, 18, created_at: 4.days.ago
+    business_one
+    business_two
+    business_three
     sign_in(user)
     visit all_businesses_path
   end
@@ -52,7 +55,7 @@ RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
   end
 
   scenario "displays cases for business" do
-    investigation = create(:allegation, :with_business, business_to_add: business_one)
+    investigation = business_one.investigations.first
     visit "/businesses/#{business_one.id}"
 
     within ".psd-case-card" do
@@ -63,5 +66,42 @@ RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
     within ".psd-case-card" do
       expect(page).to have_css("span", text: "Notification restricted")
     end
+  end
+
+  scenario "search by business type" do
+    visit all_businesses_path
+    find("details#business-type").click
+    check "Online marketplace"
+    check "Retailer"
+    check "Manufacturer"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-type").click
+    uncheck "Online marketplace"
+    click_button "Apply"
+
+    expect(page).not_to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-type").click
+    uncheck "Retailer"
+    click_button "Apply"
+
+    expect(page).not_to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).not_to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
+
+    find("details#business-type").click
+    uncheck "Manufacturer"
+    click_button "Apply"
+
+    expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
+    expect(page).to have_link(business_two.trading_name, href: business_path(business_two))
+    expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
   end
 end


### PR DESCRIPTION
## Description
Allows opss users to filter businesses by business type and primary location

## Screen-shots or screen-capture of UI changes
<img width="542" alt="Screenshot 2024-01-16 at 13 46 34" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/aa3970e7-c90a-4aac-8f3f-4856d885d7b1">


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2868.london.cloudapps.digital/
https://psd-pr-2868-support.london.cloudapps.digital/
https://psd-pr-2868-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
