### PR TITLE
PSD 2473 remove links on search for or add product page

### DIFF
--- a/app/views/notifications/create/search_for_or_add_a_product.html.erb
+++ b/app/views/notifications/create/search_for_or_add_a_product.html.erb
@@ -105,7 +105,7 @@
                     end
 
                     details = <<~DETAILS.strip
-                      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0"><a href="#{product_path(record)}" class="govuk-link" target="_blank" rel="noreferrer noopener">#{record.name_with_brand}</a></p>
+                      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">#{record.name_with_brand}</p>
                       <p class="govuk-body-s govuk-!-margin-bottom-0"><strong>Category:</strong> #{record.category}</p>
                       <p class="govuk-body-s govuk-!-margin-bottom-0"><strong>Sub-category:</strong> #{record.subcategory}</p>
                       <p class="govuk-body-s govuk-!-margin-bottom-1"><strong>PSD reference:</strong> #{record.psd_ref}</p>


### PR DESCRIPTION
## Description

Removes link to product pages from "search for or add product" page on notification creation.

## Screen-shots or screen-capture of UI changes

![Screenshot 2024-03-26 at 09-28-05 Search for or add a product - Product Safety Database - GOV UK](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/367349/47eda62f-6ed4-4126-b4d1-44c000e5d060)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://psd-pr-xxxx.london.cloudapps.digital/
https://psd-pr-xxxx-support.london.cloudapps.digital/
https://psd-pr-xxxx-report.london.cloudapps.digital/

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
