### PR TITLE
allow businesses to be added from the notification task list

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -427,7 +427,7 @@ module Notifications
           render_wizard
         end
       elsif additional_params
-        @notification.save(context: step)
+        @notification.save!(context: step)
         redirect_to wizard_path(@next_step, additional_params)
       else
         render_wizard(@notification, { context: step })

--- a/app/forms/add_business_details_form.rb
+++ b/app/forms/add_business_details_form.rb
@@ -1,0 +1,10 @@
+class AddBusinessDetailsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :trading_name, :string
+  attribute :legal_name, :string
+
+  validates :trading_name, presence: true
+end

--- a/app/forms/add_contact_form.rb
+++ b/app/forms/add_contact_form.rb
@@ -1,0 +1,11 @@
+class AddContactForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :name, :string
+  attribute :job_title, :string
+  attribute :phone_number, :string
+  attribute :email, :string
+  attribute :business_id
+end

--- a/app/forms/add_location_form.rb
+++ b/app/forms/add_location_form.rb
@@ -1,0 +1,16 @@
+class AddLocationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :address_line_1, :string
+  attribute :address_line_2, :string
+  attribute :city, :string
+  attribute :county, :string
+  attribute :country, :string
+  attribute :postal_code, :string
+  attribute :business_id
+  attribute :location_id
+
+  validates :country, presence: true
+end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -5,7 +5,7 @@ class Investigation < ApplicationRecord
     TASK_LIST_SECTIONS = {
       "product" => %i[search_for_or_add_a_product],
       "notification_details" => %i[add_notification_details add_product_safety_and_compliance_details add_product_identification_details],
-      "business_details" => %i[add_business_details],
+      "business_details" => %i[add_business_details add_location add_contact],
       "evidence" => %i[add_test_reports add_supporting_images add_supporting_documents add_risk_assessments determine_notification_risk_level],
       "corrective_actions" => %i[record_a_corrective_action],
       "submit" => %i[check_notification_details_and_submit]

--- a/app/services/change_business_names.rb
+++ b/app/services/change_business_names.rb
@@ -1,0 +1,13 @@
+class ChangeBusinessNames
+  include Interactor
+
+  delegate :trading_name, :legal_name, :notification, :business, :user, to: :context
+
+  def call
+    context.fail!(error: "No trading name supplied") unless trading_name.is_a?(String)
+
+    business.assign_attributes(legal_name:, trading_name:)
+
+    business.save!
+  end
+end

--- a/app/views/notifications/create/add_business_details.html.erb
+++ b/app/views/notifications/create/add_business_details.html.erb
@@ -2,13 +2,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @add_business_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
         <%= t("notifications.create.index.sections.business_details.tasks.add_business_details.title") %>
       </h1>
-      <p class="govuk-body">This page intentionally left blank.</p>
-      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+      <%= f.govuk_text_field :trading_name, label: { text: "Trading name (mandatory)" }, hint: { text: "The name the business is known as." }, width: "two-thirds"  %>
+      <%= f.govuk_text_field :legal_name, label: { text: "Registered or legal name" }, hint: { text: "As it appears on Companies House for UK businesses (usually ends in 'Ltd' or 'Limited')." }, width: "two-thirds"  %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/notifications/create/add_business_details.html.erb
+++ b/app/views/notifications/create/add_business_details.html.erb
@@ -1,14 +1,15 @@
-<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_details.title"), errors: false) %>
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_details.title"), errors: @add_business_details_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @add_business_details_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
         <%= t("notifications.create.index.sections.business_details.tasks.add_business_details.title") %>
       </h1>
-      <%= f.govuk_text_field :trading_name, label: { text: "Trading name (mandatory)" }, hint: { text: "The name the business is known as." }, width: "two-thirds"  %>
-      <%= f.govuk_text_field :legal_name, label: { text: "Registered or legal name" }, hint: { text: "As it appears on Companies House for UK businesses (usually ends in 'Ltd' or 'Limited')." }, width: "two-thirds"  %>
+      <%= f.govuk_text_field :trading_name, label: { text: "Trading name" }, hint: { text: "The name the business is known as." }, width: "two-thirds"  %>
+      <%= f.govuk_text_field :legal_name, label: { text: "Registered or legal name (optional)" }, hint: { text: "As it appears on Companies House for UK businesses (usually ends in 'Ltd' or 'Limited')." }, width: "two-thirds"  %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/notifications/create/add_contact.html.erb
+++ b/app/views/notifications/create/add_contact.html.erb
@@ -1,12 +1,13 @@
-<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_contact.title"), errors: false) %>
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_contact.title"), errors: @add_contact_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @add_contact_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
-      <%= t("notifications.create.index.sections.business_details.tasks.add_contact.title") %>
-    </h1>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_contact.title") %>
+      </h1>
       <%= f.govuk_text_field :name, label: { text: "Full name" }, width: "two-thirds" %>
       <%= f.govuk_text_field :job_title, label: { text: "Job title or role description" }, width: "two-thirds" %>
       <%= f.govuk_text_field :email, label: { text: "Email" }, width: "two-thirds" %>

--- a/app/views/notifications/create/add_contact.html.erb
+++ b/app/views/notifications/create/add_contact.html.erb
@@ -1,0 +1,18 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_contact.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @add_contact_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+      <%= t("notifications.create.index.sections.business_details.tasks.add_contact.title") %>
+    </h1>
+      <%= f.govuk_text_field :name, label: { text: "Full name" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :job_title, label: { text: "Job title or role description" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :email, label: { text: "Email" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :phone_number, label: { text: "Phone" }, hint: { text: "For international numbers include the country code." }, width: "two-thirds" %>
+      <%= f.hidden_field :business_id %>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_location.html.erb
+++ b/app/views/notifications/create/add_location.html.erb
@@ -1,27 +1,27 @@
-<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_location.title"), errors: false) %>
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_location.title"), errors: @add_location_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @add_location_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
-      <%= t("notifications.create.index.sections.business_details.tasks.add_location.title") %>
-    </h1>
-    <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1" }, width: "two-thirds" %>
-    <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2" }, width: "two-thirds" %>
-    <%= f.govuk_text_field :city, label: { text: "Town or city" }, width: "two-thirds" %>
-    <%= f.govuk_text_field :county, label: { text: "County" }, width: "two-thirds" %>
-    <%= f.govuk_text_field :postal_code, label: { text: "Post code" }, width: "two-thirds" %>
-    <%= f.hidden_field :business_id %>
-    <%= f.govuk_collection_select :country,
-          [OpenStruct.new(id: "", name: ""), OpenStruct.new(id: "Unknown", name: "Unknown")] + all_countries_with_uk_first.map { |country| OpenStruct.new(id: country[1], name: country[0]) },
-          :id,
-          :name,
-          label: { text: "Country" },
-          width: "two-thirds"
-    %>
-    <%= f.govuk_submit "Save and continue" %>
-
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_location.title") %>
+      </h1>
+      <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :city, label: { text: "Town or city" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :county, label: { text: "County" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :postal_code, label: { text: "Post code" }, width: "two-thirds" %>
+      <%= f.hidden_field :business_id %>
+      <%= f.govuk_collection_select :country,
+            [OpenStruct.new(id: "", name: ""), OpenStruct.new(id: "Unknown", name: "Unknown")] + all_countries_with_uk_first.map { |country| OpenStruct.new(id: country[1], name: country[0]) },
+            :id,
+            :name,
+            label: { text: "Country" },
+            width: "two-thirds"
+      %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/notifications/create/add_location.html.erb
+++ b/app/views/notifications/create/add_location.html.erb
@@ -1,0 +1,27 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_location.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @add_location_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+      <%= t("notifications.create.index.sections.business_details.tasks.add_location.title") %>
+    </h1>
+    <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1" }, width: "two-thirds" %>
+    <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2" }, width: "two-thirds" %>
+    <%= f.govuk_text_field :city, label: { text: "Town or city" }, width: "two-thirds" %>
+    <%= f.govuk_text_field :county, label: { text: "County" }, width: "two-thirds" %>
+    <%= f.govuk_text_field :postal_code, label: { text: "Post code" }, width: "two-thirds" %>
+    <%= f.hidden_field :business_id %>
+    <%= f.govuk_collection_select :country,
+          [OpenStruct.new(id: "", name: ""), OpenStruct.new(id: "Unknown", name: "Unknown")] + all_countries_with_uk_first.map { |country| OpenStruct.new(id: country[1], name: country[0]) },
+          :id,
+          :name,
+          label: { text: "Country" },
+          width: "two-thirds"
+    %>
+    <%= f.govuk_submit "Save and continue" %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_location.title"), errors: @change_notification_details_form.errors.any?) %>
+<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: @change_notification_details_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -6,7 +6,7 @@
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
-        <%= t("notifications.create.index.sections.notification_details.tasks.add_location.title") %>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title") %>
       </h1>
       <%= f.govuk_text_field :user_title, label: { text: "Notification title", size: "m" }, hint: { text: "A recommended format for the notification title includes the name of the product(s) and the hazard associated with it." } %>
       <%= f.govuk_text_area :description, label: { text: "Notification summary <span class=\"govuk-body-s\">(optional)</span>".html_safe, size: "m" }, hint: { text: "The notification summary provides a clear, concise overview to help users unfamiliar with the notification's details understand it better." }, max_chars: 10_000 %>

--- a/app/views/notifications/create/add_notification_details.html.erb
+++ b/app/views/notifications/create/add_notification_details.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title"), errors: @change_notification_details_form.errors.any?) %>
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_location.title"), errors: @change_notification_details_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,7 +6,7 @@
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("notifications.create.index.sections.notification_details.title") %></span>
-        <%= t("notifications.create.index.sections.notification_details.tasks.add_notification_details.title") %>
+        <%= t("notifications.create.index.sections.notification_details.tasks.add_location.title") %>
       </h1>
       <%= f.govuk_text_field :user_title, label: { text: "Notification title", size: "m" }, hint: { text: "A recommended format for the notification title includes the name of the product(s) and the hazard associated with it." } %>
       <%= f.govuk_text_area :description, label: { text: "Notification summary <span class=\"govuk-body-s\">(optional)</span>".html_safe, size: "m" }, hint: { text: "The notification summary provides a clear, concise overview to help users unfamiliar with the notification's details understand it better." }, max_chars: 10_000 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,10 +405,14 @@ en:
               add_product_identification_details_number_of_affected_units:
                 title: Add the number of units affected
           business_details:
-            title: Add the business in the product's supply chain
+            title: Add businesses and their roles in the supply chain
             tasks:
               add_business_details:
                 title: Add the type and details of the business
+              add_location:
+                title: Add addresses
+              add_contact:
+                title: Add contact details
           evidence:
             title: Add evidence
             tasks:

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -138,11 +138,32 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_selector(:id, "task-list-1-2-status", text: "Completed")
     expect(page).to have_content("You have completed 2 of 6 sections.")
 
-    # TODO(ruben): add to this once the pages are complete
+    expect(page).to have_selector(:id, "task-list-2-0-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-2-1-status", text: "Cannot start yet")
+    expect(page).to have_selector(:id, "task-list-2-2-status", text: "Cannot start yet")
+
     click_link "Add the type and details of the business"
+    fill_in "Trading name (mandatory)", with: "Trading name"
+    fill_in "Registered or legal name", with: "Legal name"
+    click_button "Save and continue"
+
+    fill_in "Address line 1", with: "123 Fake St"
+    fill_in "Address line 2", with: "Fake Heath"
+    fill_in "Town or city", with: "Faketon"
+    fill_in "County", with: "Fake County"
+    fill_in "Post code", with: "FA1 2KE"
+    select "United Kingdom", from: "Country"
+    click_button "Save and continue"
+
+    fill_in "Full name", with: "Max Mustermann"
+    fill_in "Job title or role description", with: "Manager"
+    fill_in "Email", with: "max@example.com"
+    fill_in "Phone", with: "+441121121212"
     click_button "Save and complete tasks in this section"
 
     expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-2-1-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-2-2-status", text: "Completed")
     expect(page).to have_content("You have completed 3 of 6 sections.")
 
     # Ensure that all of section 4 and the first task of section are enabled once section 3 is completed

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -143,8 +143,8 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_selector(:id, "task-list-2-2-status", text: "Cannot start yet")
 
     click_link "Add the type and details of the business"
-    fill_in "Trading name (mandatory)", with: "Trading name"
-    fill_in "Registered or legal name", with: "Legal name"
+    fill_in "Trading name", with: "Trading name"
+    fill_in "Registered or legal name (optional)", with: "Legal name"
     click_button "Save and continue"
 
     fill_in "Address line 1", with: "123 Fake St"

--- a/spec/forms/add_business_details_form_spec.rb
+++ b/spec/forms/add_business_details_form_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe AddBusinessDetailsForm, :with_stubbed_mailer do
+  subject(:form) { described_class.new(add_business_details_form_params) }
+
+  let(:add_business_details_form_params) do
+    {
+      legal_name:,
+      trading_name:,
+    }
+  end
+  let(:legal_name) { "Legal name" }
+  let(:trading_name) { "Trading name" }
+
+  describe "validations" do
+    context "with valid params" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "with no legal name" do
+      let(:legal_name) { nil }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "with no trading name" do
+      let(:trading_name) { nil }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/forms/add_location_form_spec.rb
+++ b/spec/forms/add_location_form_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe AddLocationForm, :with_stubbed_mailer do
+  subject(:form) { described_class.new(add_location_form_params) }
+
+  let(:add_location_form_params) do
+    {
+      address_line_1:,
+      address_line_2:,
+      city:,
+      county:,
+      postal_code:,
+      country:,
+    }
+  end
+  let(:address_line_1) { "123 Fake St" }
+  let(:address_line_2) { "Fake Heath" }
+  let(:city) { "Faketon" }
+  let(:county) { "Fakeshire" }
+  let(:postal_code) { "FA1 2KE" }
+  let(:country) { "country:BJ" }
+
+  describe "validations" do
+    context "with valid params" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "with no country" do
+      let(:country) { nil }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/change_business_names_spec.rb
+++ b/spec/services/change_business_names_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ChangeBusinessNames, :with_test_queue_adapter do
+  subject(:result) { described_class.call!(trading_name:, legal_name:, notification:, business:, user:) }
+
+  let!(:notification) { create(:notification, creator: user) }
+  let!(:business) { create(:business, trading_name: previous_trading_name, legal_name: previous_legal_name) }
+  let(:previous_trading_name) { "Old trading name" }
+  let(:previous_legal_name) { "Old legal name" }
+  let(:trading_name) { "Trading name" }
+  let(:legal_name) { "Legal name" }
+  let(:user) { create(:user, :activated) }
+
+  context "with no trading name" do
+    subject(:result) { described_class.call(legal_name:, notification:, business:, user:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when the previous and the new names are the same" do
+    subject(:result) { described_class.call!(trading_name: previous_trading_name, legal_name: previous_legal_name, notification:, business:, user:) }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "does not create a new activity" do
+      expect {
+        result
+      }.not_to change(Activity, :count)
+    end
+  end
+
+  context "when the previous names and the new names are different" do
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "changes the trading_name for the notification" do
+      expect { result }.to change(business, :trading_name).from(previous_trading_name).to(trading_name)
+    end
+
+    it "changes the legal_name for the notification" do
+      expect { result }.to change(business, :legal_name).from(previous_legal_name).to(legal_name)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds ability to create businesses with a location and contact from the notification task list

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-08 at 09-41-24 Add the type and details of the business - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/be61faf0-c8cc-456f-8256-4c26e0ad176f)
![Screenshot 2024-02-08 at 09-41-39 Add addresses - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/f34eaddf-81b4-47e9-9719-27b24f52d1d5)
![Screenshot 2024-02-08 at 09-41-51 Add contact details - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/e4a57535-d665-491f-9eb6-607e822aa898)

## Review apps

https://psd-pr-2902.london.cloudapps.digital/
https://psd-pr-2902-support.london.cloudapps.digital/
https://psd-pr-2902-report.london.cloudapps.digital/


## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
