### PR TITLE
Expand product removal timeframe for notification task list

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -47,7 +47,8 @@ module Notifications
     end
 
     def remove_product
-      return redirect_to notification_create_index_path(@notification) if @notification.tasks_status["search_for_or_add_a_product"] == "completed"
+      # Don't allows products to be removed once the "add notification details" task has been completed
+      return redirect_to notification_create_index_path(@notification) if @notification.tasks_status["add_notification_details"] == "completed"
 
       @investigation_product = @notification.investigation_products.find(params[:investigation_product_id])
 

--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -19,7 +19,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <p class="govuk-body">You have added <%= pluralize(@existing_product_ids.length, "product") %>.
-          <% if @notification.tasks_status["search_for_or_add_a_product"] == "completed" %>
+          <% if @notification.tasks_status["add_notification_details"] == "completed" %>
             <p class="govuk-body">You have completed adding products. If removal of any products is necessary, please delete the current notification and create a new one.</p>
           <% else %>
             <p class="govuk-body">Once you complete adding products, you will not be able to subsequently remove any products without deleting the current notification and creating a new one.</p>
@@ -29,7 +29,7 @@
               @notification.investigation_products.decorate.each do |investigation_product|
                 summary_list.with_row do |row|
                   row.with_key(text: investigation_product.product.name_with_brand)
-                  row.with_action(text: "Remove", href: remove_product_notification_create_index_path(investigation_product_id: investigation_product.id), visually_hidden_text: "product from notification") unless @notification.tasks_status["search_for_or_add_a_product"] == "completed"
+                  row.with_action(text: "Remove", href: remove_product_notification_create_index_path(investigation_product_id: investigation_product.id), visually_hidden_text: "product from notification") unless @notification.tasks_status["add_notification_details"] == "completed"
                 end
               end
             end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2410

## Description

Allows products to be removed when using the notification task list until the next task has been completed.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2915.london.cloudapps.digital/
https://psd-pr-2915-support.london.cloudapps.digital/
https://psd-pr-2915-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
