### PR TITLE
Don’t submit notification on “save as draft”

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -408,7 +408,7 @@ module Notifications
           end
         end
       when :check_notification_details_and_submit
-        return render_wizard unless @notification.ready_to_submit?
+        return render_wizard unless @notification.ready_to_submit? || params[:draft] == "true"
       end
 
       @notification.tasks_status[step.to_s] = "completed"
@@ -417,7 +417,7 @@ module Notifications
         # "Save as draft" or final save button of the section clicked.
         # Manually save, then finish the wizard.
         if @notification.save(context: step)
-          if step == :check_notification_details_and_submit
+          if step == :check_notification_details_and_submit && params[:final] == "true"
             @notification.submit!
             return redirect_to confirmation_notification_create_index_path(@notification)
           end

--- a/app/decorators/investigation_business_decorator.rb
+++ b/app/decorators/investigation_business_decorator.rb
@@ -14,6 +14,6 @@ private
   end
 
   def authorised_representative_relationship
-    I18n.t("business.type.authorised_reprsentative.#{authorised_representative_choice}")
+    I18n.t("business.type.authorised_representative.#{authorised_representative_choice}")
   end
 end

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -125,7 +125,7 @@
           rows: [
             {
               key: { text: "Business role in the supply chain" },
-              value: { text: investigation_business.pretty_relationship },
+              value: { text: investigation_business.relationship.present? ? investigation_business.pretty_relationship : "Not provided" },
               actions: []
             },
             {

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -147,7 +147,7 @@
           rows: [
             {
               key: { text: "Business role in the supply chain" },
-              value: { text: investigation_business.pretty_relationship }
+              value: { text: investigation_business.relationship.present? ? investigation_business.pretty_relationship : "Not provided" }
             },
             {
               key: { text: "Registered or legal name" },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1077,6 +1077,6 @@ en:
       distributor: "Distributor"
       responsible_person: "Responsible person"
       other: "Other"
-      authorised_reprsentative:
+      authorised_representative:
         uk_authorised_representative: "UK Authorised representative"
         eu_authorised_representative: "EU Authorised representative"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2409

## Description

Prevents the “save as draft” button on the notification check page from submitting the notification - it will now save changes and return to the task list.

Also fixes how business relationships appear on the check page.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2908.london.cloudapps.digital/
https://psd-pr-2908-support.london.cloudapps.digital/
https://psd-pr-2908-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
