### PR TITLE
Update notifications pages

### DIFF
--- a/.github/workflows/refresh-research.yml
+++ b/.github/workflows/refresh-research.yml
@@ -57,7 +57,7 @@ jobs:
           cf bind-service psd-web psd-database
 
           cf restage psd-web
-          cf run-task psd-web --command 'bin/rails db:migrate opensearch:index' -k 2G --wait
+          cf run-task psd-web --command 'bin/rails db:migrate notifications:index' -k 2G --wait
 
           cf delete-service -f psd-database-old
 

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -76,7 +76,7 @@ jobs:
         cf auth
         cf target -o 'beis-opss' -s $SPACE
         export APP_NAME=psd-pr-$PR_NUMBER
-        cf run-task $APP_NAME -c "bin/rails opensearch:index" --name add-opensearch-indexes -k 2G
+        cf run-task $APP_NAME -c "bin/rails notifications:index" --name add-opensearch-indexes -k 2G
         task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks psd-pr-$PR_NUMBER | grep add-opensearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
 
     - name: Update deployment status (success)

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -10,18 +10,16 @@ class InvestigationsController < ApplicationController
 
   # GET /cases
   def index
-    respond_to do |format|
-      format.html do
-        # Find the most recent incomplete bulk products upload for the current user, if any
-        @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
+    return redirect_to notifications_path if current_user.can_access_new_search?
 
-        @pagy, @answer  = pagy_searchkick(opensearch_for_investigations(20, paginate: true))
-        @count          = count_to_display
-        @investigations = InvestigationDecorator
-                            .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
-        @page_name = "all_cases"
-      end
-    end
+    # Find the most recent incomplete bulk products upload for the current user, if any
+    @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
+
+    @pagy, @answer  = pagy_searchkick(opensearch_for_investigations(20, paginate: true))
+    @count          = count_to_display
+    @investigations = InvestigationDecorator
+                        .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
+    @page_name = "all_cases"
   end
 
   # GET /cases/1
@@ -39,11 +37,17 @@ class InvestigationsController < ApplicationController
   end
 
   def your_cases
+    return redirect_to your_notifications_path if current_user.can_access_new_search?
+
     @page_name = "your_cases"
-    @search = SearchParams.new({ "case_owner" => "me",
-                                 "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"],
-                                 "page_name" => "team_cases" })
+    @search = SearchParams.new(
+      {
+        "case_owner" => "me",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "page_name" => "your_cases"
+      }
+    )
     @pagy, @answer = search_for_investigations
     @count = @pagy.count
     @investigations = InvestigationDecorator
@@ -53,6 +57,8 @@ class InvestigationsController < ApplicationController
   end
 
   def assigned_cases
+    return redirect_to assigned_notifications_path if current_user.can_access_new_search?
+
     @page_name = "assigned_cases"
     @search = SearchParams.new(
       {
@@ -61,7 +67,8 @@ class InvestigationsController < ApplicationController
         "created_by" => "others",
         "sort_by" => params["sort_by"],
         "sort_dir" => params["sort_dir"],
-        "page_name" => "team_cases"
+        "state" => "submitted",
+        "page_name" => "assigned_cases"
       }
     )
     @pagy, @answer = search_for_investigations
@@ -73,11 +80,18 @@ class InvestigationsController < ApplicationController
   end
 
   def team_cases
+    return redirect_to team_notifications_path if current_user.can_access_new_search?
+
     @page_name = "team_cases"
-    @search = SearchParams.new({ "case_owner" => "my_team",
-                                 "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"],
-                                 "page_name" => @page_name })
+    @search = SearchParams.new(
+      {
+        "case_owner" => "my_team",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "state" => "submitted",
+        "page_name" => "team_cases"
+      }
+    )
     @pagy, @answer = search_for_investigations
     @count = @pagy.count
     @investigations = InvestigationDecorator

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -36,7 +36,7 @@ class NotificationsController < ApplicationController
         "page_name" => "your_cases"
       }
     )
-    @submitted_pagy, @submitted_answer = search_for_investigations
+    @submitted_pagy, @submitted_answer = search_for_investigations(page_param: :submitted_page)
     @submitted_count = @submitted_pagy.count
     @submitted_notifications = InvestigationDecorator
                                  .decorate_collection(@submitted_answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
@@ -49,7 +49,7 @@ class NotificationsController < ApplicationController
         "page_name" => "your_cases"
       }
     )
-    @draft_pagy, @draft_answer = search_for_investigations
+    @draft_pagy, @draft_answer = search_for_investigations(page_param: :draft_page)
     @draft_count = @draft_pagy.count
     @draft_notifications = InvestigationDecorator
                              .decorate_collection(@draft_answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,30 +4,126 @@ class NotificationsController < ApplicationController
 
   before_action :set_search_params, only: %i[index]
   before_action :set_last_case_view_cookie, only: %i[index]
-  before_action :set_notification, except: %i[index]
+  before_action :set_notification, except: %i[index your_notifications team_notifications assigned_notifications]
 
   breadcrumb "cases.label", :your_cases_investigations
 
   # GET /notifications
   def index
-    redirect_to all_cases_investigations_path unless current_user.can_access_new_search?
+    return redirect_to all_cases_investigations_path unless current_user.can_access_new_search?
 
-    respond_to do |format|
-      format.html do
-        @pagy, @answer  = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
-        @count          = count_to_display
-        @investigations = InvestigationDecorator
-                            .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
-        @page_name = "all_cases"
-      end
-    end
+    # Find the most recent incomplete bulk products upload for the current user, if any
+    @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
+
+    @pagy, @answer  = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
+    @count          = count_to_display
+    @investigations = InvestigationDecorator
+                        .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
+    @page_name = "all_cases"
+  end
+
+  # GET /notifications/your-notifications
+  def your_notifications
+    return redirect_to your_cases_investigations_path unless current_user.can_access_new_search?
+
+    @page_name = "your_cases"
+    @search = SearchParams.new(
+      {
+        "case_owner" => "me",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "state" => "submitted",
+        "page_name" => "your_cases"
+      }
+    )
+    @submitted_pagy, @submitted_answer = search_for_investigations
+    @submitted_count = @submitted_pagy.count
+    @submitted_notifications = InvestigationDecorator
+                                 .decorate_collection(@submitted_answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
+    @search = SearchParams.new(
+      {
+        "case_owner" => "me",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "state" => "draft",
+        "page_name" => "your_cases"
+      }
+    )
+    @draft_pagy, @draft_answer = search_for_investigations
+    @draft_count = @draft_pagy.count
+    @draft_notifications = InvestigationDecorator
+                             .decorate_collection(@draft_answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
+  end
+
+  # GET /notifications/team-notifications
+  def team_notifications
+    return redirect_to team_cases_investigations_path unless current_user.can_access_new_search?
+
+    @page_name = "team_cases"
+    @search = SearchParams.new(
+      {
+        "case_owner" => "my_team",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "state" => "submitted",
+        "page_name" => "team_cases"
+      }
+    )
+    @pagy, @answer = search_for_investigations
+    @count = @pagy.count
+    @investigations = InvestigationDecorator
+                        .decorate_collection(@answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
+
+    render "notifications/index"
+  end
+
+  # GET /notifications/assigned-notifications
+  def assigned_notifications
+    return redirect_to assigned_cases_investigations_path unless current_user.can_access_new_search?
+
+    @page_name = "assigned_cases"
+    @search = SearchParams.new(
+      {
+        "case_owner" => "all",
+        "teams_with_access" => "my_team",
+        "created_by" => "others",
+        "sort_by" => params["sort_by"],
+        "sort_dir" => params["sort_dir"],
+        "state" => "submitted",
+        "page_name" => "assigned_cases"
+      }
+    )
+    @pagy, @answer = search_for_investigations
+    @count = @pagy.count
+    @investigations = InvestigationDecorator
+                        .decorate_collection(@answer.includes({ owner_user: :organisation, owner_team: :organisation }, :products))
+
+    render "notifications/index"
   end
 
   # GET /notifications/:pretty_id
-  def show; end
+  def show
+    breadcrumb breadcrumb_case_label, breadcrumb_case_path
+
+    # Find the most recent incomplete bulk products upload for the current user and case, if any
+    @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil, investigation: @notification).order(updated_at: :desc).first
+  end
 
   # GET /notifications/:pretty_id/access
   def access; end
+
+  # GET /notifications/:pretty_id/delete
+  def delete; end
+
+  # DELETE /notifications/:pretty_id/destroy
+  def destroy
+    if policy(@notification).delete?(user: current_user)
+      @notification.destroy!
+      flash[:success] = "The notification has been deleted."
+    end
+
+    redirect_to your_notifications_path
+  end
 
 private
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -268,7 +268,7 @@ module InvestigationsHelper
     end
   end
 
-  def search_for_investigations(user = current_user, ids_only: false)
+  def search_for_investigations(user = current_user, ids_only: false, page_param: :page)
     query = Investigation.not_deleted.includes(:owner_user, :owner_team, :creator_user, :creator_team, :collaboration_accesses, :activities)
 
     if @search.q.present?
@@ -356,7 +356,7 @@ module InvestigationsHelper
     if ids_only
       query.distinct.pluck(:id)
     else
-      pagy(query.order(@search.sorting_params))
+      pagy(query.order(@search.sorting_params), page_param:)
     end
   end
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -351,6 +351,8 @@ module InvestigationsHelper
       query = query.where("investigations.created_at <= ?", @search.created_to_date.at_end_of_day)
     end
 
+    query = query.where(state: @search.state) if @search.state.present?
+
     if ids_only
       query.distinct.pluck(:id)
     else

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class SearchParams
   include ActiveModel::Model
   include ActiveModel::Attributes
@@ -46,6 +44,7 @@ class SearchParams
   attribute :hazard_type
   attribute :category
   attribute :page_name
+  attribute :state
   attribute :retired_status
   attribute :created_from_date, :govuk_date
   attribute :created_to_date, :govuk_date

--- a/app/models/concerns/investigation_searchkick.rb
+++ b/app/models/concerns/investigation_searchkick.rb
@@ -9,7 +9,7 @@ module InvestigationSearchkick
     end
 
     def should_index?
-      deleted_at.nil?
+      submitted? && deleted_at.nil?
     end
   end
 end

--- a/app/models/investigation/allegation.rb
+++ b/app/models/investigation/allegation.rb
@@ -15,5 +15,9 @@ class Investigation < ApplicationRecord
     def case_created_audit_activity_class
       AuditActivity::Investigation::AddAllegation
     end
+
+    def submitted?
+      true
+    end
   end
 end

--- a/app/models/investigation/enquiry.rb
+++ b/app/models/investigation/enquiry.rb
@@ -23,5 +23,9 @@ class Investigation < ApplicationRecord
     def case_created_audit_activity_class
       AuditActivity::Investigation::AddEnquiry
     end
+
+    def submitted?
+      true
+    end
   end
 end

--- a/app/models/investigation/project.rb
+++ b/app/models/investigation/project.rb
@@ -15,5 +15,9 @@ class Investigation < ApplicationRecord
     def case_created_audit_activity_class
       AuditActivity::Investigation::AddProject
     end
+
+    def submitted?
+      true
+    end
   end
 end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -14,6 +14,10 @@ class InvestigationPolicy < ApplicationPolicy
     record.teams_with_edit_access.include?(user.team) || user.has_role?(:super_user)
   end
 
+  def delete?(user: @user)
+    record.draft? && (record.owner == user || user.has_role?(:super_user))
+  end
+
   # Ability to change the case owner, the status of the case (eg 'open' or 'closed'),
   # and whether or not it is 'restricted'.
   def change_owner_or_status?(user: @user)

--- a/app/views/investigations/_create_a_notification_link.html.erb
+++ b/app/views/investigations/_create_a_notification_link.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-one-third">
   <div class="opss-text-align-right govuk-!-margin-bottom-8">
     <% if current_user.can_use_notification_task_list? %>
-      <p class="govuk-body"><a href="<%= notifications_create_index_path %>" class="govuk-link govuk-link--no-visited-state" data-cy="create-new-notification">Create a notification</a></p>
+      <%= govuk_button_link_to "Create a new product safety notification", notifications_create_index_path, data: { cy: "create-new-notification" } %>
     <% else %>
       <p class="govuk-body"><a href="<%= create_a_case_page_index_path %>" class="govuk-link govuk-link--no-visited-state" data-cy="create-case">Create a notification</a></p>
     <% end %>

--- a/app/views/investigations/heading/_all_cases.html.erb
+++ b/app/views/investigations/heading/_all_cases.html.erb
@@ -1,24 +1,9 @@
 <%= render "incomplete_bulk_products_upload_notification" %>
-
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
       All notifications &ndash; Search
     </h1>
-    <p class="govuk-body opss-secondary-text">
-      Search all notifications in the Product Safety Database (<%= psd_abbr title: false %>).
-    </p>
-    <%= govuk_details(summary_text: "Help with the notifications search") do %>
-      <p class="govuk-body">
-          <span id="search-hint">You can search for a notification using a notification number or the keywords that describe it and by filtering the results.</span> You can also filter all notification records without a notification number or a keyword search.
-      </p>
-      <% if policy(Investigation).export? && @investigations.any? %>
-        <p class="govuk-body">
-            When viewing a list of search results you can <%= link_to  "request the list", generate_notification_exports_path(params: notification_export_params), class: "govuk-link govuk-link--no-visited-state" %> as a downloadable <abbr title="Microsoft Excel Open XML Format Spreadsheet">XLSX</abbr> (spreadsheet) file.
-        </p>
-      <% end %>
-    <% end %>
   </div>
-
   <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_assigned_cases.html.erb
+++ b/app/views/investigations/heading/_assigned_cases.html.erb
@@ -1,12 +1,8 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
       Assigned notifications
     </h1>
-    <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "The #{current_user.team.name} team has been added to #{@count} open notifications." %>
-    </p>
   </div>
-
   <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_team_cases.html.erb
+++ b/app/views/investigations/heading/_team_cases.html.erb
@@ -1,12 +1,8 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
       Team notifications
     </h1>
-    <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "The #{current_user.team.name} team are the notification owners of #{@count} open notifications." %>
-    </p>
   </div>
-
   <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/investigations/heading/_your_cases.html.erb
+++ b/app/views/investigations/heading/_your_cases.html.erb
@@ -1,12 +1,8 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds opss-desktop-min-height--s">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
       Your notifications
     </h1>
-    <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
-      <%= "You are the notification owner of #{@count} open notifications." %>
-    </p>
   </div>
-
   <%= render "investigations/create_a_notification_link" %>
 </div>

--- a/app/views/notifications/delete.html.erb
+++ b/app/views/notifications/delete.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("Delete #{@notification.user_title.presence || 'notification'}") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: notification_path(@notification), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to delete <%= @notification.user_title.presence || 'this notification' %>?
+      </h1>
+      <p class="govuk-body">This action will permanently delete the notification. Please confirm if you wish to proceed.</p>
+      <%= f.govuk_submit "Delete notification", warning: true do %>
+        <a href="<%= your_notifications_path %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/your_notifications.html.erb
+++ b/app/views/notifications/your_notifications.html.erb
@@ -1,0 +1,80 @@
+<%= page_title I18n.t(".investigations.titles.#{@page_name}") %>
+
+<%= render "investigations/heading/#{@page_name}" %>
+
+<%= form_with(model: @search, scope: "", url: notifications_search_path, method: :get, id: "cases-search-form", html: { role: "search" }) do |form| %>
+  <div class="govuk-grid-row opss-full-height">
+    <%= render "notifications/filters", search: @search, form: form %>
+    <section class="govuk-grid-column-three-quarters" id="page-content">
+      <div class="govuk-grid-row">
+        <%= render_sort_by(form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir, "govuk-grid-column-one-third opss-float-right-desktop") if @submitted_count > 11 %>
+      </div>
+
+      <% if @draft_notifications.any? %>
+        <%=
+          govuk_table do |table|
+            table.with_caption(size: "m", text: "Draft notifications")
+
+            table.with_head do |head|
+              head.with_row do |row|
+                row.with_cell(text: "Product name(s)")
+                row.with_cell(text: "Notification title")
+                row.with_cell(text: "Last updated")
+                row.with_cell(text: "Status")
+                row.with_cell(text: "<span class=\"govuk-visually-hidden\">Make changes/delete notification</span>".html_safe)
+              end
+            end
+
+            @draft_notifications.each do |notification|
+              table.with_body do |body|
+                body.with_row do |row|
+                  row.with_cell(header: true, text: notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).join("<br>").html_safe)
+                  row.with_cell(text: notification.user_title)
+                  row.with_cell(text: notification.updated_at.to_formatted_s(:govuk))
+                  row.with_cell(text: govuk_tag(text: "Draft", colour: "grey").html_safe)
+                  row.with_cell(text: "<a href=\"#{notification_create_index_path(notification)}\" class=\"govuk-link\">Make changes</a><hr class=\"govuk-section-break govuk-section-break--m govuk-section-break--visible\"><a href=\"#{delete_notification_path(notification)}\" class=\"govuk-link\">Delete</a>".html_safe)
+                end
+              end
+            end
+          end
+        %>
+        <%= govuk_pagination(pagy: @draft_pagy) %>
+      <% end %>
+
+      <% if @submitted_notifications.any? %>
+        <%=
+          govuk_table do |table|
+            table.with_caption(size: "m", text: "Submitted notifications")
+
+            table.with_head do |head|
+              head.with_row do |row|
+                row.with_cell(text: "Product name(s)")
+                row.with_cell(text: "Notification title")
+                row.with_cell(text: "Last updated")
+                row.with_cell(text: "Status")
+                row.with_cell(text: "<span class=\"govuk-visually-hidden\">Update notification</span>".html_safe)
+              end
+            end
+
+            @submitted_notifications.each do |notification|
+              table.with_body do |body|
+                body.with_row do |row|
+                  row.with_cell(header: true, text: notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).join("<br>").html_safe)
+                  row.with_cell(text: notification.user_title)
+                  row.with_cell(text: notification.updated_at.to_formatted_s(:govuk))
+                  row.with_cell(text: govuk_tag(text: "Submitted", colour: "green").html_safe)
+                  row.with_cell(text: "<a href=\"#{notification_path(notification)}\" class=\"govuk-link\">Update notification</a>".html_safe)
+                end
+              end
+            end
+          end
+        %>
+        <%= govuk_pagination(pagy: @submitted_pagy) %>
+      <% end %>
+
+      <% unless @draft_notifications.any? || @submitted_notifications.any? %>
+        <%= render "investigations/no_cases" %>
+      <% end %>
+    </section>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,10 @@ Rails.application.routes.draw do
     resource :notifications, only: [] do
       resource :search, only: :show
 
+      get "your-notifications", to: "notifications#your_notifications", as: "your"
+      get "team-notifications", to: "notifications#team_notifications", as: "team"
+      get "assigned-notifications", to: "notifications#assigned_notifications", as: "assigned"
+
       scope module: :notifications do
         resources :create, only: %i[index] do
           collection do
@@ -121,10 +125,12 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :notifications, param: :pretty_id, only: %i[index show] do
+    resources :notifications, param: :pretty_id, only: %i[index show destroy] do
       member do
         get :access, to: "notifications#access"
+        get :delete, to: "notifications#delete"
       end
+
       scope module: :notifications do
         resources :create, only: %i[index show update] do
           collection do

--- a/doc/using-cloud-foundry.md
+++ b/doc/using-cloud-foundry.md
@@ -34,7 +34,7 @@ cf conduit NEW_DB_NAME -- psql < psd-staging.sql
 cf unbind-service PR_APP_NAME OLD_DB_NAME
 cf bind-service PR_APP_NAME NEW_DB_NAME
 cf restage PR_APP_NAME
-cf ssh PR_APP_NAME -> cd app -> bin/tll bin/rake opensearch:index
+cf ssh PR_APP_NAME -> cd app -> bin/tll bin/rake notifications:index
 ```
 
 #### List apps

--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,0 +1,11 @@
+namespace :notifications do
+  desc "Re-index notifications"
+  task index: :environment do
+    Investigation.reindex
+  end
+
+  desc "Mark all draft notifications as submitted"
+  task mark_as_submitted: :environment do
+    Investigation::Notification.where(state: "draft").update_all(state: "submitted")
+  end
+end

--- a/spec/features/export_notifications_spec.rb
+++ b/spec/features/export_notifications_spec.rb
@@ -242,14 +242,12 @@ RSpec.feature "notification export", :with_opensearch, :with_stubbed_antivirus, 
     it "does not show the export link" do
       expand_help_details
       expect(page).to have_link("XLSX (spreadsheet)")
-      expect(page).to have_link("request the list")
 
       fill_in "Search", with: "unsuccesfulsearchquery"
       click_button "Submit search"
 
       expand_help_details
       expect(page).not_to have_link("XLSX (spreadsheet)")
-      expect(page).not_to have_link("request the list")
     end
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2354

## Description

* Completely separates the new notifications pages from the old cases pages and redirects between the two based on role
* Prevents draft notifications from being indexed by Opensearch
* Excludes draft notifications from being displayed except on the “your notifications” page in a separate section
* Allows draft notifications to be deleted
* Adds a one-time rake task to update all current notifications to a submitted state

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-05 at 11 49 23](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/2e5e0312-60ad-437f-8496-4c5fe2a774c6)

![Screenshot 2024-02-05 at 12 28 38](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/e98b1766-144e-4b9d-855b-f7b0a7132d93)

## Review apps

https://psd-pr-2879.london.cloudapps.digital/
https://psd-pr-2879-support.london.cloudapps.digital/
https://psd-pr-2879-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
