### PR TITLE
Limit PRISM risk assessments to PRISM users

### DIFF
--- a/app/views/notifications/create/add_risk_assessments_prism_or_legacy.html.erb
+++ b/app/views/notifications/create/add_risk_assessments_prism_or_legacy.html.erb
@@ -12,52 +12,54 @@
         <li class="govuk-body-l"><%= @investigation_product.decorate.product.name_with_brand %></li>
       </ul>
     <% end %>
-    <h2 class="govuk-heading-m">Related risk assessments</h2>
-    <% if @related_prism_risk_assessments.size.positive? %>
-      <%= form_with url: with_product_notification_create_index_path(@notification, step: "add_risk_assessments", investigation_product_id: @investigation_product.id), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <p class="govuk-body">Select a related risk assessment to add to the notification.</p>
-        <table class="govuk-table opss-table-items opss-table-items--first-col-33 opss-table--borders">
-          <caption class="govuk-table__caption govuk-visually-hidden">PRISM risk assessments: a simple data table.</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header">Assessment title</th>
-              <th scope="col" class="govuk-table__header">Created by</th>
-              <th scope="col" class="govuk-table__header">Last updated</th>
-              <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Add assessment to notification</span></th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <% @related_prism_risk_assessments.each do |prism_risk_assessment| %>
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">
-                  <%= prism_risk_assessment.name || "Unknown" %>
-                </th>
-                <td class="govuk-table__cell">
-                  <%= prism_risk_assessment.user_and_organisation.join("<br>").html_safe %>
-                </td>
-                <td class="govuk-table__cell">
-                  <%= date_or_recent_time_ago prism_risk_assessment.updated_at %>
-                </td>
-                <td class="govuk-table__cell">
-                  <%= f.govuk_submit("Add", name: "entity_id", value: prism_risk_assessment.id, class: "govuk-!-margin-bottom-0") %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-          <% if @related_prism_risk_assessments.size > 11 %>
-            <tfoot class="govuk-table__head">
+    <% if current_user.is_prism_user? %>
+      <h2 class="govuk-heading-m">Related risk assessments</h2>
+      <% if @related_prism_risk_assessments.size.positive? %>
+        <%= form_with url: with_product_notification_create_index_path(@notification, step: "add_risk_assessments", investigation_product_id: @investigation_product.id), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+          <p class="govuk-body">Select a related risk assessment to add to the notification.</p>
+          <table class="govuk-table opss-table-items opss-table-items--first-col-33 opss-table--borders">
+            <caption class="govuk-table__caption govuk-visually-hidden">PRISM risk assessments: a simple data table.</caption>
+            <thead class="govuk-table__head">
               <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header">Assessment title</th>
                 <th scope="col" class="govuk-table__header">Created by</th>
                 <th scope="col" class="govuk-table__header">Last updated</th>
                 <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Add assessment to notification</span></th>
               </tr>
-            </tfoot>
-          <% end %>
-        </table>
+            </thead>
+            <tbody class="govuk-table__body">
+              <% @related_prism_risk_assessments.each do |prism_risk_assessment| %>
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    <%= prism_risk_assessment.name || "Unknown" %>
+                  </th>
+                  <td class="govuk-table__cell">
+                    <%= prism_risk_assessment.user_and_organisation.join("<br>").html_safe %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <%= date_or_recent_time_ago prism_risk_assessment.updated_at %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <%= f.govuk_submit("Add", name: "entity_id", value: prism_risk_assessment.id, class: "govuk-!-margin-bottom-0") %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+            <% if @related_prism_risk_assessments.size > 11 %>
+              <tfoot class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Assessment title</th>
+                  <th scope="col" class="govuk-table__header">Created by</th>
+                  <th scope="col" class="govuk-table__header">Last updated</th>
+                  <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Add assessment to notification</span></th>
+                </tr>
+              </tfoot>
+            <% end %>
+          </table>
+        <% end %>
+      <% else %>
+        <p class="govuk-body">There are no risk assessments for <%= @investigation_product.decorate.product.name_with_brand %>. <strong>To conduct a new risk assessment</strong>, use the 'Risk Assessments' section of the Product Safety Database.</p>
       <% end %>
-    <% else %>
-      <p class="govuk-body">There are no risk assessments for <%= @investigation_product.decorate.product.name_with_brand %>. <strong>To conduct a new risk assessment</strong>, use the 'Risk Assessments' section of the Product Safety Database.</p>
     <% end %>
     <%= govuk_button_link_to("Add legacy risk assessment", with_product_and_entity_notification_create_index_path(@notification, step: "add_risk_assessments", investigation_product_id: @investigation_product.id, entity_id: "new"), secondary: true) %>
   </div>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2420

## Description

Limits the ability to add existing PRISM risk assessments via the notification task list to PRISM users.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-14 at 12 58 17](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/39fa29f3-ba20-4e76-891e-9739ae3ed521)

![Screenshot 2024-02-14 at 12 58 37](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/da9468f7-695a-44a0-988b-1600be3e7db3)

## Review apps

https://psd-pr-2921.london.cloudapps.digital/
https://psd-pr-2921-support.london.cloudapps.digital/
https://psd-pr-2921-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
