### PR TITLE
Show notification comments on new summary page

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -146,6 +146,6 @@ private
   end
 
   def set_notification
-    @notification = Investigation::Notification.includes(:creator_user, :creator_team, :owner_user, :owner_team).find_by!(pretty_id: params[:pretty_id])
+    @notification = Investigation::Notification.includes(:creator_user, :creator_team, :owner_user, :owner_team, :comments).find_by!(pretty_id: params[:pretty_id])
   end
 end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -29,6 +29,12 @@ class Investigation < ApplicationRecord
             inverse_of: :investigation,
             dependent: :destroy
 
+    has_many :comments,
+             class_name: "AuditActivity::Investigation::AddComment",
+             foreign_key: :investigation_id,
+             inverse_of: :investigation,
+             dependent: :destroy
+
     aasm column: :state, whiny_transitions: false do
       state :draft, initial: true
       state :submitted

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -263,5 +263,18 @@
       %>
     <% end %>
     <%= govuk_button_link_to "Add corrective action", new_investigation_corrective_action_path(@notification), secondary: true %>
+    <% if @notification.comments.present? %>
+      <h2 class="govuk-heading-m">Comments</h2>
+      <div class="timeline opss-timeline">
+        <ul class="govuk-list">
+        <% @notification.comments.each do |comment| %>
+          <li>
+            <p class="govuk-body-s opss-secondary-text">Comment added by <%= comment.added_by_user&.name %>, <%= comment.created_at.to_formatted_s(:govuk) %></p>
+            <p class="govuk-body"><%= comment.metadata["comment_text"] %></p>
+          </li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2480

## Description

Displays any comments added to a notification on the new summary page.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-03-21 at 10 42 40](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/c206d31d-71bb-4466-b12a-6e4b147e72d6)

## Review apps

https://psd-pr-2990.london.cloudapps.digital/
https://psd-pr-2990-support.london.cloudapps.digital/
https://psd-pr-2990-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
