### PR TITLE
add confirm business details page

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -362,7 +362,7 @@ module Notifications
         return redirect_to wizard_path(:search_for_or_add_a_business) if params[:add_another_business].blank? && params[:final].present?
 
         if params[:add_another_business].blank?
-          business = Business.without_online_marketplaces.where(id: params[:business_id])
+          business = Business.without_online_marketplaces.find(id: params[:business_id])
           AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
           return redirect_to wizard_path(:search_for_or_add_a_business)
         end

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -171,14 +171,57 @@ module Notifications
         @manage = request.query_string.split("&").first != "search" && @existing_business_ids.present?
         track_notification_event(name: "Show search for or add a business page")
       when :add_business_details
-        @add_business_details_form = AddBusinessDetailsForm.new
-        track_notification_event(name: "Create new business for notification")
+        business = if params[:business_id].present?
+                     Business.find(params[:business_id])
+                   else
+                     Business.new
+                   end
+
+        @add_business_details_form = AddBusinessDetailsForm.new(trading_name: business.trading_name, legal_name: business.legal_name, business_id: business.id)
+
+        if business.persisted?
+          track_notification_event(name: "Edit new business for notification")
+        else
+          track_notification_event(name: "Create new business for notification")
+        end
       when :add_business_roles
         @add_business_roles_form = AddBusinessRolesForm.new(business_id: params[:business_id])
       when :add_business_location
-        @add_location_form = AddLocationForm.new(business_id: params[:business_id])
+        location = if params[:location_id].present?
+                     Location.find(params[:location_id])
+                   else
+                     Location.new
+                   end
+
+        @add_location_form = AddLocationForm.new(
+          business_id: params[:business_id],
+          location_id: location.id,
+          address_line_1: location.address_line_1,
+          address_line_2: location.address_line_2,
+          city: location.city,
+          county: location.county,
+          country: location.country,
+          postal_code: location.postal_code
+        )
       when :add_business_contact
-        @add_contact_form = AddContactForm.new(business_id: params[:business_id])
+        contact = if params[:contact_id].present?
+                    Contact.find(params[:contact_id])
+                  else
+                    Contact.new
+                  end
+
+        @add_contact_form = AddContactForm.new(
+          business_id: params[:business_id],
+          contact_id: params[:contact_id],
+          name: contact.name,
+          email: contact.email,
+          job_title: contact.job_title,
+          phone_number: contact.phone_number
+        )
+      when :confirm_business_details
+        @business = Business.find(params[:business_id])
+        @locations = @business.locations
+        @contacts = @business.contacts
       when :add_test_reports
         investigation_products = @notification.investigation_products
         @existing_test_results = @notification.test_results.includes(investigation_product: :product)
@@ -319,30 +362,37 @@ module Notifications
         return redirect_to wizard_path(:search_for_or_add_a_business) if params[:add_another_business].blank? && params[:final].present?
 
         if params[:add_another_business].blank?
-          business = Business.without_online_marketplaces.find(params[:business_id])
+          business = Business.without_online_marketplaces.where(id: params[:business_id])
           AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
           return redirect_to wizard_path(:search_for_or_add_a_business)
         end
       when :add_business_details
         @add_business_details_form = AddBusinessDetailsForm.new(add_business_details_params)
 
-        # Find potential duplicate businesses by looking for the same trading name
-        # and preferring results with the same legal name too.
-        duplicate_business = Business.where("LOWER(legal_name) = ?", @add_business_details_form.legal_name.downcase)
-          .or(Business.where(legal_name: nil))
-          .or(Business.where(legal_name: ""))
-          .where("LOWER(trading_name) = ?", @add_business_details_form.trading_name.downcase)
-          .without_online_marketplaces
-          .order(Arel.sql("CASE WHEN legal_name IS NULL OR legal_name = '' THEN 1 ELSE 0 END"))
-          .order(created_at: :desc)
-          .limit(1)
-          .first
+        if add_business_details_params[:business_id].blank?
+          # Find potential duplicate businesses by looking for the same trading name
+          # and preferring results with the same legal name too.
+          duplicate_business = Business.where("LOWER(legal_name) = ?", @add_business_details_form.legal_name.downcase)
+            .or(Business.where(legal_name: nil))
+            .or(Business.where(legal_name: ""))
+            .where("LOWER(trading_name) = ?", @add_business_details_form.trading_name.downcase)
+            .without_online_marketplaces
+            .order(Arel.sql("CASE WHEN legal_name IS NULL OR legal_name = '' THEN 1 ELSE 0 END"))
+            .order(created_at: :desc)
+            .limit(1)
+            .first
 
-        return redirect_to duplicate_business_notification_create_index_path(@notification, business_id: duplicate_business.id, trading_name: @add_business_details_form.trading_name, legal_name: @add_business_details_form.legal_name) if duplicate_business.present?
+          return redirect_to duplicate_business_notification_create_index_path(@notification, business_id: duplicate_business.id, trading_name: @add_business_details_form.trading_name, legal_name: @add_business_details_form.legal_name) if duplicate_business.present?
+
+        end
 
         return render_wizard unless @add_business_details_form.valid?
 
-        business = Business.new
+        business = if add_business_details_params[:business_id].present?
+                     Business.find(add_business_details_params[:business_id])
+                   else
+                     Business.new
+                   end
 
         ChangeBusinessNames.call!(
           trading_name: @add_business_details_form.trading_name,
@@ -352,15 +402,64 @@ module Notifications
           business:
         )
 
-        AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
+        return redirect_to wizard_path(:confirm_business_details, business_id: add_business_details_params[:business_id]) if add_business_details_params[:business_id].present?
 
         additional_params = { business_id: business.id }
+      when :add_business_location
+        @add_location_form = AddLocationForm.new(add_location_params)
+
+        return render_wizard unless @add_location_form.valid?
+
+        if @add_location_form.location_id.present?
+          Location.find(@add_location_form.location_id).update!(add_location_params.except(:location_id))
+        else
+          Location.create!(
+            name: "Registered office address",
+            address_line_1: @add_location_form.address_line_1,
+            address_line_2: @add_location_form.address_line_2,
+            city: @add_location_form.city,
+            county: @add_location_form.county,
+            country: @add_location_form.country,
+            postal_code: @add_location_form.postal_code,
+            business_id: @add_location_form.business_id,
+            added_by_user_id: current_user.id
+          )
+        end
+
+        return redirect_to wizard_path(:confirm_business_details, business_id: @add_location_form.business_id) if @add_location_form.location_id.present?
+
+        additional_params = { business_id: @add_location_form.business_id }
+      when :add_business_contact
+        @add_contact_form = AddContactForm.new(add_contact_params)
+
+        return render_wizard unless @add_contact_form.valid?
+
+        if @add_contact_form.contact_id.present?
+          Contact.find(@add_contact_form.contact_id).update!(add_contact_params.except(:contact_id))
+        else
+          Contact.create!(
+            name: @add_contact_form.name,
+            job_title: @add_contact_form.job_title,
+            email: @add_contact_form.email,
+            phone_number: @add_contact_form.phone_number,
+            business_id: @add_contact_form.business_id,
+            added_by_user_id: current_user.id
+          )
+        end
+
+        return redirect_to wizard_path(:confirm_business_details, business_id: @add_contact_form.business_id) if @add_contact_form.contact_id.present?
+
+        additional_params = { business_id: @add_contact_form.business_id }
+      when :confirm_business_details
+        business = Business.find(confirm_business_details_params)
+        AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
+        additional_params = { business_id: confirm_business_details_params }
       when :add_business_roles
         @add_business_roles_form = AddBusinessRolesForm.new(add_business_roles_params)
 
         return render_wizard unless @add_business_roles_form.valid?
 
-        business = Business.without_online_marketplaces.find(@add_business_roles_form.business_id)
+        business = Business.without_online_marketplaces.where(id: @add_business_roles_form.business_id).first
 
         ChangeBusinessRoles.call!(
           notification: @notification,
@@ -370,39 +469,6 @@ module Notifications
           online_marketplace_id: @add_business_roles_form.online_marketplace_id,
           new_online_marketplace_name: @add_business_roles_form.new_online_marketplace_name,
           authorised_representative_choice: @add_business_roles_form.authorised_representative_choice
-        )
-
-        additional_params = { business_id: @add_business_roles_form.business_id }
-      when :add_business_location
-        @add_location_form = AddLocationForm.new(add_location_params)
-
-        return render_wizard unless @add_location_form.valid?
-
-        Location.create!(
-          name: "Registered office address",
-          address_line_1: @add_location_form.address_line_1,
-          address_line_2: @add_location_form.address_line_2,
-          city: @add_location_form.city,
-          county: @add_location_form.county,
-          country: @add_location_form.country,
-          postal_code: @add_location_form.postal_code,
-          business_id: @add_location_form.business_id,
-          added_by_user_id: current_user.id
-        )
-
-        additional_params = { business_id: @add_location_form.business_id }
-      when :add_business_contact
-        @add_contact_form = AddContactForm.new(add_contact_params)
-
-        return render_wizard unless @add_contact_form.valid?
-
-        Contact.create!(
-          name: @add_contact_form.name,
-          job_title: @add_contact_form.job_title,
-          email: @add_contact_form.email,
-          phone_number: @add_contact_form.phone_number,
-          business_id: @add_contact_form.business_id,
-          added_by_user_id: current_user.id
         )
 
         # Mark the task that's shown on the task list as complete to unlock the next task
@@ -991,11 +1057,15 @@ module Notifications
     end
 
     def add_business_details_params
-      params.require(:add_business_details_form).permit(:trading_name, :legal_name)
+      params.require(:add_business_details_form).permit(:trading_name, :legal_name, :business_id)
+    end
+
+    def confirm_business_details_params
+      params.require(:business_id)
     end
 
     def add_business_roles_params
-      params.require(:add_business_roles_form).permit(:online_marketplace_id, :new_online_marketplace_name, :authorised_representative_choice, :business_id, roles: [])
+      params.require(:add_business_roles_form).permit(:online_marketplace_id, :new_online_marketplace_name, :authorised_representative_choice, :business_id, :final, roles: [])
     end
 
     def add_business_details_duplicate_params
@@ -1003,11 +1073,11 @@ module Notifications
     end
 
     def add_location_params
-      params.require(:add_location_form).permit(:address_line_1, :address_line_2, :city, :county, :postal_code, :country, :business_id)
+      params.require(:add_location_form).permit(:address_line_1, :address_line_2, :city, :county, :postal_code, :country, :business_id, :location_id)
     end
 
     def add_contact_params
-      params.require(:add_contact_form).permit(:name, :job_title, :email, :phone_number, :business_id, :final)
+      params.require(:add_contact_form).permit(:name, :job_title, :email, :phone_number, :business_id, :contact_id)
     end
 
     def ucr_numbers_params

--- a/app/forms/add_business_details_form.rb
+++ b/app/forms/add_business_details_form.rb
@@ -5,6 +5,7 @@ class AddBusinessDetailsForm
 
   attribute :trading_name, :string
   attribute :legal_name, :string
+  attribute :business_id
 
   validates :trading_name, presence: true
 end

--- a/app/forms/add_contact_form.rb
+++ b/app/forms/add_contact_form.rb
@@ -8,4 +8,5 @@ class AddContactForm
   attribute :phone_number, :string
   attribute :email, :string
   attribute :business_id
+  attribute :contact_id
 end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -5,7 +5,7 @@ class Investigation < ApplicationRecord
     TASK_LIST_SECTIONS = {
       "product" => %i[search_for_or_add_a_product],
       "notification_details" => %i[add_notification_details add_product_safety_and_compliance_details add_number_of_affected_units],
-      "business_details" => %i[search_for_or_add_a_business add_business_details add_business_roles add_business_location add_business_contact],
+      "business_details" => %i[search_for_or_add_a_business add_business_details add_business_location add_business_contact confirm_business_details add_business_roles],
       "evidence" => %i[add_product_identification_details add_test_reports add_supporting_images add_supporting_documents add_risk_assessments determine_notification_risk_level],
       "corrective_actions" => %i[record_a_corrective_action],
       "submit" => %i[check_notification_details_and_submit]
@@ -18,7 +18,9 @@ class Investigation < ApplicationRecord
     TASK_LIST_TASKS_HIDDEN = [
       { add_business_details: :add_number_of_affected_units },
       { add_business_location: :add_number_of_affected_units },
-      { add_business_contact: :add_number_of_affected_units }
+      { add_business_contact: :add_number_of_affected_units },
+      { add_business_roles: :add_number_of_affected_units },
+      { confirm_business_details: :add_number_of_affected_units },
     ].freeze
 
     has_one :add_audit_activity,

--- a/app/views/notifications/create/add_business_contact.html.erb
+++ b/app/views/notifications/create/add_business_contact.html.erb
@@ -12,8 +12,9 @@
       <%= f.govuk_text_field :job_title, label: { text: "Job title or role description (optional)" }, width: "two-thirds" %>
       <%= f.govuk_text_field :email, label: { text: "Email (optional)" }, width: "two-thirds" %>
       <%= f.govuk_text_field :phone_number, label: { text: "Phone (optional)" }, hint: { text: "For international numbers include the country code." }, width: "two-thirds" %>
+      <%= f.hidden_field :contact_id %>
       <%= f.hidden_field :business_id %>
-      <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+      <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/notifications/create/add_business_details.html.erb
+++ b/app/views/notifications/create/add_business_details.html.erb
@@ -10,6 +10,7 @@
       </h1>
       <%= f.govuk_text_field :trading_name, label: { text: "Trading name" }, hint: { text: "The name the business is known as." }, width: "two-thirds" %>
       <%= f.govuk_text_field :legal_name, label: { text: "Registered or legal name (optional)" }, hint: { text: "As it appears on Companies House for UK businesses (usually ends in 'Ltd' or 'Limited')." }, width: "two-thirds" %>
+      <%= f.hidden_field :business_id %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>
   </div>

--- a/app/views/notifications/create/add_business_location.html.erb
+++ b/app/views/notifications/create/add_business_location.html.erb
@@ -14,6 +14,7 @@
       <%= f.govuk_text_field :county, label: { text: "County (optional)" }, width: "two-thirds" %>
       <%= f.govuk_text_field :postal_code, label: { text: "Post code (optional)" }, width: "two-thirds" %>
       <%= f.hidden_field :business_id %>
+      <%= f.hidden_field :location_id %>
       <%= f.govuk_collection_select :country,
             [OpenStruct.new(id: "", name: ""), OpenStruct.new(id: "Unknown", name: "Unknown")] + all_countries_with_uk_first.map { |country| OpenStruct.new(id: country[1], name: country[0]) },
             :id,

--- a/app/views/notifications/create/add_business_roles.html.erb
+++ b/app/views/notifications/create/add_business_roles.html.erb
@@ -35,7 +35,7 @@
           <%= f.govuk_text_field :new_marketplace_name, label: { text: "Other online platform" }, width: "two-thirds" %>
         <% end %>
         <%= f.hidden_field :business_id %>
-        <%= f.govuk_submit "Save and continue" %>
+        <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/notifications/create/confirm_business_details.html.erb
+++ b/app/views/notifications/create/confirm_business_details.html.erb
@@ -34,22 +34,26 @@
       <p><%= govuk_link_to "Add another address", wizard_path(:add_business_location, business_id: @business.id) %></p>
       <h2 class="govuk-heading-m">Contacts</h2>
 
-      <% @business.contacts.each do |contact| %>
-      <%=
-        govuk_summary_list do |summary_list|
-          summary_list.with_row do |row|
-            row.with_key(text: contact.name)
-            row.with_value(text: contact.email)
-            row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
-          end
-          summary_list.with_row do |row|
-            row.with_value(text: contact.job_title)
-            row.with_value(text: contact.phone_number)
-          end
-        end
-      %>
+      <% if @business.contacts.any? %>
+        <% @business.contacts.each do |contact| %>
+          <%=
+            govuk_summary_list do |summary_list|
+              summary_list.with_row do |row|
+                row.with_key(text: contact.name)
+                row.with_value(text: contact.email)
+                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
+              end
+              summary_list.with_row do |row|
+                row.with_value(text: contact.job_title)
+                row.with_value(text: contact.phone_number)
+              end
+            end
+          %>
+          <p><%= govuk_link_to "Add another contact", wizard_path(:add_business_contact, business_id: @business.id) %></p>
+        <% end %>
+      <% else %>
+        <p><%= govuk_link_to "Add a contact", wizard_path(:add_business_contact, business_id: @business.id) %></p>
       <% end %>
-      <p><%= govuk_link_to "Add another contact", wizard_path(:add_business_location, business_id: @business.id) %></p>
       <%= f.hidden_field :business_id, value: @business.id %>
       <%= f.govuk_submit "Use business details" %>
     <% end %>

--- a/app/views/notifications/create/confirm_business_details.html.erb
+++ b/app/views/notifications/create/confirm_business_details.html.erb
@@ -1,0 +1,57 @@
+<%= page_title(t("notifications.create.index.sections.business_details.tasks.confirm_business_details.title"), errors: false) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.business_details.title") %></span>
+      <%= t("notifications.create.index.sections.business_details.tasks.confirm_business_details.title") %>
+    </h1>
+    <%= form_with url: wizard_path, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h2 class="govuk-heading-m">Business details</h2>
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: "Trading name")
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
+          end
+          summary_list.with_row do |row|
+            row.with_key(text: "Registered or legal name")
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
+          end
+        end
+      %>
+      <h2 class="govuk-heading-m">Addresses</h2>
+      <% @business.locations.each do |location| %>
+        <%=
+          govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_value(text: [location.address_line_1, location.address_line_2, location.city, location.county, location.postal_code, country_from_code(location.country)].reject(&:blank?).join(", "))
+              row.with_action(text: "Change", href: "#{wizard_path(:add_business_location, business_id: @business.id, location_id: location.id)}")
+            end
+          end
+        %>
+      <% end %>
+      <p><%= govuk_link_to "Add another address", wizard_path(:add_business_location, business_id: @business.id) %></p>
+      <h2 class="govuk-heading-m">Contacts</h2>
+
+      <% @business.contacts.each do |contact| %>
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: contact.name)
+            row.with_value(text: contact.email)
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
+          end
+          summary_list.with_row do |row|
+            row.with_value(text: contact.job_title)
+            row.with_value(text: contact.phone_number)
+          end
+        end
+      %>
+      <% end %>
+      <p><%= govuk_link_to "Add another contact", wizard_path(:add_business_location, business_id: @business.id) %></p>
+      <%= f.hidden_field :business_id, value: @business.id %>
+      <%= f.govuk_submit "Use business details" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,6 +411,8 @@ en:
                 title: Add business addresses
               add_business_contact:
                 title: Add business contact details
+              confirm_business_details:
+                title: Business details
           evidence:
             title: Add product identification and evidence details
             tasks:

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -148,9 +148,6 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     fill_in "Registered or legal name (optional)", with: "Legal name"
     click_button "Save and continue"
 
-    check "Retailer"
-    click_button "Save and continue"
-
     fill_in "Address line 1", with: "123 Fake St"
     fill_in "Address line 2", with: "Fake Heath"
     fill_in "Town or city", with: "Faketon"
@@ -163,6 +160,11 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     fill_in "Job title or role description", with: "Manager"
     fill_in "Email", with: "max@example.com"
     fill_in "Phone", with: "+441121121212"
+    click_button "Save and continue"
+
+    click_button "Use business details"
+
+    check "Retailer"
     click_button "Save and complete tasks in this section"
 
     expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")


### PR DESCRIPTION
## Description

Add page to confirm of change business details

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-27 at 15-14-40 Business details - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/15a6a8f0-b9b6-4c9b-aad7-ba43ab87bc22)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2954.london.cloudapps.digital/
https://psd-pr-2954-support.london.cloudapps.digital/
https://psd-pr-2954-report.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
