### PR TITLE
Redirect to serach for a business page after adding business

### DIFF
--- a/app/views/notifications/create/add_business_roles.html.erb
+++ b/app/views/notifications/create/add_business_roles.html.erb
@@ -35,7 +35,7 @@
           <%= f.govuk_text_field :new_marketplace_name, label: { text: "Other online platform" }, width: "two-thirds" %>
         <% end %>
         <%= f.hidden_field :business_id %>
-        <%= f.govuk_submit "Save and complete tasks in this section", name: "final", value: "true" %>
+        <%= f.govuk_submit "Save and continue" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/notifications/create/confirm_business_details.html.erb
+++ b/app/views/notifications/create/confirm_business_details.html.erb
@@ -12,10 +12,12 @@
         govuk_summary_list do |summary_list|
           summary_list.with_row do |row|
             row.with_key(text: "Trading name")
+            row.with_value(text: @business.trading_name)
             row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
           end
           summary_list.with_row do |row|
             row.with_key(text: "Registered or legal name")
+            row.with_value(text: @business.legal_name)
             row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
           end
         end
@@ -39,18 +41,29 @@
           <%=
             govuk_summary_list do |summary_list|
               summary_list.with_row do |row|
-                row.with_key(text: contact.name)
+                row.with_key(text: "Name")
+                row.with_value(text: contact.name)
+                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
+              end
+              summary_list.with_row do |row|
+                row.with_key(text: "Job title")
+                row.with_value(text: contact.job_title)
+                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
+              end
+              summary_list.with_row do |row|
+                row.with_key(text: "Email")
                 row.with_value(text: contact.email)
                 row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
               summary_list.with_row do |row|
-                row.with_value(text: contact.job_title)
+                row.with_key(text: "Phone number")
                 row.with_value(text: contact.phone_number)
+                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
             end
           %>
-          <p><%= govuk_link_to "Add another contact", wizard_path(:add_business_contact, business_id: @business.id) %></p>
         <% end %>
+        <p><%= govuk_link_to "Add another contact", wizard_path(:add_business_contact, business_id: @business.id) %></p>
       <% else %>
         <p><%= govuk_link_to "Add a contact", wizard_path(:add_business_contact, business_id: @business.id) %></p>
       <% end %>

--- a/spec/features/notification_task_list_spec.rb
+++ b/spec/features/notification_task_list_spec.rb
@@ -165,7 +165,12 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_button "Use business details"
 
     check "Retailer"
-    click_button "Save and complete tasks in this section"
+    click_button "Save and continue"
+
+    within_fieldset "Do you need to add another business?" do
+      choose "No"
+    end
+    click_button "Continue"
 
     expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")
     expect(page).to have_content("You have completed 3 of 6 sections.")


### PR DESCRIPTION
## Description

Redirects user to search_for_or_add_business page after adding a business
Fixes bug that prevented existing business from being added
displays full contact information
prevents empty contacts from being saved

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-2955.london.cloudapps.digital/
https://psd-pr-2955-support.london.cloudapps.digital/
https://psd-pr-2955-report.london.cloudapps.digital/

## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
