### PR TITLE
Correctly select "no" for notification reference when revisiting the task

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -130,7 +130,7 @@ module Notifications
           noncompliance_description: @notification.non_compliant_reason,
           is_from_overseas_regulator: @notification.is_from_overseas_regulator,
           overseas_regulator_country: @notification.overseas_regulator_country,
-          add_reference_number: @notification.complainant_reference.present? ? true : nil,
+          add_reference_number: @notification.complainant_reference.nil? ? nil : @notification.complainant_reference.present?,
           reference_number: @notification.complainant_reference
         )
       when :add_number_of_affected_units


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2454

## Description

Correctly select "no" for notification reference when revisiting the task in the notification task list.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2942.london.cloudapps.digital/
https://psd-pr-2942-support.london.cloudapps.digital/
https://psd-pr-2942-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
