### PR TITLE
Fix hazard type on notification task list

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -54,7 +54,7 @@ module Notifications
     def hazards_options
       [OpenStruct.new(id: "", name: "")] +
         Rails.application.config.hazard_constants["hazard_type"].map do |hazard_type|
-          OpenStruct.new(id: hazard_type.parameterize.underscore, name: hazard_type)
+          OpenStruct.new(id: hazard_type, name: hazard_type)
         end
     end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2419

## Description

Change the hazard type select box to record hazard types as user-readable strings.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2920.london.cloudapps.digital/
https://psd-pr-2920-support.london.cloudapps.digital/
https://psd-pr-2920-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
