### PR TITLE
Notification search & example responses - PSD-2425

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -1,6 +1,15 @@
 class Api::V1::NotificationsController < Api::BaseController
   include Pagy::Backend
-  before_action :notification, only: :show
+  include InvestigationsHelper
+
+  before_action :set_search_params, only: %i[index]
+  before_action :notification, only: %i[show]
+
+  def index
+    @pagy, @answer  = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
+    @notifications = InvestigationDecorator
+                        .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
+  end
 
   def show; end
 
@@ -21,6 +30,14 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
 private
+
+  def default_params
+    params["case_statuses"] == %w[open closed] && params[:q].blank?
+  end
+
+  def set_search_params
+    @search = SearchParams.new(query_params.except(:page_name))
+  end
 
   def notification_create_params
     params.require(:notification).permit(

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::NotificationsController < Api::BaseController
   before_action :notification, only: %i[show]
 
   def index
-    @pagy, @answer  = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
+    @pagy, @answer = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
     @notifications = InvestigationDecorator
                         .decorate_collection(@answer.includes([{ owner_user: :organisation, owner_team: :organisation }, :products]))
   end

--- a/app/views/api/v1/notifications/index.json.jbuilder
+++ b/app/views/api/v1/notifications/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.notifications @notifications, partial: 'api/v1/notifications/notification', as: :notification

--- a/app/views/api/v1/notifications/index.json.jbuilder
+++ b/app/views/api/v1/notifications/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.notifications @notifications, partial: 'api/v1/notifications/notification', as: :notification
+json.notifications @notifications, partial: "api/v1/notifications/notification", as: :notification

--- a/app/views/api/v1/products/index.json.jbuilder
+++ b/app/views/api/v1/products/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.products @products, partial: 'api/v1/products/product', as: :product
+json.products @products, partial: "api/v1/products/product", as: :product

--- a/app/views/api/v1/products/index.json.jbuilder
+++ b/app/views/api/v1/products/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "api/v1/products/product", collection: @products, as: @product
+json.products @products, partial: 'api/v1/products/product', as: :product

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,7 +410,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :auth, only: %i[create destroy]
       resources :products, only: %i[index create show]
-      resources :notifications, only: %i[create show]
+      resources :notifications, only: %i[index create show]
     end
   end
 

--- a/spec/requests/api/v1/notifications_controller_spec.rb
+++ b/spec/requests/api/v1/notifications_controller_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "API Notifications Controller", type: :request do
+RSpec.describe "API Notifications Controller",  :with_opensearch, type: :request do
   let(:user) { create(:user, :activated, :with_api_token, has_viewed_introduction: true, team: user_team) }
   let(:user_team) { create(:team) }
-  let!(:notification) { create(:notification, :with_products, :with_business) }
+  let!(:notification) { create(:notification, :with_products, :with_business, user_title: notification_title) }
+  let(:notification_title) { "Turbo vac 3000" }
+
+  before do
+    Investigation.reindex
+  end
 
   path "/api/v1/notifications/{id}" do
     get "Retrieves a Notification" do
@@ -19,8 +24,22 @@ RSpec.describe "API Notifications Controller", type: :request do
         schema '$ref' => '#/components/schemas/notification_object'
 
         let(:Authorization) { "Authorization #{user.api_tokens.first&.token}" }
-
         let(:id) { notification.pretty_id }
+
+        after do |example|
+          content = example.metadata[:response][:content] || {}
+          example_spec = {
+            "application/json"=>{
+              examples: {
+                test_example: {
+                  value: JSON.parse(response.body, symbolize_names: true)
+                }
+              }
+            }
+          }
+          example.metadata[:response][:content] = content.deep_merge(example_spec)
+        end
+
         run_test! do |response|
           json = JSON.parse(response.body, symbolize_names: true)
 
@@ -40,6 +59,57 @@ RSpec.describe "API Notifications Controller", type: :request do
         let(:Authorization) { "Authorization 0000" }
         let(:id) { "invalid" }
         run_test!
+      end
+    end
+  end
+
+  path "/api/v1/notifications" do
+    get "Search for Notifications" do
+      description %{
+Search for a Product
+
+* The search `q` query performs a full text search on the notificaiton title and product name. It uses the same code as the search bar in the UI within PSD.
+
+* The `sort_by` parameter can be used to sort the results. The default is `updated_at` which returns the most recent updated notification first. The `sort_dir` parameter can be used to sort the results in ascending or descending order. The default is descending.
+* The `category` parameter can be used to filter the results by category. If given, only products in this category will be returned.
+* The `page` parameter can be used to paginate the results. By default, 20 results are returned per page.
+}
+      tags "Notifications"
+      produces "application/json"
+      security [bearer: []]
+      parameter name: :Authorization, in: :header, type: :string
+      parameter name: :q, in: :query, type: :string, description: "Search query. Searches based on name, description, brand, PSD ID, and product_code"
+      parameter name: :sort_by, in: :query, required: false, type: :string, description: "Sort by parameter. Choose name, updated_at, or relevant. Default is updated_at"
+      parameter name: :sort_dir, in: :query, required: false, type: :string, description: "Sort direction. Choose asc or desc. Default is desc"
+
+      parameter name: :page, required: false, in: :query, type: :integer, description: "Page number"
+
+      response "200", "Search results returned" do
+        let(:Authorization) { "Authorization #{user.api_tokens.first&.token}" }
+        let(:q) { notification_title }
+
+        after do |example|
+          content = example.metadata[:response][:content] || {}
+          example_spec = {
+            "application/json"=>{
+              examples: {
+                test_example: {
+                  value: JSON.parse(response.body, symbolize_names: true)
+                }
+              }
+            }
+          }
+          example.metadata[:response][:content] = content.deep_merge(example_spec)
+        end
+
+        run_test! do |response|
+          expect(response).to have_http_status(:ok)
+
+          json = JSON.parse(response.body, symbolize_names: true)
+
+          expect(json[:notifications].count).to eq(1)
+          expect(json[:notifications].first[:id]).to eq(notification.pretty_id)
+        end
       end
     end
   end

--- a/spec/requests/api/v1/products_controller_spec.rb
+++ b/spec/requests/api/v1/products_controller_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe "API Products Controller", type: :request do
         let(:Authorization) { "Authorization #{user.api_tokens.first&.token}" }
 
         let(:id) { create(:product, country_of_origin: 'country:GB').id }
+
+        after do |example|
+          content = example.metadata[:response][:content] || {}
+          example_spec = {
+            "application/json"=>{
+              examples: {
+                test_example: {
+                  value: JSON.parse(response.body, symbolize_names: true)
+                }
+              }
+            }
+          }
+          example.metadata[:response][:content] = content.deep_merge(example_spec)
+        end
+
         run_test! do |response|
 
         end

--- a/spec/requests/api/v1/products_controller_spec.rb
+++ b/spec/requests/api/v1/products_controller_spec.rb
@@ -68,6 +68,10 @@ Search for a Product
 
         run_test! do |response|
           expect(response).to have_http_status(:ok)
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:products].size).to eq(1)
+          expect(json[:products].first[:product_code]).to eq(product_code_asin)
         end
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -590,6 +590,54 @@ paths:
         '401':
           description: Unauthorised user
   "/api/v1/notifications":
+    get:
+      summary: Search for Notifications
+      description: |2
+
+        Search for a Product
+
+        * The search `q` query performs a full text search on the notificaiton title and product name. It uses the same code as the search bar in the UI within PSD.
+
+        * The `sort_by` parameter can be used to sort the results. The default is `updated_at` which returns the most recent updated notification first. The `sort_dir` parameter can be used to sort the results in ascending or descending order. The default is descending.
+        * The `category` parameter can be used to filter the results by category. If given, only products in this category will be returned.
+        * The `page` parameter can be used to paginate the results. By default, 20 results are returned per page.
+      tags:
+      - Notifications
+      security:
+      - bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: q
+        in: query
+        description: Search query. Searches based on name, description, brand, PSD
+          ID, and product_code
+        schema:
+          type: string
+      - name: sort_by
+        in: query
+        required: false
+        description: Sort by parameter. Choose name, updated_at, or relevant. Default
+          is updated_at
+        schema:
+          type: string
+      - name: sort_dir
+        in: query
+        required: false
+        description: Sort direction. Choose asc or desc. Default is desc
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: Page number
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Search results returned
     post:
       summary: Creates a draft Notification
       description: Creates a draft Notification in PSD


### PR DESCRIPTION
- Adds notification search API, using new opensearch helper
- Add new example responses for product, notification index endpoints
- Fix index array view, always have a named array instead of root json array 