### PR TITLE
Mark task as “in progress” when saving as draft

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -541,7 +541,7 @@ module Notifications
         return render_wizard unless @notification.ready_to_submit? || params[:draft] == "true"
       end
 
-      @notification.tasks_status[step.to_s] = "completed"
+      @notification.tasks_status[step.to_s] = params[:draft] == "true" ?  "in_progress" : "completed"
 
       if params[:draft] == "true" || params[:final] == "true"
         # "Save as draft" or final save button of the section clicked.

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -230,6 +230,7 @@ module Notifications
         if params[:add_another_product].blank?
           product = Product.find(params[:product_id])
           AddProductToNotification.call!(notification: @notification, product:, user: current_user, skip_email: true)
+          return redirect_to wizard_path(:search_for_or_add_a_product)
         end
       when :add_notification_details
         @change_notification_details_form = ChangeNotificationDetailsForm.new(add_notification_details_params.merge(current_user:, notification_id: @notification.id))
@@ -310,6 +311,7 @@ module Notifications
         if params[:add_another_business].blank?
           business = Business.find(params[:business_id])
           AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
+          return redirect_to wizard_path(:search_for_or_add_a_business)
         end
       when :add_business_details
         @add_business_details_form = AddBusinessDetailsForm.new(add_business_details_params)

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -541,7 +541,7 @@ module Notifications
         return render_wizard unless @notification.ready_to_submit? || params[:draft] == "true"
       end
 
-      @notification.tasks_status[step.to_s] = params[:draft] == "true" ?  "in_progress" : "completed"
+      @notification.tasks_status[step.to_s] = params[:draft] == "true" ? "in_progress" : "completed"
 
       if params[:draft] == "true" || params[:final] == "true"
         # "Save as draft" or final save button of the section clicked.

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -99,6 +99,12 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_link "Search for or add a product"
     click_button "Select", match: :first
 
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
     expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
     expect(page).to have_content("You have completed 1 of 6 sections.")
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2440

## Description

Changes the notifications task list to show tasks as “in progress” rather than “completed” when “save as draft” is used rather than “save and continue”.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2941.london.cloudapps.digital/
https://psd-pr-2941-support.london.cloudapps.digital/
https://psd-pr-2941-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
