### PR TITLE
Use HTTPS for antivirus endpoint

### DIFF
--- a/app/analyzers/anti_virus_analyzer.rb
+++ b/app/analyzers/anti_virus_analyzer.rb
@@ -10,7 +10,7 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
       req.basic_auth(ENV["ANTIVIRUS_USERNAME"], ENV["ANTIVIRUS_PASSWORD"])
       req.set_form([["file", File.open(file)]], "multipart/form-data")
 
-      response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: Rails.env.production?) do |http|
         http.request(req)
       end
 


### PR DESCRIPTION
## Description

Configures `Net::HTTP` to use HTTPS for the antivirus endpoint when on a non-development/test environment.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2900.london.cloudapps.digital/
https://psd-pr-2900-support.london.cloudapps.digital/
https://psd-pr-2900-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
