### PR TITLE
Notification task list: submitted summary

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -690,8 +690,7 @@ module Notifications
     end
 
     def disallow_changing_submitted_notification
-      # TODO(ruben): redirect to view notification page once ready
-      redirect_to notifications_path unless @notification.draft?
+      redirect_to notification_path(@notification) unless @notification.draft?
     end
 
     def set_steps

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,6 +4,7 @@ class NotificationsController < ApplicationController
 
   before_action :set_search_params, only: %i[index]
   before_action :set_last_case_view_cookie, only: %i[index]
+  before_action :set_notification, except: %i[index]
 
   breadcrumb "cases.label", :your_cases_investigations
 
@@ -22,6 +23,12 @@ class NotificationsController < ApplicationController
     end
   end
 
+  # GET /notifications/:pretty_id
+  def show; end
+
+  # GET /notifications/:pretty_id/access
+  def access; end
+
 private
 
   def set_last_case_view_cookie
@@ -38,5 +45,9 @@ private
 
   def default_params
     params["case_statuses"] == %w[open closed] && params[:q].blank?
+  end
+
+  def set_notification
+    @notification = Investigation::Notification.includes(:creator_user, :creator_team, :owner_user, :owner_team).find_by!(pretty_id: params[:pretty_id])
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,14 @@
+module NotificationsHelper
+  def show_edit_link?
+    policy(@notification).update?(user: current_user)
+  end
+
+  def collaborator_access(collaborator)
+    case collaborator
+    when Collaboration::Access::Edit
+      "Edit"
+    when Collaboration::Access::ReadOnly
+      "View"
+    end
+  end
+end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -121,7 +121,7 @@ class Investigation < ApplicationRecord
   end
 
   def non_owner_teams_with_access
-    (teams_with_read_only_access.or(teams_with_edit_access)).order(:name) - [owner.team]
+    teams_with_read_only_access.or(teams_with_edit_access).order(:name) - [owner.team]
   end
 
   def non_owner_collaborators_with_access

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -121,7 +121,11 @@ class Investigation < ApplicationRecord
   end
 
   def non_owner_teams_with_access
-    teams_with_read_only_access.or(teams_with_edit_access) - [owner.team]
+    (teams_with_read_only_access.or(teams_with_edit_access)).order(:name) - [owner.team]
+  end
+
+  def non_owner_collaborators_with_access
+    collaboration_accesses.sorted_by_team_name - [owner_team_collaboration]
   end
 
   def build_owner_collaborations_from(user)

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -12,6 +12,7 @@ class CreateNotification
     notification.creator_user = user
     notification.creator_team = team
     notification.notifying_country = team.country
+    notification.state = "submitted" unless from_task_list
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -1,30 +1,21 @@
 <% page_heading = "Has the notification risk level been validated?" %>
 <% page_title page_heading, errors: @risk_validation_form.errors.any? %>
-<%= form_with scope: :investigation, model: @risk_validation_form, builder: ApplicationFormBuilder, url: investigation_risk_validations_path(@investigation), method: :put do |form| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @risk_validation_form.errors %>
 
-      <% if @currently_not_validated %>
-        <% no_row = { text: "No", value: "false"} %>
-      <% else %>
-        <% no_row = { text: "No", value: "false", conditional: { html: form.govuk_text_area(:risk_validation_change_rationale, label: "Further details", hint: "Tell us the reason in a few words") } } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @risk_validation_form, url: investigation_risk_validations_path(@investigation), scope: :investigation, method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :is_risk_validated, legend: { text: page_heading, size: "l" } do %>
+        <%= f.govuk_radio_button :is_risk_validated, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :is_risk_validated, false, label: { text: "No" } do %>
+          <% unless @currently_not_validated %>
+            <%= f.govuk_text_area :risk_validation_change_rationale, label: { text: "Provide a brief explanation" }, max_chars: 10_000 %>
+          <% end %>
+        <% end %>
       <% end %>
-
-      <%= govukRadios(
-        form: form,
-        key: :is_risk_validated,
-        fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
-        items: [
-          { text: "Yes", value: "true", id: "is_risk_validated" },
-          no_row
-        ]
-      ) %>
-
-      <div class="govuk-form-group">
-        <%= govukButton(text: t("Continue")) %>
-        <p><%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link--no-visited-state" %></p>
-      </div>
-    </div>
+      <%= f.govuk_submit "Continue" do %>
+        <a href="<%= investigation_path(@investigation) %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/notifications/access.html.erb
+++ b/app/views/notifications/access.html.erb
@@ -1,0 +1,43 @@
+<%= page_title("Manage notification and team access") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @notification.user_title %></span>
+      Manage notification and team access
+    </h1>
+    <p class="govuk-body">Reassign the notification to a specific team or individual and adjust their editing permissions. Notification owners have the exclusive ability to add or remove teams, manage team permissions, and reassign the notification owner.</p>
+    <%=
+      govuk_table do |table|
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: "Team")
+            row.with_cell(text: "Individual")
+            row.with_cell(text: "Permission level")
+            row.with_cell(text: "Actions")
+          end
+        end
+        table.with_body do |body|
+          body.with_row do |row|
+            row.with_cell(text: @notification.owner_team.name)
+            row.with_cell(text: @notification.owner_user&.name)
+            row.with_cell(text: govuk_tag(text: "Notification owner", colour: "green").html_safe)
+            row.with_cell(text: "<a href=\"#{new_investigation_ownership_path(@notification)}\" class=\"govuk-link\">Change</a>".html_safe)
+          end
+          @notification.non_owner_collaborators_with_access.each do |collaborator|
+            body.with_row do |row|
+              row.with_cell(text: collaborator.collaborator.name)
+              row.with_cell(text: "")
+              row.with_cell(text: collaborator_access(collaborator))
+              row.with_cell(text: "<a href=\"#{edit_investigation_collaborator_path(@notification, collaborator.id)}\" class=\"govuk-link\">Change</a>".html_safe)
+            end
+          end
+        end
+      end
+    %>
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to "Add team", new_investigation_collaborator_path(@notification) %>
+      <p class="govuk-body"><a href="<%= notification_path(@notification) %>" class="govuk-link">Return to notification overview</a></p>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/create/add_product_identification_details.html.erb
+++ b/app/views/notifications/create/add_product_identification_details.html.erb
@@ -54,7 +54,7 @@
                 ]
               },
               {
-                key: { text: "Number of units affected" },
+                key: { text: "Number of units affected (mandatory)" },
                 value: { text: number_of_affected_units(investigation_product.affected_units_status, investigation_product.number_of_affected_units) },
                 actions: [
                   {

--- a/app/views/notifications/create/confirmation.html.erb
+++ b/app/views/notifications/create/confirmation.html.erb
@@ -6,8 +6,7 @@
     <p class="govuk-body">You have successfully submitted the notification for <%= @products %>.</p>
     <h2 class="govuk-heading-m">Next steps</h2>
     <p class="govuk-body">Make changes or update the information in your recently submitted safety notification.</p>
-    <%# TODO(ruben) add link once editing is available %>
-    <p class="govuk-body"><a href="#" class="govuk-link">Edit submitted notification</a></p>
+    <p class="govuk-body"><a href="<%= notification_path(@notification) %>" class="govuk-link">Edit submitted notification</a></p>
     <p class="govuk-body">View or edit any of your existing draft or submitted notifications to ensure all information is accurate and up-to-date.</p>
     <p class="govuk-body"><a href="<%= your_cases_investigations_path %>" class="govuk-link">Manage notifications</a></p>
   </div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -1,0 +1,272 @@
+<%= page_title(@notification.user_title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= @notification.user_title %>
+    </h1>
+    <%= govuk_tag(text: "Submitted", colour: "green") %>
+    <%= govuk_inset_text do %>
+      <p class="govuk-body">For</p>
+      <ul class="govuk-list">
+      <% @notification.investigation_products.decorate.each do |investigation_product| %>
+        <li class="govuk-body-l"><%= investigation_product.product.name_with_brand %></li>
+      <% end %>
+      </ul>
+      <p class="govuk-body"><a href="<%= new_investigation_product_path(@notification) %>" class="govuk-link govuk-link--no-visited-state">Add another product</a></p>
+    <% end %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <p class="govuk-body-s">
+      <strong>Notification number:</strong> <%= @notification.pretty_id %><br>
+      <strong>Last updated:</strong> <%= date_or_recent_time_ago(@notification.updated_at) %><br>
+      <strong>Created:</strong> <%= @notification.created_at.to_formatted_s(:govuk) %><br>
+      <strong>Created by:</strong> <%= @notification.creator_user.name %> (<%= @notification.creator_team.name %>)<br>
+      <strong>Notifying country:</strong> <%= country_from_code(@notification.notifying_country, Country.notifying_countries) %>
+    </p>
+    <h2 class="govuk-heading-m">Notification details</h2>
+    <%=
+      govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key(text: "Notification title")
+          row.with_value(text: @notification.user_title)
+          row.with_action(text: "Change", href: edit_investigation_case_names_path(@notification), visually_hidden_text: "notification title") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Notification summary")
+          row.with_value(text: @notification.description || "Not provided")
+          row.with_action(text: "Change", href: edit_investigation_summary_path(@notification), visually_hidden_text: "notification summary") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Notification reason")
+          row.with_value(text: @notification.safe_and_compliant? ? "Safe and compliant product(s)" : "Unsafe or non-compliant product(s)")
+          row.with_action(text: "Change", href: edit_investigation_reported_reason_path(@notification), visually_hidden_text: "notification reason") if show_edit_link?
+        end
+        unless @notification.reported_reason.safe_and_compliant?
+          summary_list.with_row do |row|
+            row.with_key(text: "Specific product safety issues")
+            row.with_value(text: specific_product_safety_issues.html_safe)
+            row.with_action(text: "Change", href: edit_investigation_reported_reason_path(@notification), visually_hidden_text: "specific product safety issues") if show_edit_link?
+          end
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Reported by overseas regulator")
+          row.with_value(text: @notification.is_from_overseas_regulator ? "Yes: #{country_from_code(@notification.overseas_regulator_country)}" : "No")
+          row.with_action(text: "Change", href: edit_investigation_overseas_regulator_path(@notification), visually_hidden_text: "reported by overseas regulator") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Notification risk level")
+          row.with_value(text: risk_level_tag)
+          row.with_action(text: "Change", href: investigation_risk_level_path(@notification), visually_hidden_text: "notification risk level") if show_edit_link?
+        end
+        if current_user.can_validate_risk_level?
+          summary_list.with_row do |row|
+            row.with_key(text: "Risk level validated")
+            row.with_value(text: @notification.risk_level_currently_validated? ? "Yes" : "No")
+            row.with_action(text: "Change", href: edit_investigation_risk_validations_path(@notification), visually_hidden_text: "risk level validation")
+          end
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Notification owner")
+          row.with_value(text: @notification.owner_user.present? ? "#{@notification.owner_user.name} (#{@notification.owner_team.name})" : @notification.owner_team.name)
+          row.with_action(text: "Change", href: access_notification_path(@notification), visually_hidden_text: "notification owner") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Team access")
+          row.with_value(text: @notification.non_owner_teams_with_access.map(&:name).join("<br>").html_safe)
+          row.with_action(text: "Change", href: access_notification_path(@notification), visually_hidden_text: "team access") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Internal reference number")
+          row.with_value(text: @notification.complainant_reference.presence || "Not provided")
+          row.with_action(text: "Change", href: edit_investigation_reference_numbers_path(@notification), visually_hidden_text: "internal reference number") if show_edit_link?
+        end
+      end
+    %>
+    <h2 class="govuk-heading-m">Product identification details</h2>
+    <% @notification.investigation_products.decorate.each do |investigation_product| %>
+      <%=
+        govuk_summary_list(
+          card: { title: investigation_product.product.name_with_brand },
+          rows: [
+            {
+              key: { text: "Batch numbers" },
+              value: { text: investigation_product.batch_number.presence || "Not provided" },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: edit_investigation_product_batch_numbers_path(investigation_product),
+                  visually_hidden_text: "batch numbers"
+                }
+              ] : []
+            },
+            {
+              key: { text: "Customs codes" },
+              value: { text: investigation_product.customs_code.presence || "Not provided" },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: edit_investigation_product_customs_code_path(investigation_product),
+                  visually_hidden_text: "customs codes"
+                }
+              ] : []
+            },
+            {
+              key: { text: "Unique Consignment Reference (UCR) numbers" },
+              value: { text: investigation_product.ucr_numbers.pluck(:number).join(", ").presence || "Not provided" },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: edit_investigation_product_ucr_numbers_path(investigation_product),
+                  visually_hidden_text: "unique consignment reference numbers"
+                }
+              ] : []
+            },
+            {
+              key: { text: "Number of units affected" },
+              value: { text: number_of_affected_units(investigation_product.affected_units_status, investigation_product.number_of_affected_units) },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: edit_investigation_product_number_of_affected_units_path(investigation_product),
+                  visually_hidden_text: "number of units affected"
+                }
+              ] : []
+            }
+          ]
+        )
+      %>
+    <% end %>
+    <h2 class="govuk-heading-m">Businesses and their role in the supply chain</h2>
+    <% @notification.investigation_businesses.decorate.each do |investigation_business| %>
+      <%=
+        govuk_summary_list(
+          card: {
+            title: investigation_business.business.trading_name,
+            actions: show_edit_link? ? [govuk_link_to("Change", edit_business_path(investigation_business.business))] : []
+          },
+          rows: [
+            {
+              key: { text: "Business role in the supply chain" },
+              value: { text: investigation_business.pretty_relationship }
+            },
+            {
+              key: { text: "Registered or legal name" },
+              value: { text: investigation_business.business.legal_name.presence || "Not provided" }
+            },
+            {
+              key: { text: "Companies House number" },
+              value: { text: investigation_business.business.company_number.presence || "Not provided" }
+            },
+            {
+              key: { text: "Address" },
+              value: { text: formatted_business_address(investigation_business.business.locations.find_by(name: "Registered office address")).html_safe.presence || "Not provided" }
+            },
+            {
+              key: { text: "Contact details" },
+              value: { text: investigation_business.business.contacts.map { |contact| formatted_business_contact(contact) }.join("<br><br>").html_safe.presence || "Not provided" }
+            }
+          ]
+        )
+      %>
+    <% end %>
+    <%= govuk_button_link_to "Add business", new_investigation_business_types_path(@notification), secondary: true %>
+    <h2 class="govuk-heading-m">Evidence</h2>
+    <% @notification.investigation_products.decorate.each do |investigation_product| %>
+      <%=
+        govuk_summary_list(
+          card: { title: investigation_product.product.name_with_brand },
+          rows: [
+            {
+              key: { text: "Test reports" },
+              value: { text: formatted_test_results(investigation_product.test_results).html_safe.presence || "Not provided" },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: investigation_supporting_information_index_path(@notification, anchor: "test-results"),
+                  visually_hidden_text: "test reports"
+                }
+              ] : []
+            },
+            {
+              key: { text: "Risk assessments" },
+              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
+              actions: show_edit_link? ? [
+                {
+                  text: "Change",
+                  href: investigation_supporting_information_index_path(@notification, anchor: "risk-assessments"),
+                  visually_hidden_text: "risk assessments"
+                }
+              ] : []
+            }
+          ]
+        )
+      %>
+    <% end %>
+    <%=
+      govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key(text: "Supporting images")
+          row.with_value(text: formatted_uploads(@notification.image_uploads.map(&:file_upload)).html_safe.presence || "Not provided")
+          row.with_action(text: "Change", href: investigation_images_path(@notification), visually_hidden_text: "supporting images") if show_edit_link?
+        end
+        summary_list.with_row do |row|
+          row.with_key(text: "Supporting documents")
+          row.with_value(text: formatted_uploads(@notification.documents).html_safe.presence || "Not provided")
+          row.with_action(text: "Change", href: investigation_supporting_information_index_path(@notification, anchor: "other"), visually_hidden_text: "supporting documents") if show_edit_link?
+        end
+      end
+    %>
+    <%= govuk_button_link_to "Add evidence", investigation_supporting_information_index_path(@notification), secondary: true %>
+    <h2 class="govuk-heading-m">Corrective actions</h2>
+    <% @notification.corrective_actions.includes(investigation_product: :product).decorate.each do |corrective_action| %>
+      <%=
+        govuk_summary_list(
+          card: {
+            title: corrective_action.investigation_product.product.decorate.name_with_brand,
+            actions: show_edit_link? ? [govuk_link_to("Change", edit_investigation_corrective_action_path(@notification, corrective_action))] : []
+          },
+          rows: [
+            {
+              key: { text: "Corrective action" },
+              value: { text: corrective_action.page_title }
+            },
+            {
+              key: { text: "Effective date" },
+              value: { text: corrective_action.date_of_activity }
+            },
+            {
+              key: { text: "Legislation" },
+              value: { text: corrective_action.legislation }
+            },
+            {
+              key: { text: "Responsible business" },
+              value: { text: corrective_action.business&.trading_name || "Not provided" }
+            },
+            if corrective_action.recall_of_the_product_from_end_users?
+              {
+                key: { text: "Recall information" },
+                value: { text: corrective_action.has_online_recall_information ? "Yes: #{corrective_action.online_recall_information}" : "No" }
+              }
+            end,
+            {
+              key: { text: "Action type" },
+              value: { text: corrective_action.measure_type }
+            },
+            {
+              key: { text: "Geographic scope" },
+              value: { text: corrective_action.geographic_scopes }
+            },
+            {
+              key: { text: "Further details" },
+              value: { text: corrective_action.details.presence || "Not provided" }
+            },
+            {
+              key: { text: "Related file" },
+              value: { text: formatted_uploads([corrective_action.document]).html_safe.presence || "Not provided" }
+            }
+          ].compact
+        )
+      %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,10 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :notifications, param: :pretty_id, only: %i[index] do
+    resources :notifications, param: :pretty_id, only: %i[index show] do
+      member do
+        get :access, to: "notifications#access"
+      end
       scope module: :notifications do
         resources :create, only: %i[index show update] do
           collection do

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Validate risk level", :with_stubbed_antivirus, :with_stubbed_mail
 
       within_fieldset("Has the notification risk level been validated?") do
         choose "No"
-        fill_in "Further details", with: "Mistake made by team member"
+        fill_in "Provide a brief explanation", with: "Mistake made by team member"
       end
 
       click_on "Continue"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2376

## Description

Add the notification summary page for submitted notifications, allowing owner and team access changes and linking to existing pages to add/change other information.

Also changes the existing notification creation flow to create submitted notifications since that flow has no concept of drafts.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-02 at 13 50 16](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/a4d02297-0831-46d2-938a-5f31db52f83b)

## Review apps

https://psd-pr-2877.london.cloudapps.digital/
https://psd-pr-2877-support.london.cloudapps.digital/
https://psd-pr-2877-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
