### PR TITLE
Add business search for notification task list

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -3,7 +3,7 @@ module Notifications
     def sections_complete
       tasks_status = @notification.tasks_status
       Investigation::Notification::TASK_LIST_SECTIONS.map { |_section, tasks|
-        complete = tasks.map { |task|
+        complete = tasks.excluding(*Investigation::Notification::TASK_LIST_TASKS_HIDDEN.map(&:keys).flatten).map { |task|
           tasks_status[task.to_s] == "completed" ? 1 : 0
         }.exclude?(0)
         complete ? 1 : 0
@@ -12,7 +12,7 @@ module Notifications
 
     def task_status(task)
       optional_tasks = Investigation::Notification::TASK_LIST_SECTIONS.slice(*Investigation::Notification::TASK_LIST_SECTIONS_OPTIONAL).values.flatten
-      previous_task = TaskListService.previous_task(task:, all_tasks: wizard_steps, optional_tasks:)
+      previous_task = TaskListService.previous_task(task:, all_tasks: wizard_steps, optional_tasks:, hidden_tasks: Investigation::Notification::TASK_LIST_TASKS_HIDDEN)
 
       if %w[in_progress completed].include?(@notification.tasks_status[task.to_s])
         @notification.tasks_status[task.to_s]

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -13,6 +13,8 @@ class Investigation < ApplicationRecord
 
     TASK_LIST_SECTIONS_OPTIONAL = %w[evidence].freeze
 
+    # Each hidden task is the key to a hash, the value of which is the task whose completion
+    # should unlock the hidden task in question.
     TASK_LIST_TASKS_HIDDEN = [
       { add_business_details: :add_product_identification_details },
       { add_business_location: :add_product_identification_details },

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -5,13 +5,19 @@ class Investigation < ApplicationRecord
     TASK_LIST_SECTIONS = {
       "product" => %i[search_for_or_add_a_product],
       "notification_details" => %i[add_notification_details add_product_safety_and_compliance_details add_product_identification_details],
-      "business_details" => %i[add_business_details add_location add_contact],
+      "business_details" => %i[search_for_or_add_a_business add_business_details add_business_location add_business_contact],
       "evidence" => %i[add_test_reports add_supporting_images add_supporting_documents add_risk_assessments determine_notification_risk_level],
       "corrective_actions" => %i[record_a_corrective_action],
       "submit" => %i[check_notification_details_and_submit]
     }.freeze
 
     TASK_LIST_SECTIONS_OPTIONAL = %w[evidence].freeze
+
+    TASK_LIST_TASKS_HIDDEN = [
+      { add_business_details: :add_product_identification_details },
+      { add_business_location: :add_product_identification_details },
+      { add_business_contact: :add_product_identification_details }
+    ].freeze
 
     has_one :add_audit_activity,
             class_name: "AuditActivity::Investigation::AddCase",
@@ -35,7 +41,7 @@ class Investigation < ApplicationRecord
     def ready_to_submit?
       # Ensure all mandatory sections have been completed *and* every product has a value for "number of units affected"
       draft? &&
-        TASK_LIST_SECTIONS.except(*TASK_LIST_SECTIONS_OPTIONAL, "submit").values.flatten.map { |task| tasks_status[task.to_s] == "completed" }.all?(true) &&
+        TASK_LIST_SECTIONS.except(*TASK_LIST_SECTIONS_OPTIONAL, "submit").values.flatten.excluding(*TASK_LIST_TASKS_HIDDEN.map(&:keys).flatten).map { |task| tasks_status[task.to_s] == "completed" }.all?(true) &&
         all_products_have_affected_units?
     end
 

--- a/app/services/change_business_names.rb
+++ b/app/services/change_business_names.rb
@@ -5,8 +5,9 @@ class ChangeBusinessNames
 
   def call
     context.fail!(error: "No trading name supplied") unless trading_name.is_a?(String)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
 
-    business.assign_attributes(legal_name:, trading_name:)
+    business.assign_attributes(legal_name:, trading_name:, added_by_user_id: user.id)
 
     business.save!
   end

--- a/app/services/remove_business_from_notification.rb
+++ b/app/services/remove_business_from_notification.rb
@@ -16,7 +16,7 @@ class RemoveBusinessFromNotification
     notification.businesses.delete(business)
     notification.reindex
 
-    send_notification_email(create_audit_activity_for_business_removed)
+    send_notification_email(create_audit_activity_for_business_removed) unless context.silent
   end
 
 private

--- a/app/services/task_list_service.rb
+++ b/app/services/task_list_service.rb
@@ -1,6 +1,11 @@
 class TaskListService
-  def self.previous_task(task:, all_tasks:, optional_tasks:)
+  def self.previous_task(task:, all_tasks:, optional_tasks:, hidden_tasks:)
     return if task.blank? || all_tasks.index(task).zero?
+
+    hidden_task_parent = hidden_tasks.select { |h| h[task].present? }
+    if hidden_task_parent.present?
+      return hidden_task_parent.first[task]
+    end
 
     mandatory_tasks = all_tasks - optional_tasks
 

--- a/app/views/notifications/create/add_business_contact.html.erb
+++ b/app/views/notifications/create/add_business_contact.html.erb
@@ -1,0 +1,19 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_contact.title"), errors: @add_contact_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @add_contact_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_business_contact.title") %>
+      </h1>
+      <%= f.govuk_text_field :name, label: { text: "Full name (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :job_title, label: { text: "Job title or role description (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :email, label: { text: "Email (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :phone_number, label: { text: "Phone (optional)" }, hint: { text: "For international numbers include the country code." }, width: "two-thirds" %>
+      <%= f.hidden_field :business_id %>
+      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/add_business_location.html.erb
+++ b/app/views/notifications/create/add_business_location.html.erb
@@ -1,0 +1,27 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_location.title"), errors: @add_location_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @add_location_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_business_location.title") %>
+      </h1>
+      <%= f.govuk_text_field :address_line_1, label: { text: "Address line 1 (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :address_line_2, label: { text: "Address line 2 (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :city, label: { text: "Town or city (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :county, label: { text: "County (optional)" }, width: "two-thirds" %>
+      <%= f.govuk_text_field :postal_code, label: { text: "Post code (optional)" }, width: "two-thirds" %>
+      <%= f.hidden_field :business_id %>
+      <%= f.govuk_collection_select :country,
+            [OpenStruct.new(id: "", name: ""), OpenStruct.new(id: "Unknown", name: "Unknown")] + all_countries_with_uk_first.map { |country| OpenStruct.new(id: country[1], name: country[0]) },
+            :id,
+            :name,
+            label: { text: "Country" },
+            width: "two-thirds"
+      %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/index.html.erb
+++ b/app/views/notifications/create/index.html.erb
@@ -25,6 +25,7 @@
           <h2 class="govuk-heading-m"><%= t(".sections.#{section}.title") %><% if Investigation::Notification::TASK_LIST_SECTIONS_OPTIONAL.include?(section) %> <small class="govuk-body-s">(can be completed after the initial submission)</small><% end %></h2>
           <ul class="govuk-task-list">
             <% tasks.each_with_index do |task, task_index| %>
+              <% next if Investigation::Notification::TASK_LIST_TASKS_HIDDEN.map(&:keys).flatten.include?(task) %>
               <% status = task_status(task) %>
               <li class="govuk-task-list__item<% if status != "cannot_start_yet" %> govuk-task-list__item--with-link<% end %>">
                 <div class="govuk-task-list__task-name-and-hint">

--- a/app/views/notifications/create/remove_business.html.erb
+++ b/app/views/notifications/create/remove_business.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("Remove business from notification", errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: remove_business_notification_create_index_path(investigation_business_id: @investigation_business.id), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        Are you sure you want to remove this business from your notification?
+      </h1>
+      <p class="govuk-body">This action will remove <strong><%= @investigation_business.business.trading_name %></strong> from your notification. Please confirm if you wish to proceed.</p>
+      <%= f.govuk_submit "Remove business", warning: true do %>
+        <a href="<%= notification_create_path(@notification, "search_for_or_add_a_business") %>" class="govuk-link">Cancel</a>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/search_for_or_add_a_business.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_business.html.erb
@@ -1,0 +1,107 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.search_for_or_add_a_business.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+          <%= t("notifications.create.index.sections.business_details.tasks.search_for_or_add_a_business.title") %>
+        </h1>
+      </div>
+      <% unless @manage %>
+        <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
+          <%= govuk_button_link_to "Add a new business", wizard_path(:add_business_details), secondary: true %>
+        </div>
+      <% end %>
+    </div>
+    <% if @manage %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body">You have added <%= pluralize(@existing_business_ids.length, "business") %>.
+          <%=
+            govuk_summary_list do |summary_list|
+              @notification.investigation_businesses.decorate.each do |investigation_business|
+                summary_list.with_row do |row|
+                  row.with_key(text: investigation_business.business.trading_name)
+                  row.with_action(text: "Remove", href: remove_business_notification_create_index_path(investigation_business_id: investigation_business.id), visually_hidden_text: "business from notification")
+                end
+              end
+            end
+          %>
+          <%= form_with url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+            <%= f.govuk_collection_radio_buttons :add_another_business, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another business?", size: "m" } %>
+            <%= f.govuk_submit "Continue", name: "final", value: "true" %>
+          <% end %>
+        </div>
+      </div>
+    <% else %>
+      <%= form_with url: wizard_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <div class="moj-search">
+              <div class="govuk-form-group">
+                <label for="q-field" class="govuk-label moj-search__label">Search by business name, Companies House number or address</label>
+                <input id="q-field" class="govuk-input moj-search__input" aria-describedby="q-hint" type="search" name="q" value="<%= params[:q] %>">
+              </div>
+              <button type="submit" formnovalidate="formnovalidate" class="govuk-button moj-search__button" data-module="govuk-button" data-prevent-double-click="true">
+                <span class="govuk-visually-hidden">Search</span>
+              </button>
+            </div>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <%= f.govuk_collection_select :sort_by, sort_by_options, :id, :name, label: { text: "Sort by" }, options: { selected: params[:sort_by] } %>
+          </div>
+        </div>
+      <% end %>
+      <% if @records.any? %>
+        <p class="govuk-body"><% if @records_count == 1 %>There is currently 1 business.<% else %>There are currently <%= @records_count %> businesses.<% end %></p>
+        <%=
+          govuk_table do |table|
+            table.with_head do |head|
+              head.with_row do |row|
+                row.with_cell(text: "Business name")
+                row.with_cell(text: "Companies House number")
+                row.with_cell(text: "Address")
+                row.with_cell(text: "<span class=\"govuk-visually-hidden\">Select business</span>".html_safe)
+              end
+            end
+
+            table.with_body do |body|
+              @records.each do |record|
+                addresses = if record.locations.size > 4
+                              "Multiple addresses (#{record.locations.size})"
+                            else
+                              record.locations.map do |location|
+                                [location.address_line_1, location.address_line_2, location.city, location.county, location.postal_code, country_from_code(location.country)].reject(&:blank?).join(", ")
+                              end.join("<hr class=\"govuk-section-break govuk-section-break--m govuk-section-break--visible\">")
+                            end
+
+                select_button = form_with url: "#{wizard_path}?business_id=#{record.id}", method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+                  f.govuk_submit "Select", name: "draft", value: true, secondary: true
+                end
+
+                body.with_row do |row|
+                  row.with_cell(text: record.trading_name)
+                  row.with_cell(text: record.company_number)
+                  row.with_cell(text: addresses.html_safe)
+                  if @existing_business_ids.include?(record.id)
+                    row.with_cell(text: "")
+                  else
+                    row.with_cell(text: select_button)
+                  end
+                end
+              end
+            end
+          end
+        %>
+        <%= govuk_pagination(pagy: @pagy) %>
+      <% else %>
+        <p class="govuk-body">
+          <%= "There are no business records." unless @search_query.present? %>
+          <%= "There are no business records for \"#{@search_query}\"." if @search_query.present? %>
+        </p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -11,7 +11,7 @@
       </div>
       <% unless @manage %>
         <div class="govuk-grid-column-one-third govuk-!-text-align-right">
-          <%= govuk_button_link_to "Add a product", new_product_path(notification_pretty_id: @notification.pretty_id), secondary: true %>
+          <%= govuk_button_link_to "Add a new product", new_product_path(notification_pretty_id: @notification.pretty_id), secondary: true %>
         </div>
       <% end %>
     </div>
@@ -76,7 +76,7 @@
                 <div class="govuk-grid-column-two-thirds">
                   <div class="moj-search">
                     <div class="govuk-form-group">
-                      <label for="q-field" class="govuk-label moj-search__label">Search</label>
+                      <label for="q-field" class="govuk-label moj-search__label">Search by product name, description or PSD reference</label>
                       <input id="q-field" class="govuk-input moj-search__input" aria-describedby="q-hint" type="search" name="q" value="<%= params[:q] %>">
                     </div>
                     <button type="submit" formnovalidate="formnovalidate" class="govuk-button moj-search__button" data-module="govuk-button" data-prevent-double-click="true">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,12 +407,14 @@ en:
           business_details:
             title: Add businesses and their roles in the supply chain
             tasks:
+              search_for_or_add_a_business:
+                title: Search for or add a business
               add_business_details:
                 title: Add the type and details of the business
-              add_location:
-                title: Add addresses
-              add_contact:
-                title: Add contact details
+              add_business_location:
+                title: Add business addresses
+              add_business_contact:
+                title: Add business contact details
           evidence:
             title: Add evidence
             tasks:
@@ -895,6 +897,14 @@ en:
             corrective_action_not_taken_reason:
               blank: Enter the reason for not taking a corrective action
               too_long: The reason for not taking a corrective action must be %{count} characters or less
+        add_business_details_form:
+          attributes:
+            trading_name:
+              blank: Enter a trading name
+        add_location_form:
+          attributes:
+            country:
+              blank: Choose a country
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,8 @@ Rails.application.routes.draw do
             get "add-product/:product_id", to: "create#add_product", as: "add_product"
             get "remove-product/:investigation_product_id", to: "create#remove_product", as: "remove_product"
             delete "remove-product/:investigation_product_id", to: "create#remove_product"
+            get "remove-business/:investigation_business_id", to: "create#remove_business", as: "remove_business"
+            delete "remove-business/:investigation_business_id", to: "create#remove_business"
             get "confirmation", to: "create#confirmation"
 
             %w[batch_numbers customs_codes ucr_numbers number_of_affected_units].each do |identifier|

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     visit "/notifications/create"
 
     click_link "Search for or add a product"
-    click_link "Add a product"
+    click_link "Add a new product"
 
     select new_product_attributes[:category], from: "Product category"
 
@@ -138,11 +138,8 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_selector(:id, "task-list-1-2-status", text: "Completed")
     expect(page).to have_content("You have completed 2 of 6 sections.")
 
-    expect(page).to have_selector(:id, "task-list-2-0-status", text: "Not yet started")
-    expect(page).to have_selector(:id, "task-list-2-1-status", text: "Cannot start yet")
-    expect(page).to have_selector(:id, "task-list-2-2-status", text: "Cannot start yet")
-
-    click_link "Add the type and details of the business"
+    click_link "Search for or add a business"
+    click_link "Add a new business"
     fill_in "Trading name", with: "Trading name"
     fill_in "Registered or legal name (optional)", with: "Legal name"
     click_button "Save and continue"
@@ -162,8 +159,6 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_button "Save and complete tasks in this section"
 
     expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")
-    expect(page).to have_selector(:id, "task-list-2-1-status", text: "Completed")
-    expect(page).to have_selector(:id, "task-list-2-2-status", text: "Completed")
     expect(page).to have_content("You have completed 3 of 6 sections.")
 
     # Ensure that all of section 4 and the first task of section are enabled once section 3 is completed

--- a/spec/services/task_list_service_spec.rb
+++ b/spec/services/task_list_service_spec.rb
@@ -64,7 +64,7 @@ describe TaskListService do
     end
 
     context "when there are hidden tasks" do
-      let(:hidden_tasks) { [ { adjust: :setup }, { frobnicate: :tweak } ] }
+      let(:hidden_tasks) { [{ adjust: :setup }, { frobnicate: :tweak }] }
       let(:optional_tasks) { [] }
 
       context "when the supplied task is a hidden task" do

--- a/spec/services/task_list_service_spec.rb
+++ b/spec/services/task_list_service_spec.rb
@@ -64,40 +64,22 @@ describe TaskListService do
     end
 
     context "when there are hidden tasks" do
-      let(:hidden_tasks) { %i[read_manual adjust frobnicate] }
+      let(:hidden_tasks) { [ { adjust: :setup }, { frobnicate: :tweak } ] }
       let(:optional_tasks) { [] }
 
-      context "when the supplied task is a mandatory one" do
-        let(:task) { :percussive_maintenance }
-
-        it "returns the previous mandatory task" do
-          expect(result).to eq(:tweak)
-        end
-      end
-
-      context "when the supplied task is the first mandatory one" do
-        let(:task) { :setup }
-
-        it "returns nil" do
-          expect(result).to be_nil
-        end
-      end
-
-      context "when the supplied task is an optional one" do
-        let(:task) { :frobnicate }
-
-        it "returns the previous mandatory task" do
-          expect(result).to eq(:tweak)
-        end
-      end
-
-      context "when there are no mandatory tasks before the supplied task" do
-        let(:hidden_tasks) { %i[read_manual setup tweak] }
-        let(:optional_tasks) { [] }
+      context "when the supplied task is a hidden task" do
         let(:task) { :adjust }
 
-        it "returns nil" do
-          expect(result).to be_nil
+        it "returns the supplied previous task" do
+          expect(result).to eq(:setup)
+        end
+      end
+
+      context "when the supplied task is not a hidden task" do
+        let(:task) { :setup }
+
+        it "returns the previous task" do
+          expect(result).to eq(:read_manual)
         end
       end
     end

--- a/spec/services/task_list_service_spec.rb
+++ b/spec/services/task_list_service_spec.rb
@@ -2,20 +2,21 @@ require "rails_helper"
 
 describe TaskListService do
   describe ".previous_task" do
-    subject(:result) { described_class.previous_task(task:, all_tasks:, optional_tasks:) }
+    subject(:result) { described_class.previous_task(task:, all_tasks:, optional_tasks:, hidden_tasks:) }
 
-    let(:all_tasks) { %w[read_manual setup tweak adjust frobnicate percussive_maintenance submission evaluation] }
+    let(:all_tasks) { %i[read_manual setup tweak adjust frobnicate percussive_maintenance submission evaluation] }
 
-    context "when there are no optional tasks" do
+    context "when there are no optional or hidden tasks" do
       let(:optional_tasks) { [] }
-      let(:task) { "adjust" }
+      let(:hidden_tasks) { [] }
+      let(:task) { :adjust }
 
       it "returns the previous task" do
-        expect(result).to eq("tweak")
+        expect(result).to eq(:tweak)
       end
 
       context "when the supplied task is the first one" do
-        let(:task) { "read_manual" }
+        let(:task) { :read_manual }
 
         it "returns nil" do
           expect(result).to be_nil
@@ -24,18 +25,19 @@ describe TaskListService do
     end
 
     context "when there are optional tasks" do
-      let(:optional_tasks) { %w[read_manual adjust frobnicate] }
+      let(:optional_tasks) { %i[read_manual adjust frobnicate] }
+      let(:hidden_tasks) { [] }
 
       context "when the supplied task is a mandatory one" do
-        let(:task) { "percussive_maintenance" }
+        let(:task) { :percussive_maintenance }
 
         it "returns the previous mandatory task" do
-          expect(result).to eq("tweak")
+          expect(result).to eq(:tweak)
         end
       end
 
       context "when the supplied task is the first mandatory one" do
-        let(:task) { "setup" }
+        let(:task) { :setup }
 
         it "returns nil" do
           expect(result).to be_nil
@@ -43,16 +45,56 @@ describe TaskListService do
       end
 
       context "when the supplied task is an optional one" do
-        let(:task) { "frobnicate" }
+        let(:task) { :frobnicate }
 
         it "returns the previous mandatory task" do
-          expect(result).to eq("tweak")
+          expect(result).to eq(:tweak)
         end
       end
 
       context "when there are no mandatory tasks before the supplied task" do
-        let(:optional_tasks) { %w[read_manual setup tweak] }
-        let(:task) { "adjust" }
+        let(:optional_tasks) { %i[read_manual setup tweak] }
+        let(:hidden_tasks) { [] }
+        let(:task) { :adjust }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context "when there are hidden tasks" do
+      let(:hidden_tasks) { %i[read_manual adjust frobnicate] }
+      let(:optional_tasks) { [] }
+
+      context "when the supplied task is a mandatory one" do
+        let(:task) { :percussive_maintenance }
+
+        it "returns the previous mandatory task" do
+          expect(result).to eq(:tweak)
+        end
+      end
+
+      context "when the supplied task is the first mandatory one" do
+        let(:task) { :setup }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "when the supplied task is an optional one" do
+        let(:task) { :frobnicate }
+
+        it "returns the previous mandatory task" do
+          expect(result).to eq(:tweak)
+        end
+      end
+
+      context "when there are no mandatory tasks before the supplied task" do
+        let(:hidden_tasks) { %i[read_manual setup tweak] }
+        let(:optional_tasks) { [] }
+        let(:task) { :adjust }
 
         it "returns nil" do
           expect(result).to be_nil


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-1999

## Description

Adds a business search option for the notification task list to add existing busiesses to a notification. Also allows a new business to be added and cleans up the presentation of this option.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-19 at 11 30 58](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/f6c38e38-6ea7-4874-ba78-1d383a4c96a6)

## Review apps

https://psd-pr-2931.london.cloudapps.digital/
https://psd-pr-2931-support.london.cloudapps.digital/
https://psd-pr-2931-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
