### PR TITLE
Fx typo in reporting summary view - PSD-2400

### DIFF
--- a/report_portal/app/views/report_portal/dashboard/index.html.erb
+++ b/report_portal/app/views/report_portal/dashboard/index.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-column-one-half">
     <a href="<%= summary_index_path %>" class="app-card">
       <h3 class="govuk-heading-s app-card__heading">Summary</h3>
-      <p class="govuk-body">At a glace statistics from all areas of PSD</p>
+      <p class="govuk-body">At a glance statistics from all areas of PSD</p>
     </a>
   </div>
   <div class="govuk-grid-column-one-half">


### PR DESCRIPTION

https://regulatorydelivery.atlassian.net/browse/PSD-2400

## Description
Fixes a typo in the reporting portal summary page

<img width="767" alt="5f7424d1-06f7-4727-8a82-529c903f0759" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/f7d406e6-453b-44fb-a1cc-d026cacc4e80">
