### PR TITLE
add business roles page

### DIFF
--- a/app/forms/add_business_roles_form.rb
+++ b/app/forms/add_business_roles_form.rb
@@ -1,0 +1,33 @@
+class AddBusinessRolesForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :roles, array: true
+  attribute :online_marketplace_id
+  attribute :new_online_marketplace_name
+  attribute :authorised_representative_choice
+  attribute :business_id
+
+  validate :online_marketplace_or_other
+  validate :online_marketplace_provided
+  validate :only_allowed_business_types
+  validates :authorised_representative_choice, inclusion: { in: %w[uk_authorised_representative eu_authorised_representative] }, if: -> { roles.include?("authorised_representative") }
+
+private
+
+  def online_marketplace_or_other
+    errors.add(:roles, "Choose either online marketplace or another role") if roles.include?("online_marketplace") && roles.count > 1
+  end
+
+  def only_allowed_business_types
+    errors.add(:roles, "Please select at least one role") unless (roles.compact_blank! - Business::BUSINESS_TYPES).empty?
+  end
+
+  def online_marketplace_provided
+    return true unless roles.include?("online_marketplace")
+
+    errors.add(:online_marketplace_id, "Please select an online marketplace") unless online_marketplace_id.present? || new_online_marketplace_name.present?
+    errors.add(:online_marketplace_id, "Please select an existing online marketplace or a new online marketplace") if online_marketplace_id.present? && new_online_marketplace_name.present?
+  end
+end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -5,7 +5,7 @@ class Investigation < ApplicationRecord
     TASK_LIST_SECTIONS = {
       "product" => %i[search_for_or_add_a_product],
       "notification_details" => %i[add_notification_details add_product_safety_and_compliance_details add_product_identification_details],
-      "business_details" => %i[search_for_or_add_a_business add_business_details add_business_location add_business_contact],
+      "business_details" => %i[search_for_or_add_a_business add_business_details add_business_roles add_business_location add_business_contact],
       "evidence" => %i[add_test_reports add_supporting_images add_supporting_documents add_risk_assessments determine_notification_risk_level],
       "corrective_actions" => %i[record_a_corrective_action],
       "submit" => %i[check_notification_details_and_submit]

--- a/app/services/change_business_roles.rb
+++ b/app/services/change_business_roles.rb
@@ -1,0 +1,42 @@
+class ChangeBusinessRoles
+  include Interactor
+
+  delegate :roles, :online_marketplace_id, :new_online_marketplace_name, :authorised_representative_choice, :notification, :business, :user, to: :context
+
+  def call
+    context.fail!(error: "No roles supplied") unless roles.is_a?(Array)
+
+    ActiveRecord::Base.transaction do
+      InvestigationBusiness.where(business:, investigation: notification, relationship: roles_to_be_deleted).destroy_all
+
+      roles_to_be_added.each do |role|
+        if role == "online_marketplace"
+          if online_marketplace_id
+            InvestigationBusiness.create!(business:, investigation: notification, relationship: role, online_marketplace_id:)
+          elsif new_online_marketplace_name
+            new_online_marketplace = OnlineMarketplace.create!(name: new_online_marketplace_name, approved_by_opss: false)
+            InvestigationBusiness.create!(business:, investigation: notification, relationship: role, online_marketplace: new_online_marketplace)
+          end
+        elsif role == "authorised_representative"
+          InvestigationBusiness.create!(business:, investigation: notification, relationship: authorised_representative_choice)
+        else
+          InvestigationBusiness.create!(business:, investigation: notification, relationship: role)
+        end
+      end
+    end
+  end
+
+private
+
+  def roles_to_be_deleted
+    existing_roles - roles.compact_blank!
+  end
+
+  def roles_to_be_added
+    roles.compact_blank! - existing_roles
+  end
+
+  def existing_roles
+    InvestigationBusiness.where(business:, investigation: notification).pluck(:relationship)
+  end
+end

--- a/app/views/notifications/create/add_business_roles.html.erb
+++ b/app/views/notifications/create/add_business_roles.html.erb
@@ -1,0 +1,42 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.add_business_roles.title"), errors: @add_business_roles_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @add_business_roles_form, url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+        <%= t("notifications.create.index.sections.business_details.tasks.add_business_roles.title") %>
+      </h1>
+      <div class="govuk-hint" id="add-business-roles-form-roles-hint">You can select more than one option except for online marketplace.</div>
+      <%= f.govuk_check_boxes_fieldset :roles, legend: nil, hint: { text: "You can select more than one option except for online marketplace." } do %>
+        <%= f.govuk_check_box :roles, :retailer, label: { text: t("investigations.business_types.new.types.retailer.label") }, hint:{ text: "This includes traditional retailers and retailers selling directly to customers via their own online presence." } %>
+        <%= f.govuk_check_box :roles, :online_seller, label: { text: t("investigations.business_types.new.types.online_seller.label") }, hint:{ text: "This includes businesses primarily selling products to end users via an online marketplace such as Amazon." }%>
+        <% (Business::BUSINESS_TYPES - ["retailer", "online_seller", "online_marketplace", "authorised_representative", "responsible_person"]).each do |role| %>
+          <%= f.govuk_check_box :roles, role.to_sym, label: { text: t("investigations.business_types.new.types.#{role}.label") } %>
+        <% end %>
+        <%= f.govuk_check_box :roles, :authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.label") } do %>
+          <%= f.govuk_radio_button :authorised_representative, :uk_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.uk.label") } %>
+          <%= f.govuk_radio_button :authorised_representative, :eu_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.eu.label") } %>
+        <% end %>
+        <%= f.govuk_check_box :roles, :responsible_person, label: { text: t("investigations.business_types.new.types.responsible_person.label") } %>
+        <div class="govuk-checkboxes__divider">or</div>
+        <%= f.govuk_check_box :roles, :online_marketplace, label: { text: t("investigations.business_types.new.types.online_marketplace.label") } do %>
+          <% OnlineMarketplace.approved.each_slice(2) do |slice| %>
+            <div class="govuk-grid-row">
+              <% slice.each do |online_marketplace| %>
+                <div class="govuk-grid-column-one-half">
+                  <%= f.govuk_radio_button :online_marketplace_id, online_marketplace.id, label: { text: online_marketplace.name } %>
+                </div>
+              <% end %>
+            </div>
+            <div class="govuk-checkboxes__divider"></div>
+            <% end %>
+          <%= f.govuk_text_field :new_marketplace_name, label: { text: "Other online platform" }, width: "two-thirds" %>
+        <% end %>
+        <%= f.hidden_field :business_id %>
+        <%= f.govuk_submit "Save and continue" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,6 +411,8 @@ en:
                 title: Search for or add a business
               add_business_details:
                 title: Add the type and details of the business
+              add_business_roles:
+                title: Add the business's role
               add_business_details_duplicate:
                 title: We found a similar business
               add_business_location:

--- a/db/migrate/20240221161301_remove_uniqueness_constraint_for_investigation_businesses.rb
+++ b/db/migrate/20240221161301_remove_uniqueness_constraint_for_investigation_businesses.rb
@@ -1,0 +1,34 @@
+class RemoveUniquenessConstraintForInvestigationBusinesses < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :investigation_businesses, column: %i[investigation_id business_id]
+    add_index :investigation_businesses, %i[investigation_id business_id], algorithm: :concurrently
+  end
+
+  def down
+    remove_index :investigation_businesses, column: %i[investigation_id business_id]
+    results = execute <<-SQL
+    SELECT dups.id_groups
+      FROM
+        (SELECT  array_agg(ib.id) AS id_groups
+        FROM investigation_businesses ib
+        WHERE EXISTS
+          (
+          SELECT 1
+          FROM investigation_businesses tmp
+          WHERE tmp.business_id = ib.business_id
+          LIMIT 1
+          OFFSET 1
+         )
+        GROUP BY ib.investigation_id
+    ) AS dups
+    SQL
+
+    results.each do |id_array|
+      InvestigationBusiness.where(id: id_array[1..]).delete_all
+    end
+
+    add_index :investigation_businesses, %i[investigation_id business_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_144317) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_21_161301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -253,7 +253,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_144317) do
     t.string "relationship"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["business_id"], name: "index_investigation_businesses_on_business_id"
-    t.index ["investigation_id", "business_id"], name: "index_on_investigation_id_and_business_id", unique: true
+    t.index ["investigation_id", "business_id"], name: "idx_on_investigation_id_business_id_8346809cb6"
     t.index ["investigation_id"], name: "index_investigation_businesses_on_investigation_id"
   end
 

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -144,6 +144,9 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     fill_in "Registered or legal name (optional)", with: "Legal name"
     click_button "Save and continue"
 
+    check "Retailer"
+    click_button "Save and continue"
+
     fill_in "Address line 1", with: "123 Fake St"
     fill_in "Address line 2", with: "Fake Heath"
     fill_in "Town or city", with: "Faketon"

--- a/spec/forms/add_business_roles_form_spec.rb
+++ b/spec/forms/add_business_roles_form_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe AddBusinessRolesForm, :with_stubbed_mailer do
+  subject(:form) { described_class.new(add_business_roles_form_params) }
+
+  let(:add_business_roles_form_params) { { roles:, online_marketplace_id:, new_online_marketplace_name:, authorised_representative_choice: } }
+  let(:roles) { Business::BUSINESS_TYPES - %w[online_marketplace authorised_representative] }
+  let(:online_marketplace_id) { nil }
+  let(:new_online_marketplace_name) { nil }
+  let(:authorised_representative_choice) { nil }
+  let(:online_marketplace) { create(:online_marketplace) }
+
+  describe "validations" do
+    context "with valid params" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when authorised_representative is selected" do
+      let(:roles) { %w[authorised_representative] }
+
+      context "when a valid authorised_representative_choice is selected" do
+        let(:authorised_representative_choice) { "uk_authorised_representative" }
+
+        it "is valid" do
+          expect(form).to be_valid
+        end
+      end
+
+      context "when an invalid authorised_representative_choice is selected" do
+        let(:authorised_representative_choice) { "non_authorised_representative" }
+
+        it "is not valid" do
+          expect(form).not_to be_valid
+        end
+      end
+    end
+
+    context "when online_marketplace is included" do
+      context "when it is the sole business type" do
+        let(:roles) { %w[online_marketplace] }
+
+        context "when no online_marketplace_id or new_online_marketplace_name is provided" do
+          it "is not valid" do
+            expect(form).not_to be_valid
+          end
+        end
+
+        context "when an existing online marketplace id is provided" do
+          let(:online_marketplace_id) { online_marketplace.id }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "when an existing online marketplace id and new online marketplace name are provided" do
+          let(:online_marketplace_id) { online_marketplace.id }
+          let(:new_online_marketplace_name) { "New online marketplace" }
+
+          it "is not valid" do
+            expect(form).not_to be_valid
+          end
+        end
+
+        context "when a new online marketplace name is provided" do
+          let(:new_online_marketplace_name) { "New online marketplace" }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+      end
+
+      context "when it is one of many business types" do
+        let(:roles) { %w[online_marketplace retailer] }
+
+        it "is not valid" do
+          expect(form).not_to be_valid
+        end
+      end
+    end
+
+    context "when only allowed business types are included" do
+      let(:roles) { %w[bad_type] }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/change_business_roles_spec.rb
+++ b/spec/services/change_business_roles_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe ChangeBusinessRoles, :with_test_queue_adapter do
+  subject(:result) { described_class.call!(roles:, online_marketplace_id:, new_online_marketplace_name:, authorised_representative_choice:, notification:, business:, user:) }
+
+  let!(:notification) { create(:notification, creator: user) }
+  let!(:business) { create(:business) }
+  let(:roles) { %w[retailer manufacturer] }
+  let(:online_marketplace_id) { nil }
+  let(:online_marketplace) { create(:online_marketplace, :approved) }
+  let(:new_online_marketplace_name) { nil }
+  let(:authorised_representative_choice) { nil }
+  let(:user) { create(:user, :activated) }
+
+  context "with no roles" do
+    subject(:result) { described_class.call(notification:, business:, user:) }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with allowed roles" do
+    it "passes" do
+      expect(result).not_to be_failure
+    end
+  end
+
+  context "with roles to be removed" do
+    before { InvestigationBusiness.create(business:, investigation: notification, relationship: "exporter") }
+
+    it "correctly removes the roles" do
+      expect(InvestigationBusiness.where(business:, investigation: notification).pluck(:relationship)).to match(%w[exporter])
+
+      result
+
+      expect(InvestigationBusiness.where(business:, investigation: notification).pluck(:relationship)).to match_array(roles)
+    end
+  end
+
+  context "with roles to be added" do
+    before { InvestigationBusiness.create(business:, investigation: notification, relationship: "retailer") }
+
+    it "correctly removes the roles" do
+      expect(InvestigationBusiness.where(business:, investigation: notification).pluck(:relationship)).to match(%w[retailer])
+
+      result
+
+      expect(InvestigationBusiness.where(business:, investigation: notification).pluck(:relationship)).to match_array(roles)
+    end
+  end
+
+  context "when adding an online marketplace" do
+    let(:roles) { %w[online_marketplace] }
+
+    context "with an existing online_marketplace_id" do
+      let(:online_marketplace_id) { online_marketplace.id }
+
+      it "creates a new InvestigationBusiness with that online marketplace" do
+        expect {
+          result
+        }.to change(InvestigationBusiness.where(business:, investigation: notification, relationship: "online_marketplace", online_marketplace_id:), :count).by(1)
+      end
+    end
+
+    context "with a new_online_marketplace_name" do
+      let(:new_online_marketplace_name) { "New online marketplace" }
+
+      it "creates a new, unapproved online marketplace" do
+        expect {
+          result
+        }.to change(OnlineMarketplace.where(approved_by_opss: false), :count).by(1)
+      end
+
+      it "creates a new InvestigationBusiness with that online marketplace" do
+        expect {
+          result
+        }.to change(InvestigationBusiness.where(business:, investigation: notification, relationship: "online_marketplace"), :count).by(1)
+      end
+    end
+  end
+
+  context "with role of authorised representative" do
+    let(:roles) { %w[authorised_representative] }
+    let(:authorised_representative_choice) { "uk_authorised_representative" }
+
+    it "created a new InvestigatuonBusiness with the correct relationship" do
+      expect {
+        result
+      }.to change(InvestigationBusiness.where(business:, investigation: notification, relationship: "uk_authorised_representative"), :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add business roles for a notification

## Screen-shots or screen-capture of UI changes
![Screenshot 2024-02-22 at 13-04-20 Add the business's role - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/de318325-a13f-4592-83b1-1038419b26e6)
![Screenshot 2024-02-22 at 13-04-44 Error Add the business's role - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/ec88b4ff-ab3e-4016-a068-ad7181f9b6ac)

## Review apps

https://psd-pr-2937.london.cloudapps.digital/
https://psd-pr-2937-support.london.cloudapps.digital/
https://psd-pr-2937-report.london.cloudapps.digital/


## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
