### PR TITLE
add country and notification type filters to products

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -137,7 +137,7 @@ private
   end
 
   def query_params
-    params.permit(:q, :sort_by, :sort_dir, :direction, :category, :retired_status, :page_name)
+    params.permit(:q, :sort_by, :sort_dir, :direction, :category, :retired_status, :page_name, :notification, :allegation, :enquiry, :project, countries: [])
   end
 
   def set_last_product_view_cookie
@@ -164,6 +164,17 @@ private
   end
 
   def count_to_display
-    params[:category].blank? && params[:q].blank? && [nil, "active"].include?(params[:retired_status]) ? Product.not_retired.count : @pagy.count
+    filters_empty? ? Product.not_retired.count : @pagy.count
+  end
+
+  def filters_empty?
+    params[:category].blank? &&
+      params[:q].blank? &&
+      [nil, "active"].include?(params[:retired_status]) &&
+      params[:countries].blank? &&
+      params[:notification].blank? &&
+      params[:allegation].blank? &&
+      params[:enquiry].blank? &&
+      params[:project].blank?
   end
 end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -61,6 +61,7 @@ class SearchParams
   Country.all.each do |country|
     attribute country[0].parameterize.underscore.to_sym, :boolean
   end
+  attribute :countries, array: true, default: []
 
   def selected_sort_by
     if sort_by.blank?

--- a/app/views/products/_filters.html.erb
+++ b/app/views/products/_filters.html.erb
@@ -51,8 +51,48 @@
       ) %>
     <% end %>
 
+    <% if current_user.is_opss? %>
+      <%= govuk_details(summary_text: "Country of origin", classes: "opss-details--plain", id: "products-countries") do %>
+        <% Country.all.each do |country| %>
+          <div class="govuk-checkboxes__item">
+            <%= form.check_box :countries, { multiple: true, checked: params.dig(:search_params, :countries)&.include?(country[1]), class: "govuk-checkboxes__input" }, country[1], false %>
+            <%= form.label "countries_#{country[1].downcase.remove(':')}", country[0], { class: "govuk-label govuk-checkboxes__label" } %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= govuk_details(summary_text: "Notification type", classes: "opss-details--plain", id: "products-notification-type") do %>
+        <%= govukCheckboxes(
+          key: "",
+          form: form,
+          items: [
+            {
+              key: "notification",
+              text: "Notification",
+              value: true
+            },
+            {
+              key: "allegation",
+              text: "Allegation",
+              value: true
+            },
+            {
+              key: "enquiry",
+              text: "Enquiry",
+              value: true
+            },
+            {
+              key: "project",
+              text: "Project",
+              value: true
+            }
+          ]
+        ) %>
+      <% end %>
+    <% end %>
+
     <div class="govuk-button-group">
-      <%= form.button "Apply", name: nil, type: "submit", class: "govuk-button" %>
+      <%= form.submit "Apply", name: nil, type: "submit", class: "govuk-button" %>
       <a href="<%= all_products_path %>" class="govuk-link govuk-link--no-visited-state">Reset</a>
     </div>
 

--- a/app/views/products/_search_statement.html.erb
+++ b/app/views/products/_search_statement.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  <% filters_are_blank = filter[:category].blank? && filter[:retired_status].blank? %>
+  <% filters_are_blank = filter[:category].blank? && filter[:retired_status].blank? && filter[:countries].blank? && filter[:notification_types].blank? %>
   <% if keywords.blank? && filters_are_blank %>
     There are currently <%= pluralize count, "product" %>.
   <% else %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <%= render "search_statement", count: @count, keywords: params[:q], filter: { category: params[:category], retired_status: params[:retired_status] } %>
+            <%= render "search_statement", count: @count, keywords: params[:q], filter: { category: params[:category], retired_status: params[:retired_status], countries: params[:countries], notification_type: ["notification", "allegation", "enquiry", "project"] & [*params.keys] } %>
           </div>
         </div>
       <% elsif (@count > 11) %>

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -5,11 +5,11 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   let(:user)                  { create(:user, :activated, organisation:, has_viewed_introduction: true) }
   let(:opss_user)             { create(:user, :opss_user, :activated, organisation:, has_viewed_introduction: true) }
 
-  let!(:chemical_investigation)              { create(:allegation, hazard_type: "Chemical") }
+  let!(:chemical_investigation)              { create(:notification, hazard_type: "Chemical") }
   let!(:fire_investigation)                  { create(:allegation, hazard_type: "Fire") }
   let!(:drowning_investigation)              { create(:allegation, hazard_type: "Drowning") }
 
-  let!(:lift_product_1)   { create(:product, name: "Elevator", investigations: [fire_investigation], category: "Clothing, textiles and fashion items") }
+  let!(:lift_product_1)   { create(:product, name: "Elevator", investigations: [fire_investigation], category: "Clothing, textiles and fashion items", country_of_origin: "territory:AE-AZ") }
   let!(:lift_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation], category: "Clothing, textiles and fashion items") }
   let!(:furniture_product) { create(:product, name: "Hot product1", investigations: [chemical_investigation], category: "Furniture") }
   let!(:sanitiser_product) { create(:product, name: "SoapForHandz", investigations: [drowning_investigation], category: "Communication and media equipment") }
@@ -165,6 +165,32 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
       expect(page).to have_content(sanitiser_product.name)
       expect(page).to have_content("#{retired_sanitiser_product.name} (Retired product record)")
       expect(page).to have_content("5 products using the current filters, were found.")
+    end
+
+    scenario "filtering by country" do
+      find("details#products-countries").click
+      check "Abu Dhabi"
+      click_button "Apply"
+
+      expect(page).to have_content(lift_product_1.name)
+      expect(page).not_to have_content(lift_product_2.name)
+      expect(page).not_to have_content(furniture_product.name)
+      expect(page).not_to have_content(sanitiser_product.name)
+      expect(page).not_to have_content("#{retired_sanitiser_product.name} (Retired product record)")
+      expect(page).to have_content("1 product using the current filters, was found.")
+    end
+
+    scenario "filtering by notification type" do
+      find("details#products-notification-type").click
+      check "Notification"
+      click_button "Apply"
+
+      expect(page).not_to have_content(lift_product_1.name)
+      expect(page).not_to have_content(lift_product_2.name)
+      expect(page).to have_content(furniture_product.name)
+      expect(page).not_to have_content(sanitiser_product.name)
+      expect(page).not_to have_content("#{retired_sanitiser_product.name} (Retired product record)")
+      expect(page).to have_content("1 product using the current filters, was found.")
     end
   end
 end


### PR DESCRIPTION
## Description

Add filters so OPSS users can filter by country of origin and notification type

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-03-13 at 10-12-03 All Products - Search - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/4852dc61-afc0-4884-ad92-e1a7bb74d531)

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
