### PR TITLE
Fix review app deletion

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -35,8 +35,7 @@ jobs:
         cf api api.london.cloud.service.gov.uk
         cf auth
         cf target -o 'beis-opss' -s $SPACE
-        app_exists="$(cf apps | grep psd-pr-$PR_NUMBER)"
-        if [ -z "$app_exists" ]; then
+        if [[ $(cf apps | grep psd-pr-$PR_NUMBER) ]]; then
           cf stop psd-pr-$PR_NUMBER
           cf run-task psd-pr-$PR_NUMBER --command "./env/delete-opensearch-indexes.sh" --name delete-opensearch-indexes
           task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks psd-pr-$PR_NUMBER | grep delete-opensearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;


### PR DESCRIPTION
## Description

Fixes the GitHub Action that deletes review apps after the PR is merged or closed to use the correct test of an app’s existence when attempting to delete it.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2914.london.cloudapps.digital/
https://psd-pr-2914-support.london.cloudapps.digital/
https://psd-pr-2914-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
