### PR TITLE
Allow user to change whether a corrective action has been taken

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -139,8 +139,12 @@ module Notifications
         @risk_level_form = RiskLevelForm.new(risk_level: @notification.risk_level)
         highest_risk_level
       when :record_a_corrective_action
-        if @notification.corrective_action_taken.blank?
-          @corrective_action_taken_form = CorrectiveActionTakenForm.new
+        if @notification.corrective_action_taken.blank? || @notification.corrective_action_taken != "yes"
+          @corrective_action_taken_form = CorrectiveActionTakenForm.new(
+            corrective_action_taken_yes_no: @notification.corrective_action_taken.present? ? @notification.corrective_action_taken_yes? : nil,
+            corrective_action_taken_no_specific: @notification.corrective_action_taken_yes? ? nil : @notification.corrective_action_taken,
+            corrective_action_not_taken_reason: @notification.corrective_action_not_taken_reason
+          )
           return render :record_a_corrective_action_taken
         elsif params[:investigation_product_ids].present?
           @corrective_action_form = CorrectiveActionForm.new
@@ -345,7 +349,7 @@ module Notifications
           return render_wizard
         end
       when :record_a_corrective_action
-        if @notification.corrective_action_taken.blank?
+        if params[:corrective_action_taken_form].present?
           @corrective_action_taken_form = CorrectiveActionTakenForm.new(corrective_action_taken_params)
 
           if @corrective_action_taken_form.valid?

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -142,5 +142,9 @@ module Notifications
         govuk_tag(text: "Unknown risk", colour: "grey")
       end
     end
+
+    def corrective_action_not_taken_reasons
+      @notification.corrective_action_taken_other? ? @notification.corrective_action_not_taken_reason : I18n.t("corrective_action.not_taken_reason.#{@notification.corrective_action_taken}")
+    end
   end
 end

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -204,54 +204,78 @@
       end
     %>
     <h2 class="govuk-heading-m">Corrective actions</h2>
-    <% @notification.corrective_actions.includes(investigation_product: :product).decorate.each do |corrective_action| %>
+    <% if @notification.corrective_action_taken_yes? %>
+      <% if @notification.corrective_actions.present? %>
+        <% @notification.corrective_actions.includes(investigation_product: :product).decorate.each do |corrective_action| %>
+          <%=
+            govuk_summary_list(
+              card: {
+                title: corrective_action.investigation_product.product.decorate.name_with_brand,
+                actions: [govuk_link_to("Change", with_entity_notification_create_index_path(@notification, entity_id: corrective_action.id))]
+              },
+              rows: [
+                {
+                  key: { text: "Corrective action" },
+                  value: { text: corrective_action.page_title }
+                },
+                {
+                  key: { text: "Effective date" },
+                  value: { text: corrective_action.date_of_activity }
+                },
+                {
+                  key: { text: "Legislation" },
+                  value: { text: corrective_action.legislation }
+                },
+                {
+                  key: { text: "Responsible business" },
+                  value: { text: corrective_action.business&.trading_name || "Not provided" }
+                },
+                if corrective_action.recall_of_the_product_from_end_users?
+                  {
+                    key: { text: "Recall information" },
+                    value: { text: corrective_action.has_online_recall_information ? "Yes: #{corrective_action.online_recall_information}" : "No" }
+                  }
+                end,
+                {
+                  key: { text: "Action type" },
+                  value: { text: corrective_action.measure_type }
+                },
+                {
+                  key: { text: "Geographic scope" },
+                  value: { text: corrective_action.geographic_scopes }
+                },
+                {
+                  key: { text: "Further details" },
+                  value: { text: corrective_action.details.presence || "Not provided" }
+                },
+                {
+                  key: { text: "Related file" },
+                  value: { text: formatted_uploads([corrective_action.document]).html_safe.presence || "Not provided" }
+                }
+              ].compact
+            )
+          %>
+        <% end %>
+      <% else %>
+        <%=
+          govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key(text: "Corrective action taken?")
+              row.with_value(text: "Yes")
+              row.with_action(text: "Add", href: wizard_path(:record_a_corrective_action), visually_hidden_text: "a corrective action")
+            end
+          end
+        %>
+      <% end %>
+    <% else %>
       <%=
-        govuk_summary_list(
-          card: {
-            title: corrective_action.investigation_product.product.decorate.name_with_brand,
-            actions: [govuk_link_to("Change", with_entity_notification_create_index_path(@notification, entity_id: corrective_action.id))]
-          },
-          rows: [
-            {
-              key: { text: "Corrective action" },
-              value: { text: corrective_action.page_title }
-            },
-            {
-              key: { text: "Effective date" },
-              value: { text: corrective_action.date_of_activity }
-            },
-            {
-              key: { text: "Legislation" },
-              value: { text: corrective_action.legislation }
-            },
-            {
-              key: { text: "Responsible business" },
-              value: { text: corrective_action.business&.trading_name || "Not provided" }
-            },
-            if corrective_action.recall_of_the_product_from_end_users?
-              {
-                key: { text: "Recall information" },
-                value: { text: corrective_action.has_online_recall_information ? "Yes: #{corrective_action.online_recall_information}" : "No" }
-              }
-            end,
-            {
-              key: { text: "Action type" },
-              value: { text: corrective_action.measure_type }
-            },
-            {
-              key: { text: "Geographic scope" },
-              value: { text: corrective_action.geographic_scopes }
-            },
-            {
-              key: { text: "Further details" },
-              value: { text: corrective_action.details.presence || "Not provided" }
-            },
-            {
-              key: { text: "Related file" },
-              value: { text: formatted_uploads([corrective_action.document]).html_safe.presence || "Not provided" }
-            }
-          ].compact
-        )
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: "Corrective action taken?")
+            row.with_value(text: "No: #{corrective_action_not_taken_reasons}")
+            row.with_action(text: "Change", href: wizard_path(:record_a_corrective_action), visually_hidden_text: "corrective action taken")
+          end
+        end
       %>
     <% end %>
     <%= form_with url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1011,7 +1011,6 @@ en:
       unknown_severity: "Unknown"
     date:
       unknown: "Unknown"
-
   corrective_action:
     attributes:
       geographic_scopes:
@@ -1039,6 +1038,9 @@ en:
         referred_to_overseas_regulator: "Referred to an overseas regulator"
         product_no_longer_available_for_sale: "Product is no longer available for sale"
         other: "Other"
+    not_taken_reason:
+      referred_to_another_authority: I need to refer the issue to another authority
+      not_enough_information: I don't have enough information to take a corrective action
   enter_email_address: "Enter your email address"
   file_added: "The file was added"
   file_updated: "File has been updated"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2417

## Description

Adds the ability for a user to change whether a corrective action has been taken in the notification task list from “no” to “yes”.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-15 at 10 12 22](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/d31a8eba-fd31-4527-80a2-73a9b985b032)

![Screenshot 2024-02-15 at 10 12 38](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/d4813823-b3cf-43bd-b81a-7f0c5f419772)

![Screenshot 2024-02-15 at 10 13 25](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/52da98b0-9170-49c3-bd09-3e8da82de378)

## Review apps

https://psd-pr-2924.london.cloudapps.digital/
https://psd-pr-2924-support.london.cloudapps.digital/
https://psd-pr-2924-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
