### PR TITLE
Change “product hazard” to “product harm”

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -104,7 +104,7 @@ module Notifications
     end
 
     def specific_product_safety_issues
-      unsafe = "<p class=\"govuk-body\">Product hazard: #{@notification.hazard_type}</p><p class=\"govuk-body-s\">#{@notification.hazard_description}</p>" if @notification.unsafe? || @notification.unsafe_and_non_compliant?
+      unsafe = "<p class=\"govuk-body\">Product harm: #{@notification.hazard_type}</p><p class=\"govuk-body-s\">#{@notification.hazard_description}</p>" if @notification.unsafe? || @notification.unsafe_and_non_compliant?
       non_compliant = "<p class=\"govuk-body\">Product incomplete markings, labeling or other issues</p><p class=\"govuk-body-s\">#{@notification.non_compliant_reason}</p>" if @notification.non_compliant? || @notification.unsafe_and_non_compliant?
       [unsafe, non_compliant].join
     end

--- a/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
+++ b/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
@@ -18,9 +18,9 @@
       <% end %>
       <% unless @notification.reported_reason&.safe_and_compliant? %>
         <%= f.govuk_check_boxes_fieldset :unsafe, multiple: false, legend: { text: "What specific issues make the #{'product'.pluralize(@notification.products.count)} unsafe or non-compliant?", size: "m" }, hint: { text: "Please select all applicable issues." } do %>
-          <%= f.govuk_check_box :unsafe, true, false, multiple: false, link_errors: true, label: { text: "Product hazard" } do %>
-            <%= f.govuk_collection_select :primary_hazard, hazards_options, :id, :name, label: { text: "What is the primary hazard?" } %>
-            <%= f.govuk_text_area :primary_hazard_description, label: { text: "Provide additional information about the product hazard" }, hint: { text: "If the product has been involved in an incident include this additional information." }, max_chars: 10_000 %>
+          <%= f.govuk_check_box :unsafe, true, false, multiple: false, link_errors: true, label: { text: "Product harm" } do %>
+            <%= f.govuk_collection_select :primary_hazard, hazards_options, :id, :name, label: { text: "What is the primary harm?" } %>
+            <%= f.govuk_text_area :primary_hazard_description, label: { text: "Provide additional information about the product harm" }, hint: { text: "If the product has been involved in an incident include this additional information." }, max_chars: 10_000 %>
           <% end %>
           <%= f.govuk_check_box :noncompliant, true, false, multiple: false, label: { text: "Product incomplete markings, labeling or other issues" } do %>
             <%= f.govuk_text_area :noncompliance_description, label: { text: "Describe the product non-compliance issues" }, max_chars: 10_000 %>

--- a/app/views/notifications/create/add_supporting_documents.html.erb
+++ b/app/views/notifications/create/add_supporting_documents.html.erb
@@ -16,7 +16,7 @@
         <% end %>
         </ul>
       <% end %>
-      <p class="govuk-body">To provide proof of the product hazard or accident, you can upload supporting documents with your notification.</p>
+      <p class="govuk-body">To provide proof of the product harm or accident, you can upload supporting documents with your notification.</p>
       <%= f.govuk_text_field :title, label: { text: "Document title", size: "s" } %>
       <%= f.govuk_file_field :document, label: nil, hint: { text: "Maximum file size: 100MB." } %>
       <%= f.govuk_submit "Upload document", secondary: true %>

--- a/app/views/notifications/create/add_supporting_images.html.erb
+++ b/app/views/notifications/create/add_supporting_images.html.erb
@@ -16,7 +16,7 @@
         <% end %>
         </ul>
       <% end %>
-      <p class="govuk-body">To provide visual evidence of the product hazard or incident/accident, you can upload either a single image or multiple images to the notification.</p>
+      <p class="govuk-body">To provide visual evidence of the product harm or incident/accident, you can upload either a single image or multiple images to the notification.</p>
       <%= f.hidden_field :file_upload, value: "" %>
       <%= f.govuk_file_field :file_upload, label: nil, hint: { text: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF. Maximum file size: 100MB." } %>
       <%= f.govuk_submit "Upload image", secondary: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -865,10 +865,10 @@ en:
             unsafe:
               blank: Choose at least one issue
             primary_hazard:
-              blank: Choose the primary hazard
+              blank: Choose the primary harm
             primary_hazard_description:
-              blank: Enter additional information about the product hazard
-              too_long: Additional information about the product hazard must be %{count} characters or less
+              blank: Enter additional information about the product harm
+              too_long: Additional information about the product harm must be %{count} characters or less
             noncompliance_description:
               blank: Enter a description of the product non-compliance issues
               too_long: Description of the product non-compliance issues must be %{count} characters or less

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -111,9 +111,9 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_button "Save and continue"
 
     within_fieldset "What specific issues make the product unsafe or non-compliant?" do
-      check "Product hazard"
-      select "Chemical", from: "What is the primary hazard?"
-      fill_in "Provide additional information about the product hazard", with: "Fake description"
+      check "Product harm"
+      select "Chemical", from: "What is the primary harm?"
+      fill_in "Provide additional information about the product harm", with: "Fake description"
     end
 
     within_fieldset "Was the safety issue reported by an overseas regulator?" do


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2438

## Description

Changes all instances of “product hazard” to “product harm” in the notification task list.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2939.london.cloudapps.digital/
https://psd-pr-2939-support.london.cloudapps.digital/
https://psd-pr-2939-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
