### PR TITLE
Disallow associated business removal for notification task list

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -164,6 +164,7 @@ module Notifications
         @records_count = businesses.size
         @pagy, @records = pagy(businesses)
         @existing_business_ids = InvestigationBusiness.where(investigation: @notification).pluck(:business_id)
+        @existing_attached_business_ids = @notification.corrective_actions.pluck(:business_id) + @notification.risk_assessments.pluck(:assessed_by_business_id)
         @manage = request.query_string.split("&").first != "search" && @existing_business_ids.present?
       when :add_business_details
         @add_business_details_form = AddBusinessDetailsForm.new

--- a/app/views/notifications/create/search_for_or_add_a_business.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_business.html.erb
@@ -23,8 +23,8 @@
             govuk_summary_list do |summary_list|
               @notification.investigation_businesses.decorate.each do |investigation_business|
                 summary_list.with_row do |row|
-                  row.with_key(text: investigation_business.business.trading_name)
-                  row.with_action(text: "Remove", href: remove_business_notification_create_index_path(investigation_business_id: investigation_business.id), visually_hidden_text: "business from notification")
+                  row.with_key(text: "#{investigation_business.business.trading_name}#{@existing_attached_business_ids.include?(investigation_business.business_id) ? '<br><span class="govuk-hint govuk-!-font-size-16">This business cannot be removed because it is associated with a risk assessment or corrective action.</span>' : ''}".html_safe)
+                  row.with_action(text: "Remove", href: remove_business_notification_create_index_path(investigation_business_id: investigation_business.id), visually_hidden_text: "business from notification") unless @existing_attached_business_ids.include?(investigation_business.business_id)
                 end
               end
             end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2452

## Description

Don’t display a “remove” link for any business that is currently associated with at least one corrective action or risk assessment for the same notification.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-26 at 13 36 23](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/4caf02bd-669b-4ef6-8efa-30ba5dddd10d)

## Review apps

https://psd-pr-2950.london.cloudapps.digital/
https://psd-pr-2950-support.london.cloudapps.digital/
https://psd-pr-2950-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
