### PR TITLE
Remove native enums

### DIFF
--- a/db/migrate/20240207103811_remove_enums.rb
+++ b/db/migrate/20240207103811_remove_enums.rb
@@ -1,0 +1,55 @@
+class RemoveEnums < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      change_column :users, :locked_reason, :string
+      change_column :investigation_products, :affected_units_status, :string
+      change_column :products, :authenticity, :string
+      change_column :products, :has_markings, :string
+      change_column :corrective_actions, :has_online_recall_information, :string
+      change_column :investigations, :reported_reason, :string
+      change_column :investigations, :risk_level, :string
+      change_column :risk_assessments, :risk_level, :string
+      change_column :unexpected_events, :severity, :string
+      change_column :unexpected_events, :usage, :string
+      change_column :products, :when_placed_on_market, :string
+
+      drop_enum :account_locked_reasons
+      drop_enum :affected_units_statuses
+      drop_enum :authenticities
+      drop_enum :has_markings_values
+      drop_enum :has_online_recall_information
+      drop_enum :reported_reasons
+      drop_enum :risk_levels
+      drop_enum :severities
+      drop_enum :usages
+      drop_enum :when_placed_on_markets
+    end
+  end
+
+  def down
+    safety_assured do
+      create_enum :account_locked_reasons, %w[failed_attempts inactivity]
+      create_enum :affected_units_statuses, %w[exact approx unknown not_relevant]
+      create_enum :authenticities, %w[counterfeit genuine unsure]
+      create_enum :has_markings_values, %w[markings_yes markings_no markings_unknown]
+      create_enum :has_online_recall_information, %w[has_online_recall_information_yes has_online_recall_information_no has_online_recall_information_not_relevant]
+      create_enum :reported_reasons, %w[unsafe non_compliant unsafe_and_non_compliant safe_and_compliant]
+      create_enum :risk_levels, %w[serious high medium low other not_conclusive]
+      create_enum :severities, %w[serious high medium low unknown_severity other]
+      create_enum :usages, %w[during_normal_use during_misuse with_adult_supervision without_adult_supervision unknown_usage]
+      create_enum :when_placed_on_markets, %w[before_2021 on_or_after_2021 unknown_date]
+
+      change_column :users, :locked_reason, :enum, enum_type: "account_locked_reasons"
+      change_column :investigation_products, :affected_units_status, :enum, enum_type: "affected_units_statuses"
+      change_column :products, :authenticity, :enum, enum_type: "authenticities"
+      change_column :products, :has_markings, :enum, enum_type: "has_markings_values"
+      change_column :corrective_actions, :has_online_recall_information, :enum, enum_type: "has_online_recall_information"
+      change_column :investigations, :reported_reason, :enum, enum_type: "reported_reasons"
+      change_column :investigations, :risk_level, :enum, enum_type: "risk_levels"
+      change_column :risk_assessments, :risk_level, :enum, enum_type: "risk_levels"
+      change_column :unexpected_events, :severity, :enum, enum_type: "severities"
+      change_column :unexpected_events, :usage, :enum, enum_type: "usages"
+      change_column :products, :when_placed_on_market, :enum, enum_type: "when_placed_on_markets"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,19 +15,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  # Custom types defined in this database.
-  # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "account_locked_reasons", ["failed_attempts", "inactivity"]
-  create_enum "affected_units_statuses", ["exact", "approx", "unknown", "not_relevant"]
-  create_enum "authenticities", ["counterfeit", "genuine", "unsure"]
-  create_enum "has_markings_values", ["markings_yes", "markings_no", "markings_unknown"]
-  create_enum "has_online_recall_information", ["has_online_recall_information_yes", "has_online_recall_information_no", "has_online_recall_information_not_relevant"]
-  create_enum "reported_reasons", ["unsafe", "non_compliant", "unsafe_and_non_compliant", "safe_and_compliant"]
-  create_enum "risk_levels", ["serious", "high", "medium", "low", "other", "not_conclusive"]
-  create_enum "severities", ["serious", "high", "medium", "low", "unknown_severity", "other"]
-  create_enum "usages", ["during_normal_use", "during_misuse", "with_adult_supervision", "without_adult_supervision", "unknown_usage"]
-  create_enum "when_placed_on_markets", ["before_2021", "on_or_after_2021", "unknown_date"]
-
   create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -199,7 +186,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.string "duration"
     t.string "geographic_scope"
     t.string "geographic_scopes", default: [], array: true
-    t.enum "has_online_recall_information", enum_type: "has_online_recall_information"
+    t.string "has_online_recall_information"
     t.integer "investigation_id"
     t.bigint "investigation_product_id"
     t.string "legislation", default: [], array: true
@@ -271,7 +258,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
   end
 
   create_table "investigation_products", id: :serial, force: :cascade do |t|
-    t.enum "affected_units_status", enum_type: "affected_units_statuses"
+    t.string "affected_units_status"
     t.string "batch_number"
     t.datetime "created_at", precision: nil, null: false
     t.text "customs_code"
@@ -310,8 +297,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.string "pretty_id", null: false
     t.string "product_category"
     t.string "received_type"
-    t.enum "reported_reason", enum_type: "reported_reasons"
-    t.enum "risk_level", enum_type: "risk_levels"
+    t.string "reported_reason"
+    t.string "risk_level"
     t.datetime "risk_validated_at", precision: nil
     t.string "risk_validated_by"
     t.string "state"
@@ -496,7 +483,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
   create_table "products", id: :serial, force: :cascade do |t|
     t.uuid "added_by_user_id"
     t.bigint "ahoy_visit_id"
-    t.enum "authenticity", enum_type: "authenticities"
+    t.string "authenticity"
     t.string "barcode", limit: 15
     t.text "brand"
     t.string "category"
@@ -504,7 +491,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
     t.bigint "document_upload_ids", default: [], array: true
-    t.enum "has_markings", enum_type: "has_markings_values"
+    t.string "has_markings"
     t.bigint "image_upload_ids", default: [], array: true
     t.text "markings", array: true
     t.string "name"
@@ -514,7 +501,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.string "subcategory"
     t.datetime "updated_at", precision: nil, null: false
     t.string "webpage"
-    t.enum "when_placed_on_market", enum_type: "when_placed_on_markets"
+    t.string "when_placed_on_market"
     t.index ["ahoy_visit_id"], name: "index_products_on_ahoy_visit_id"
     t.index ["owning_team_id"], name: "index_products_on_owning_team_id"
     t.index ["retired_at"], name: "index_products_on_retired_at"
@@ -540,7 +527,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.text "custom_risk_level"
     t.text "details"
     t.integer "investigation_id", null: false
-    t.enum "risk_level", enum_type: "risk_levels"
+    t.string "risk_level"
     t.datetime "updated_at", precision: nil, null: false
   end
 
@@ -616,11 +603,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.integer "investigation_id", null: false
     t.bigint "investigation_product_id"
     t.boolean "is_date_known"
-    t.enum "severity", enum_type: "severities"
+    t.string "severity"
     t.string "severity_other"
     t.string "type", null: false
     t.datetime "updated_at", null: false
-    t.enum "usage", enum_type: "usages"
+    t.string "usage"
     t.index ["investigation_product_id"], name: "index_unexpected_events_on_investigation_product_id"
   end
 
@@ -651,7 +638,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_112516) do
     t.datetime "last_sign_in_at", precision: nil
     t.inet "last_sign_in_ip"
     t.datetime "locked_at", precision: nil
-    t.enum "locked_reason", enum_type: "account_locked_reasons"
+    t.string "locked_reason"
     t.text "mobile_number"
     t.boolean "mobile_number_verified", default: false, null: false
     t.string "name"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2199

## Description

Removes PostgreSQL native enums and replace them with ActiveRecord enums (already existing) backed by string columns to make them more flexible.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2899.london.cloudapps.digital/
https://psd-pr-2899-support.london.cloudapps.digital/
https://psd-pr-2899-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
