### PR TITLE
Add comment via notification summary page

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -23,7 +23,11 @@ class CommentsController < Investigations::BaseController
       })
     )
 
-    redirect_to investigation_activity_path(@investigation), flash: { success: "The comment was successfully added" }
+    if current_user.can_use_notification_task_list?
+      redirect_to notification_path(@investigation)
+    else
+      redirect_to investigation_activity_path(@investigation), flash: { success: "The comment was successfully added" }
+    end
   end
 
 private

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -80,7 +80,7 @@
           row.with_value(text: @notification.complainant_reference.presence || "Not provided")
           row.with_action(text: "Change", href: edit_investigation_reference_numbers_path(@notification), visually_hidden_text: "internal reference number") if show_edit_link?
         end
-        # TODO(ruben): implement change link that leads to a single page for all investigation products
+        # TODO: implement change link that leads to a single page for all investigation products
         summary_list.with_row do |row|
           row.with_key(text: "Number of affected products")
           row.with_value(text: number_of_affected_units(@notification.investigation_products).html_safe)
@@ -263,9 +263,9 @@
       %>
     <% end %>
     <%= govuk_button_link_to "Add corrective action", new_investigation_corrective_action_path(@notification), secondary: true %>
-    <% if @notification.comments.present? %>
-      <h2 class="govuk-heading-m">Comments</h2>
-      <div class="timeline opss-timeline">
+    <h2 class="govuk-heading-m">Comments</h2>
+    <div class="timeline opss-timeline">
+      <% if @notification.comments.present? %>
         <ul class="govuk-list">
         <% @notification.comments.each do |comment| %>
           <li>
@@ -274,7 +274,8 @@
           </li>
         <% end %>
         </ul>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+    <%= govuk_button_link_to "Add comment", new_investigation_activity_comment_path(@notification), secondary: true %>
   </div>
 </div>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2479

## Description

Adds the ability to add comments to a submitted notification via the new notification summary page.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-03-25 at 09 39 52](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/444232/32ca8c47-2f53-49b7-b2fc-111e84ba080e)

## Review apps

https://psd-pr-2992.london.cloudapps.digital/
https://psd-pr-2992-support.london.cloudapps.digital/
https://psd-pr-2992-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
