### PR TITLE
Working submission rate stat on summary page, use 'last month' in copy - PSD-2444

### DIFF
--- a/report_portal/app/controllers/report_portal/summary_controller.rb
+++ b/report_portal/app/controllers/report_portal/summary_controller.rb
@@ -1,10 +1,10 @@
 module ReportPortal
   class SummaryController < ApplicationController
     def index
-      @month = Date.current.all_month
       @last_month = 1.month.ago.beginning_of_month
       @current_month = Date.current.beginning_of_month
 
+      @total_users = User.active.count
       @active_users_this_month = Rollup.series("Active users", interval: :month)[@current_month]&.to_i || 0
       @active_users_last_month = Rollup.series("Active users", interval: :month)[@last_month]&.to_i || 0
       @active_users_change_pc = get_change_pc(@active_users_this_month, @active_users_last_month)
@@ -18,6 +18,19 @@ module ReportPortal
       @cost_per_notification_this_month = cost_per_period(monthly_price_of_psd, @notifications_this_month)
       @cost_per_notification_last_month = cost_per_period(monthly_price_of_psd, @notifications_last_month)
       @cost_per_notification_change_pc = get_change_pc(@cost_per_notification_this_month, @cost_per_notification_last_month)
+
+      @total_notifications = Investigation::Notification.count
+
+      notifications_this_month = Investigation::Notification.where("updated_at >= ?", Date.current.beginning_of_month).where("updated_at <= ?", Date.current.end_of_month)
+      @draft_notifications_this_month = notifications_this_month.draft.count
+      @submitted_notifications_this_month = notifications_this_month.submitted.count
+      @submission_rate_this_month = @submitted_notifications_this_month / notifications_this_month.count.to_f * 100
+
+      notifications_last_month = Investigation::Notification.where("updated_at >= ?", 1.month.ago.beginning_of_month).where("updated_at <= ?", 1.month.ago.end_of_month)
+      @draft_notifications_last_month = notifications_last_month.draft.count
+      @submitted_notifications_last_month = notifications_last_month.submitted.count
+      @submission_rate_last_month = @submitted_notifications_last_month / notifications_last_month.count.to_f * 100
+      @submission_rate_change_pc = get_change_pc(@submission_rate_this_month, @submission_rate_last_month)
     end
 
   private

--- a/report_portal/app/views/report_portal/summary/index.html.erb
+++ b/report_portal/app/views/report_portal/summary/index.html.erb
@@ -33,7 +33,7 @@
       <%= pluralize @active_users_this_month, 'user' %>
     </h2>
     <p class="govuk-body">
-      <span class="govuk-caption-m">Last 30 days</span>
+      <span class="govuk-caption-m"><%= pluralize @total_users, 'user' %> in total</span>
       <span class="govuk-caption-m">
         <% if @active_users_change_pc.positive? %>
           <span class="govuk-visually-hidden">Increase of</span>
@@ -54,7 +54,7 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        An active user is one that has logged in to the service in the last 30 days
+        An active user is one that has logged in to the service in the last month
       </div>
     </details>
   </div>
@@ -65,7 +65,7 @@
       <%= pluralize @notifications_this_month, 'notification' %>
     </h2>
     <p class="govuk-body">
-      <span class="govuk-caption-m">Last 30 days</span>
+      <span class="govuk-caption-m"><%= pluralize @total_notifications, 'notification' %> in total</span>
       <span class="govuk-caption-m">
         <% if @notifications_change_pc.positive? %>
           <span class="govuk-visually-hidden">Increase of</span>
@@ -96,11 +96,24 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-l">
       <span class="govuk-caption-l">Submission rate</span>
-      x% submitted
+      <%= @submission_rate_this_month.round(0) %>% submitted
     </h2>
     <p class="govuk-body">
-      <span class="govuk-caption-m">Last 30 days</span>
-      <span class="govuk-caption-m">+x% from last month</span>
+      <span class="govuk-caption-m">
+        <%= @submitted_notifications_this_month %> of <%= @draft_notifications_this_month + @submitted_notifications_this_month %> submitted
+      </span>
+      <span class="govuk-caption-m">
+        <% if @submission_rate_change_pc.positive? %>
+          <span class="govuk-visually-hidden">Increase of</span>
+          +<%= number_to_percentage @submission_rate_change_pc, precision: 0 %>
+        <% elsif @submission_rate_change_pc.zero? %>
+          No change
+        <% else %>
+          <span class="govuk-visually-hidden">Decrease of</span>
+          -<%= number_to_percentage @submission_rate_change_pc, precision: 0 %>
+        <% end %>
+        from last month
+      </span>
     </p>
     <details class="govuk-details">
       <summary class="govuk-details__summary">


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-2444
https://regulatorydelivery.atlassian.net/browse/PSD-2445

## Description
- Working submission rate statistic for notifications
- Use 'last month' instead of 'last 30 days' copy in several places


## Screen-shots or screen-capture of UI changes
![CleanShot 2024-02-29 at 16 38 08](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/28108/18fcd0cf-18b8-4ce2-a218-473bcd2c08f7)
