### PR TITLE
Redirect between case and notification summary pages

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -24,6 +24,8 @@ class InvestigationsController < ApplicationController
 
   # GET /cases/1
   def show
+    return redirect_to notification_path(@investigation) if current_user.can_use_notification_task_list?
+
     authorize @investigation, :view_non_protected_details?
     breadcrumb breadcrumb_case_label, breadcrumb_case_path
     @complainant = @investigation.complainant&.decorate
@@ -37,7 +39,7 @@ class InvestigationsController < ApplicationController
   end
 
   def your_cases
-    return redirect_to your_notifications_path if current_user.can_access_new_search?
+    return redirect_to your_notifications_path if current_user.can_use_notification_task_list?
 
     @page_name = "your_cases"
     @search = SearchParams.new(
@@ -57,7 +59,7 @@ class InvestigationsController < ApplicationController
   end
 
   def assigned_cases
-    return redirect_to assigned_notifications_path if current_user.can_access_new_search?
+    return redirect_to assigned_notifications_path if current_user.can_use_notification_task_list?
 
     @page_name = "assigned_cases"
     @search = SearchParams.new(
@@ -80,7 +82,7 @@ class InvestigationsController < ApplicationController
   end
 
   def team_cases
-    return redirect_to team_notifications_path if current_user.can_access_new_search?
+    return redirect_to team_notifications_path if current_user.can_use_notification_task_list?
 
     @page_name = "team_cases"
     @search = SearchParams.new(

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -24,7 +24,7 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/your-notifications
   def your_notifications
-    return redirect_to your_cases_investigations_path unless current_user.can_access_new_search?
+    return redirect_to your_cases_investigations_path unless current_user.can_use_notification_task_list?
 
     @page_name = "your_cases"
     @search = SearchParams.new(
@@ -57,7 +57,7 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/team-notifications
   def team_notifications
-    return redirect_to team_cases_investigations_path unless current_user.can_access_new_search?
+    return redirect_to team_cases_investigations_path unless current_user.can_use_notification_task_list?
 
     @page_name = "team_cases"
     @search = SearchParams.new(
@@ -79,7 +79,7 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/assigned-notifications
   def assigned_notifications
-    return redirect_to assigned_cases_investigations_path unless current_user.can_access_new_search?
+    return redirect_to assigned_cases_investigations_path unless current_user.can_use_notification_task_list?
 
     @page_name = "assigned_cases"
     @search = SearchParams.new(
@@ -103,6 +103,8 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/:pretty_id
   def show
+    return redirect_to investigation_path(@notification) unless current_user.can_use_notification_task_list?
+
     breadcrumb breadcrumb_case_label, breadcrumb_case_path
 
     # Find the most recent incomplete bulk products upload for the current user and case, if any


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2411

## Description

Adds redirects so users of the notification task list always see the new notification summary page and vice versa.

Also fixes existing redirects between the your, team and assigned cases and notifications pages to use the same redirection criteria.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2909.london.cloudapps.digital/
https://psd-pr-2909-support.london.cloudapps.digital/
https://psd-pr-2909-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
