### PR TITLE
Remove rest-client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem "rack", "~> 2.2.8"
 gem "rails", "~> 7.0.4"
 gem "redcarpet", "~> 3.5"
 gem "redis-rails", "~> 5.0"
-gem "rest-client", "~> 2.1"
 gem "rollups"
 gem "rubyXL", "~> 3.4.25"
 gem "sassc-rails"
@@ -69,6 +68,9 @@ gem "prism", path: "prism"
 
 # OSU Support Portal engine
 gem "support_portal", path: "support_portal"
+
+# Report Portal engine
+gem "report_portal", path: "report_portal"
 
 group :development, :test do
   gem "awesome_print", "~> 1.9", require: "ap"
@@ -114,5 +116,3 @@ group :test do
   gem "timecop", "~> 0.9"
   gem "webmock", "~> 3.19"
 end
-
-gem "report_portal", path: "report_portal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,8 +224,6 @@ GEM
       devise (>= 2.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -278,9 +276,6 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
-    http-accept (1.7.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -325,9 +320,6 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
@@ -342,7 +334,6 @@ GEM
       timeout
     net-smtp (0.4.0.1)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.7.0)
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
@@ -467,11 +458,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.6)
@@ -649,9 +635,6 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2023.4)
       tzinfo (>= 1.0.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -750,7 +733,6 @@ DEPENDENCIES
   redcarpet (~> 3.5)
   redis-rails (~> 5.0)
   report_portal!
-  rest-client (~> 2.1)
   rollups
   roo (~> 2.9)
   rspec


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1399

## Description

Removes the `rest-client` gem and switches usage to `Net::HTTP`.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2895.london.cloudapps.digital/
https://psd-pr-2895-support.london.cloudapps.digital/
https://psd-pr-2895-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
