### PR TITLE
Show more product details for notification task list

### DIFF
--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -7,10 +7,6 @@ class ProductDecorator < ApplicationDecorator
     [brand, name].compact.join(" ")
   end
 
-  def subcategory_with_brand
-    [subcategory, brand].compact.join(" by ")
-  end
-
   def pretty_description
     "Product: #{name}"
   end

--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -106,8 +106,19 @@
 
                     details = <<~DETAILS.strip
                       <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0"><a href="#{product_path(record)}" class="govuk-link" target="_blank" rel="noreferrer noopener">#{record.name_with_brand}</a></p>
-                      <p class="govuk-body-s govuk-!-margin-bottom-0">#{record.subcategory_with_brand}</p>
-                      <p class="govuk-body-s govuk-!-margin-bottom-0">#{record.psd_ref}</p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-0"><strong>Category:</strong> #{record.category}</p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-1"><strong>Sub-category:</strong> #{record.subcategory}</p>
+                      #{
+                        if record.barcode.present? || record.product_code.present? || record.unformatted_description.present?
+                          govuk_details(summary_text: "More details", classes: "govuk-!-font-size-16 govuk-!-margin-bottom-0") do
+                            details = []
+                            details << "<p class=\"govuk-body-s govuk-!-margin-bottom-0\"><strong>Barcode:</strong> #{record.barcode}</p>" if record.barcode.present?
+                            details << "<p class=\"govuk-body-s govuk-!-margin-bottom-0\"><strong>Other product identifiers:</strong> #{record.product_code}</p>" if record.product_code.present?
+                            details << "<p class=\"govuk-body-s govuk-!-margin-bottom-0\"><strong>Product description:</strong> #{record.unformatted_description}</p>" if record.unformatted_description.present?
+                            details.join.html_safe
+                          end
+                        end
+                      }
                     DETAILS
 
                     select_button = form_with url: "#{wizard_path}?product_id=#{record.id}", method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2416

## Description

Adds more product details to the notification task list page when selecting products.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-14 at 14 20 55](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/76db61c4-99b9-43c3-9a78-090b3ed1724f)

## Review apps

https://psd-pr-2922.london.cloudapps.digital/
https://psd-pr-2922-support.london.cloudapps.digital/
https://psd-pr-2922-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
