### PR TITLE
Add PSD reference to product search results

### DIFF
--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -107,7 +107,8 @@
                     details = <<~DETAILS.strip
                       <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0"><a href="#{product_path(record)}" class="govuk-link" target="_blank" rel="noreferrer noopener">#{record.name_with_brand}</a></p>
                       <p class="govuk-body-s govuk-!-margin-bottom-0"><strong>Category:</strong> #{record.category}</p>
-                      <p class="govuk-body-s govuk-!-margin-bottom-1"><strong>Sub-category:</strong> #{record.subcategory}</p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-0"><strong>Sub-category:</strong> #{record.subcategory}</p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-1"><strong>PSD reference:</strong> #{record.psd_ref}</p>
                       #{
                         if record.barcode.present? || record.product_code.present? || record.unformatted_description.present?
                           govuk_details(summary_text: "More details", classes: "govuk-!-font-size-16 govuk-!-margin-bottom-0") do


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2441

## Description

Adds the PSD reference to product search results in the notifications task list.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-23 at 11 40 03](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/674be603-726c-49f6-aba5-f70f4c7aed2e)

## Review apps

https://psd-pr-2943.london.cloudapps.digital/
https://psd-pr-2943-support.london.cloudapps.digital/
https://psd-pr-2943-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
