### PR TITLE
Rename to most/least active teams - PSD-2442

### DIFF
--- a/report_portal/app/views/report_portal/best_teams/_notifications.html.erb
+++ b/report_portal/app/views/report_portal/best_teams/_notifications.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure best teams (notifications)
+      How we measure most active teams (notifications)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/best_teams/_products.html.erb
+++ b/report_portal/app/views/report_portal/best_teams/_products.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure best teams (products)
+      How we measure most active teams (products)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/best_teams/_users.html.erb
+++ b/report_portal/app/views/report_portal/best_teams/_users.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure best teams (active users)
+      How we measure most active teams (active users)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/best_teams/index.html.erb
+++ b/report_portal/app/views/report_portal/best_teams/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Best ranking teams" %>
+<% content_for :page_title, "Most active teams" %>
 
 <% content_for :aside do %>
   Last 12 months

--- a/report_portal/app/views/report_portal/worst_teams/_notifications.html.erb
+++ b/report_portal/app/views/report_portal/worst_teams/_notifications.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure worst teams (notifications)
+      How we measure least active teams (notifications)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/worst_teams/_products.html.erb
+++ b/report_portal/app/views/report_portal/worst_teams/_products.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure worst teams (products)
+      How we measure least active teams (products)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/worst_teams/_users.html.erb
+++ b/report_portal/app/views/report_portal/worst_teams/_users.html.erb
@@ -21,7 +21,7 @@
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      How we measure worst teams (active users)
+      How we measure least active teams (active users)
     </span>
   </summary>
   <div class="govuk-details__text">

--- a/report_portal/app/views/report_portal/worst_teams/index.html.erb
+++ b/report_portal/app/views/report_portal/worst_teams/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Worst ranking teams" %>
+<% content_for :page_title, "Least active teams" %>
 
 <% content_for :aside do %>
   Last 12 months


### PR DESCRIPTION
Changes copy from 'worst' -> 'least active', 'best' -> 'most active'