### PR TITLE
Fix recall display in notification summary

### DIFF
--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -220,7 +220,7 @@
                 if corrective_action.recall_of_the_product_from_end_users?
                   {
                     key: { text: "Recall information" },
-                    value: { text: corrective_action.has_online_recall_information ? "Yes: #{corrective_action.online_recall_information}" : "No" }
+                    value: { text: corrective_action.has_online_recall_information == "has_online_recall_information_yes" ? "Yes: #{corrective_action.online_recall_information}" : "No" }
                   }
                 end,
                 {

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -239,7 +239,7 @@
             if corrective_action.recall_of_the_product_from_end_users?
               {
                 key: { text: "Recall information" },
-                value: { text: corrective_action.has_online_recall_information ? "Yes: #{corrective_action.online_recall_information}" : "No" }
+                value: { text: corrective_action.has_online_recall_information == "has_online_recall_information_yes" ? "Yes: #{corrective_action.online_recall_information}" : "No" }
               }
             end,
             {


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2474

## Description

Fixes the display of recall information on the notification summary page.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
