### PR TITLE
Exclude online marketplaces from notifications task list

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -154,10 +154,11 @@ module Notifications
                          .or(Business.where("businesses.legal_name ILIKE ?", "%#{@search_query}%"))
                          .or(Business.where("CONCAT(locations.address_line_1, ' ', locations.address_line_2, ' ', locations.city, ' ', locations.county, ' ', locations.country, ' ', locations.postal_code) ILIKE ?", "%#{@search_query}%"))
                          .or(Business.where(company_number: @search_query))
+                         .without_online_marketplaces
                          .distinct
                          .order(sort_by)
                      else
-                       Business.all.order(sort_by)
+                       Business.without_online_marketplaces.order(sort_by)
                      end
 
         @records_count = businesses.size
@@ -312,7 +313,7 @@ module Notifications
         return redirect_to wizard_path(:search_for_or_add_a_business) if params[:add_another_business].blank? && params[:final].present?
 
         if params[:add_another_business].blank?
-          business = Business.find(params[:business_id])
+          business = Business.without_online_marketplaces.find(params[:business_id])
           AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
           return redirect_to wizard_path(:search_for_or_add_a_business)
         end
@@ -325,6 +326,7 @@ module Notifications
           .or(Business.where(legal_name: nil))
           .or(Business.where(legal_name: ""))
           .where("LOWER(trading_name) = ?", @add_business_details_form.trading_name.downcase)
+          .without_online_marketplaces
           .order(Arel.sql("CASE WHEN legal_name IS NULL OR legal_name = '' THEN 1 ELSE 0 END"))
           .order(created_at: :desc)
           .limit(1)
@@ -352,7 +354,7 @@ module Notifications
 
         return render_wizard unless @add_business_roles_form.valid?
 
-        business = Business.find(@add_business_roles_form.business_id)
+        business = Business.without_online_marketplaces.find(@add_business_roles_form.business_id)
 
         ChangeBusinessRoles.call!(
           notification: @notification,
@@ -610,7 +612,7 @@ module Notifications
         legal_name: params[:legal_name]
       )
 
-      @duplicate_business = Business.find(params[:business_id])
+      @duplicate_business = Business.without_online_marketplaces.find(params[:business_id])
 
       render :add_business_details_duplicate
     end
@@ -619,12 +621,12 @@ module Notifications
       @add_business_details_duplicate_form = AddBusinessDetailsDuplicateForm.new(add_business_details_duplicate_params)
 
       unless @add_business_details_duplicate_form.valid?
-        @duplicate_business = Business.find(params[:business_id])
+        @duplicate_business = Business.without_online_marketplaces.find(params[:business_id])
         return render :add_business_details_duplicate
       end
 
       if @add_business_details_duplicate_form.resolution == "existing_record"
-        business = Business.find(params[:business_id])
+        business = Business.without_online_marketplaces.find(params[:business_id])
 
         AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2455

## Description

Prevents online marketplaces from being searched for or added to a notification via the task list as a normal business.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
