### PR TITLE
Remove HTML formatting from notification summary edit page

### DIFF
--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -10,6 +10,11 @@ class InvestigationDecorator < ApplicationDecorator
     user_title || complainant_reference || pretty_id
   end
 
+  def unformatted_description
+    # Bypasses `FormattedDescription` for situations where we want the raw value of the field.
+    object.description
+  end
+
   def risk_assessment_risk_levels
     risk_assessments.collect(&:risk_level_description).uniq
   end

--- a/app/views/investigations/summary/edit.html.erb
+++ b/app/views/investigations/summary/edit.html.erb
@@ -1,23 +1,13 @@
 <%= page_title "Update summary", errors: @form.errors.any? %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= error_summary @form.errors %>
-    <%= form_with(model: @form,
-                  url: investigation_summary_path(@investigation),
-                  method: :patch,
-                  builder: ApplicationFormBuilder) do |form| %>
-
-      <%= form.govuk_text_area(:summary,
-                               rows: 11,
-                               label: "Edit the summary",
-                               label_classes: "govuk-label--l govuk-!-margin-bottom-2",
-                               hint: "You can add and edit a general summary about the notification.",
-                               hint_classes: "govuk-!-margin-bottom-6") %>
-
-      <div class="govuk-button-group">
-        <%= form.submit "Save", class: "govuk-button govuk-link--no-visited-state" %>
-        <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
-      </div>
+    <%= form_with model: @form, url: investigation_summary_path(@investigation), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_area :summary, label: { text: "Edit the summary", size: "l", tag: "h1" }, hint: { text: "You can add and edit a general summary about the notification." }, rows: 11, value: @investigation.unformatted_description %>
+      <%= f.govuk_submit "Save" do %>
+        <a href="<%= investigation_path(@investigation) %>" class="govuk-link">Cancel</a>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2405

## Description

Fixes the notification summary edit page to show the summary without HTML tags.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2905.london.cloudapps.digital/
https://psd-pr-2905-support.london.cloudapps.digital/
https://psd-pr-2905-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
