### PR TITLE
Named parameter search for product API - PSD-2449

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -3,11 +3,19 @@ class Api::V1::ProductsController < Api::BaseController
   include ProductsHelper
   before_action :product, only: :show
   before_action :set_search_params, only: %i[index]
+  before_action :set_named_search_params, only: %i[named_parameter_search]
 
   def index
+    @pagy, @results = search_for_products
+    @count = count_to_display
+    @products = ProductDecorator.decorate_collection(@results)
+  end
+
+  def named_parameter_search
     @pagy, @results = api_search_for_products
     @count = count_to_display
     @products = ProductDecorator.decorate_collection(@results)
+    render :index
   end
 
   def create
@@ -34,7 +42,11 @@ private
   end
 
   def set_search_params
-    @search = SearchParams.new(query_params.except(:page_name))
+    @search = SearchParams.new(query_params)
+  end
+
+  def set_named_search_params
+    @search = SearchParams.new(named_search_query_params)
   end
 
   def product_create_params
@@ -47,6 +59,10 @@ private
 
   def query_params
     params.permit(:q, :sort_by, :sort_dir, :category)
+  end
+
+  def named_search_query_params
+    params.permit(:name, :id, :barcode, :product_code, :sort_by, :sort_dir, :category)
   end
 
   def count_to_display

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -46,6 +46,10 @@ class SearchParams
   attribute :page_name
   attribute :state
   attribute :retired_status
+  attribute :id
+  attribute :name
+  attribute :product_code
+  attribute :barcode
   attribute :created_from_date, :govuk_date
   attribute :created_to_date, :govuk_date
   Rails.application.config.hazard_constants["hazard_type"].each do |type|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,8 +428,12 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resource :auth, only: %i[create destroy]
-      resources :products, only: %i[index create show]
       resources :notifications, only: %i[index create show]
+      resources :products, only: %i[index create show] do
+        collection do
+          get :named_parameter_search
+        end
+      end
     end
   end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -706,8 +706,7 @@ paths:
 
         Search for a Product
 
-        * The search `q` query searches based on `name`, `brand`, `ID`, `barcode`, and `product_code`.
-        * `product_code` can contain the ASIN, EAN, or UPC codes for a given product.
+        * The search `q` query searches for Products in PSD with the same code as is used in the application. It fuzzy matches based on name, description, brand, PSD ID, and product_code.
         * The `sort_by` parameter can be used to sort the results. The default is `relevant` which returns the most relevant first. The `sort_dir` parameter can be used to sort the results in ascending `asc` or descending `desc` order. The default is descending.
         * The `category` parameter can be used to filter the results by category. If given, only products in this category will be returned.
         * The `page` parameter can be used to paginate the results. By default, 20 results are returned per page.
@@ -791,3 +790,82 @@ paths:
                     when_placed_on_market: on_or_after_2021
                     authenticity: genuine
                     has_markings: markings_no
+  "/api/v1/products/named_parameter_search":
+    get:
+      summary: Named parameter search for a Product
+      description: |2
+
+        Search for a Product using named parameters.
+
+        * The `name` parameter fuzzy searches based on `name`
+        * The `ID`, `barcode`, and `product_code` parameters search based on exact matches
+        * Providing each parameter will perform an AND search, i.e. all parameters must match
+        * For PSD ID, please issue without `psd-` (e.g. for `psd-1234` use `1234`).
+        * `product_code` can contain the ASIN, EAN, or UPC codes for a given product.
+        * The `sort_by` parameter can be used to sort the results. The default is `relevant` which returns the most relevant first. The `sort_dir` parameter can be used to sort the results in ascending `asc` or descending `desc` order. The default is descending.
+        * The `category` parameter can be used to filter the results by category. If given, only products in this category will be returned.
+        * The `page` parameter can be used to paginate the results. By default, 20 results are returned per page.
+      tags:
+      - Products
+      security:
+      - bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: name
+        in: query
+        description: Fuzzy searches based on product name
+        required: false
+        schema:
+          type: string
+      - name: id
+        in: query
+        description: Search based on exact match of PSD ID. Please issue without `psd-`
+          (e.g. for `psd-1234` use `1234`)
+        required: false
+        schema:
+          type: string
+      - name: barcode
+        in: query
+        description: Search based on exact match of barcode
+        required: false
+        schema:
+          type: string
+      - name: product_code
+        in: query
+        description: Search based on exact match of product_code. Can contain the
+          ASIN, EAN, or UPC codes for a given product
+        required: false
+        schema:
+          type: string
+      - name: sort_by
+        in: query
+        required: false
+        description: Sort by parameter. Choose name, created_at, updated_at, or relevant.
+          Default is relevant
+        schema:
+          type: string
+      - name: sort_dir
+        in: query
+        required: false
+        description: Sort direction. Choose asc or desc. Default is desc
+        schema:
+          type: string
+      - name: category
+        in: query
+        required: false
+        description: Category of the product. If given, only products in this category
+          will be returned
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: Page number
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Search results returned


### PR DESCRIPTION
- New endpoint /api/products/named_parameter_search
- Search does AND matching for products, no fuzzy matching except for name
- Updated swagger docs