### PR TITLE
confirm business details for existing businesses

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -177,7 +177,7 @@ module Notifications
                      Business.new
                    end
 
-        @add_business_details_form = AddBusinessDetailsForm.new(trading_name: business.trading_name, legal_name: business.legal_name, business_id: business.id)
+        @add_business_details_form = AddBusinessDetailsForm.new(trading_name: business.trading_name, legal_name: business.legal_name, company_number: business.company_number, business_id: business.id)
 
         if business.persisted?
           track_notification_event(name: "Edit new business for notification")
@@ -360,12 +360,7 @@ module Notifications
       when :search_for_or_add_a_business
         return redirect_to "#{wizard_path(:search_for_or_add_a_business)}?search" if params[:add_another_business] == "true"
         return redirect_to wizard_path(:search_for_or_add_a_business) if params[:add_another_business].blank? && params[:final].present?
-
-        if params[:add_another_business].blank?
-          business = Business.without_online_marketplaces.find(params[:business_id])
-          AddBusinessToNotification.call!(notification: @notification, business:, user: current_user, skip_email: true)
-          return redirect_to wizard_path(:search_for_or_add_a_business)
-        end
+        return redirect_to wizard_path(:confirm_business_details, business_id: params[:business_id]) if params[:add_another_business].blank?
       when :add_business_details
         @add_business_details_form = AddBusinessDetailsForm.new(add_business_details_params)
 
@@ -397,7 +392,7 @@ module Notifications
         ChangeBusinessNames.call!(
           trading_name: @add_business_details_form.trading_name,
           legal_name: @add_business_details_form.legal_name,
-          notification: @notification,
+          company_number: @add_business_details_form.company_number,
           user: current_user,
           business:
         )
@@ -1061,7 +1056,7 @@ module Notifications
     end
 
     def add_business_details_params
-      params.require(:add_business_details_form).permit(:trading_name, :legal_name, :business_id)
+      params.require(:add_business_details_form).permit(:trading_name, :legal_name, :company_number, :business_id)
     end
 
     def confirm_business_details_params

--- a/app/forms/add_business_details_form.rb
+++ b/app/forms/add_business_details_form.rb
@@ -5,6 +5,7 @@ class AddBusinessDetailsForm
 
   attribute :trading_name, :string
   attribute :legal_name, :string
+  attribute :company_number, :string
   attribute :business_id
 
   validates :trading_name, presence: true

--- a/app/services/change_business_names.rb
+++ b/app/services/change_business_names.rb
@@ -1,13 +1,13 @@
 class ChangeBusinessNames
   include Interactor
 
-  delegate :trading_name, :legal_name, :notification, :business, :user, to: :context
+  delegate :trading_name, :legal_name, :company_number, :business, :user, to: :context
 
   def call
     context.fail!(error: "No trading name supplied") unless trading_name.is_a?(String)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
-    business.assign_attributes(legal_name:, trading_name:, added_by_user_id: user.id)
+    business.assign_attributes(legal_name:, trading_name:, company_number:, added_by_user_id: user.id)
 
     business.save!
   end

--- a/app/views/notifications/create/add_business_details.html.erb
+++ b/app/views/notifications/create/add_business_details.html.erb
@@ -10,6 +10,7 @@
       </h1>
       <%= f.govuk_text_field :trading_name, label: { text: "Trading name" }, hint: { text: "The name the business is known as." }, width: "two-thirds" %>
       <%= f.govuk_text_field :legal_name, label: { text: "Registered or legal name (optional)" }, hint: { text: "As it appears on Companies House for UK businesses (usually ends in 'Ltd' or 'Limited')." }, width: "two-thirds" %>
+      <%= f.govuk_text_field :company_number, label: { text: "Companies house number (optional)" }, width: "two-thirds" %>
       <%= f.hidden_field :business_id %>
       <%= f.govuk_submit "Save and continue" %>
     <% end %>

--- a/app/views/notifications/create/add_business_roles.html.erb
+++ b/app/views/notifications/create/add_business_roles.html.erb
@@ -16,8 +16,8 @@
           <%= f.govuk_check_box :roles, role.to_sym, label: { text: t("investigations.business_types.new.types.#{role}.label") } %>
         <% end %>
         <%= f.govuk_check_box :roles, :authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.label") } do %>
-          <%= f.govuk_radio_button :authorised_representative, :uk_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.uk.label") } %>
-          <%= f.govuk_radio_button :authorised_representative, :eu_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.eu.label") } %>
+          <%= f.govuk_radio_button :authorised_representative_choice, :uk_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.uk.label") } %>
+          <%= f.govuk_radio_button :authorised_representative_choice, :eu_authorised_representative, label: { text: t("investigations.business_types.new.types.authorised_representative.eu.label") } %>
         <% end %>
         <%= f.govuk_check_box :roles, :responsible_person, label: { text: t("investigations.business_types.new.types.responsible_person.label") } %>
         <div class="govuk-checkboxes__divider">or</div>

--- a/app/views/notifications/create/confirm_business_details.html.erb
+++ b/app/views/notifications/create/confirm_business_details.html.erb
@@ -13,12 +13,17 @@
           summary_list.with_row do |row|
             row.with_key(text: "Trading name")
             row.with_value(text: @business.trading_name)
-            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}") unless @business.investigations.any?
           end
           summary_list.with_row do |row|
             row.with_key(text: "Registered or legal name")
             row.with_value(text: @business.legal_name)
-            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")  unless @business.investigations.any?
+          end
+          summary_list.with_row do |row|
+            row.with_key(text: "Companies house number")
+            row.with_value(text: @business.company_number)
+            row.with_action(text: "Change", href: "#{wizard_path(:add_business_details, business_id: @business.id)}")  unless @business.investigations.any?
           end
         end
       %>
@@ -28,7 +33,6 @@
           govuk_summary_list do |summary_list|
             summary_list.with_row do |row|
               row.with_value(text: [location.address_line_1, location.address_line_2, location.city, location.county, location.postal_code, country_from_code(location.country)].reject(&:blank?).join(", "))
-              row.with_action(text: "Change", href: "#{wizard_path(:add_business_location, business_id: @business.id, location_id: location.id)}")
             end
           end
         %>
@@ -43,22 +47,18 @@
               summary_list.with_row do |row|
                 row.with_key(text: "Name")
                 row.with_value(text: contact.name)
-                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
               summary_list.with_row do |row|
                 row.with_key(text: "Job title")
                 row.with_value(text: contact.job_title)
-                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
               summary_list.with_row do |row|
                 row.with_key(text: "Email")
                 row.with_value(text: contact.email)
-                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
               summary_list.with_row do |row|
                 row.with_key(text: "Phone number")
                 row.with_value(text: contact.phone_number)
-                row.with_action(text: "Change", href: "#{wizard_path(:add_business_contact, business_id: @business.id, contact_id: contact.id)}")
               end
             end
           %>

--- a/app/views/notifications/create/search_for_or_add_a_business.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_business.html.erb
@@ -24,6 +24,11 @@
               @notification.investigation_businesses.decorate.each do |investigation_business|
                 summary_list.with_row do |row|
                   row.with_key(text: "#{investigation_business.business.trading_name}#{@existing_attached_business_ids.include?(investigation_business.business_id) ? '<br><span class="govuk-hint govuk-!-font-size-16">This business cannot be removed because it is associated with a risk assessment or corrective action.</span>' : ''}".html_safe)
+                  if investigation_business.relationship.match?(/authorised_representative/)
+                    row.with_value(text: "#{t('business.type.authorised_representative.' + investigation_business.relationship.to_s)}#{@existing_attached_business_ids.include?(investigation_business.business_id) ? '<br><span class="govuk-hint govuk-!-font-size-16">This business cannot be removed because it is associated with a risk assessment or corrective action.</span>' : ''}".html_safe)
+                  else
+                    row.with_value(text: "#{t('business.type.' + investigation_business.relationship.to_s)}#{@existing_attached_business_ids.include?(investigation_business.business_id) ? '<br><span class="govuk-hint govuk-!-font-size-16">This business cannot be removed because it is associated with a risk assessment or corrective action.</span>' : ''}".html_safe)
+                  end
                   row.with_action(text: "Remove", href: remove_business_notification_create_index_path(investigation_business_id: investigation_business.id), visually_hidden_text: "business from notification") unless @existing_attached_business_ids.include?(investigation_business.business_id)
                 end
               end


### PR DESCRIPTION
## Description

- Adds company number as a field for new business records
- Confirm business details when adding existing businesses
- Display roles businesses have for notification

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-02-28 at 10-02-24 Search for or add a business - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/d1a7961c-37f1-41f0-8763-277cee229055)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
