### PR TITLE
Add User-Agent header to DNS docs

### DIFF
--- a/doc/dns.md
+++ b/doc/dns.md
@@ -14,7 +14,7 @@ To add a new subdomain:
    the service including a section named "Showing status of last operation"
    that has a list of already-configured subdomains for the current
    environment
-1. Run `cf update-service opss-cdn-route -c '{"domain": "<domains>", "headers": ["Accept", "Authorization", "Referer", "Host"]}'`
+1. Run `cf update-service opss-cdn-route -c '{"domain": "<domains>", "headers": ["Accept", "Authorization", "Referer", "Host", "User-Agent"]}'`
    where `<domains>` is a comma-separated list of the domains from the
    previous step plus the new subdomain you want to add
 1. Run `cf service opss-cdn-route` again - the "Showing status of last operation"


### PR DESCRIPTION
## Description

Changes the DNS docs to include allowing the `User-Agent` header.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-2951.london.cloudapps.digital/
https://psd-pr-2951-support.london.cloudapps.digital/
https://psd-pr-2951-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
