### PR TITLE
Fix test reports

### DIFF
--- a/app/services/update_test_result.rb
+++ b/app/services/update_test_result.rb
@@ -12,26 +12,26 @@ class UpdateTestResult
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No user supplied")          unless user.is_a?(User)
 
-    test_result.assign_attributes(
-      date:,
-      details:,
-      legislation:,
-      result:,
-      failure_details: updated_failure_details,
-      standards_product_was_tested_against:,
-      investigation_product_id:,
-    )
-
-    if tso_certificate_reference_number.present? || tso_certificate_issue_date.present?
-      test_result.assign_attributes(
-        tso_certificate_reference_number:,
-        tso_certificate_issue_date:,
-      )
-    end
-
     test_result.transaction do
-      test_result.document.detach
-      test_result.document.attach(document)
+      if tso_certificate_reference_number.present? || tso_certificate_issue_date.present?
+        test_result.assign_attributes(
+          tso_certificate_reference_number:,
+          tso_certificate_issue_date:,
+        )
+      else
+        test_result.assign_attributes(
+          date:,
+          details:,
+          legislation:,
+          result:,
+          failure_details: updated_failure_details,
+          standards_product_was_tested_against:,
+          investigation_product_id:,
+        )
+
+        test_result.document.detach
+        test_result.document.attach(document)
+      end
 
       if test_result.save
         create_audit_activity_for_test_result_updated if any_changes?

--- a/app/views/notifications/create/add_test_reports.html.erb
+++ b/app/views/notifications/create/add_test_reports.html.erb
@@ -12,7 +12,7 @@
           @existing_test_results.each do |test_result|
             summary_list.with_row do |row|
               row.with_key(text: "#{test_result.document.blob&.filename || 'No document'}<br>#{test_result.investigation_product.product.decorate.name_with_brand}".html_safe)
-              row.with_action(text: "Change", href: "#{with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id)}?opss_funded=false", visually_hidden_text: "test report")
+              row.with_action(text: "Change", href: with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id, opss_funded: false), visually_hidden_text: "test report")
               row.with_action(text: "Remove", href: remove_with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id), visually_hidden_text: "test report")
             end
           end

--- a/app/views/notifications/create/add_test_reports.html.erb
+++ b/app/views/notifications/create/add_test_reports.html.erb
@@ -12,7 +12,7 @@
           @existing_test_results.each do |test_result|
             summary_list.with_row do |row|
               row.with_key(text: "#{test_result.document.blob&.filename || 'No document'}<br>#{test_result.investigation_product.product.decorate.name_with_brand}".html_safe)
-              row.with_action(text: "Change", href: with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id), visually_hidden_text: "test report")
+              row.with_action(text: "Change", href: "#{with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id)}?opss_funded=false", visually_hidden_text: "test report")
               row.with_action(text: "Remove", href: remove_with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: test_result.investigation_product.id, entity_id: test_result.id), visually_hidden_text: "test report")
             end
           end

--- a/app/views/notifications/create/add_test_reports_details.html.erb
+++ b/app/views/notifications/create/add_test_reports_details.html.erb
@@ -15,6 +15,11 @@
           <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
         </ul>
       <% end %>
+      <% if @test_result.date.present? %>
+        <%= govuk_inset_text do %>
+          This test report is marked as <strong><%= "not" if @test_result.tso_certificate_issue_date.blank? %> being funded under the <abbr>OPSS</abbr> sampling protocol</strong>. If this is incorrect, <a href="<%= remove_with_product_and_entity_notification_create_index_path(@notification, step: "add_test_reports", investigation_product_id: @test_result.investigation_product.id, entity_id: @test_result.id) %>" class="govuk-link">remove this test report</a> and create a new one.
+        <% end %>
+      <% end %>
       <%= f.govuk_collection_select :legislation, legislation_options, :id, :name, label: { text: "Under which legislation?", size: "m" }, hint: { text: "Select the relevant legislation from the list." } %>
       <%= f.govuk_text_field :standards_product_was_tested_against, label: { text: "Which standard was the product tested against?", size: "m" }, hint: { text: "For example, EN71. Use a comma to separate multiple standards." } %>
       <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>


### PR DESCRIPTION
## Description

Fixes test reports for the notification task list to ignore funding status when editing and prevent data being overwritten.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2875.london.cloudapps.digital/
https://psd-pr-2875-support.london.cloudapps.digital/
https://psd-pr-2875-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
