### PR TITLE
PSD-2481 - Test report and Risk assessment hyperlinks

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -126,7 +126,7 @@ module Notifications
     end
 
     def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, product_id)
-      "<a class=\"govuk-link\" href=\"/cases/#{notification_id}/risk-assessments/#{product_id} \" >#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")}</a>"
+      "<a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{product_id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join('<br>')}</a>"
     end
 
     def formatted_uploads(uploads)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -121,16 +121,16 @@ module Notifications
       test_results.map { |test_result| link_to "#{test_result.document.blob.filename} (opens in new tab)", test_result.document.blob, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" if test_result.document.blob.present? }.join("<br>")
     end
 
-    def formatted_risk_assessments(prism_risk_assessments, risk_assessments)
-      (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
-    end
-
-    def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
-      hyperlinks = ""
-      risk_assessment_list.each_with_index do |risk, index|
-        hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
+    def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
+      if notification_id == nil and risk_assessment_list == nil
+        (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
+      else
+        hyperlinks = ""
+        risk_assessment_list.each_with_index do |risk, index|
+          hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
+        end
+        hyperlinks
       end
-      hyperlinks
     end
 
     def formatted_uploads(uploads)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -122,7 +122,7 @@ module Notifications
     end
 
     def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
-      if notification_id == nil and risk_assessment_list == nil
+      if notification_id.nil?  && risk_assessment_list.nil?
         (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
       else
         hyperlinks = ""

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -125,6 +125,11 @@ module Notifications
       (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
     end
 
+    def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, product_id)
+      ("<a class=\"govuk-link\" href=\"/cases/"+ notification_id +"/risk-assessments/#{product_id} \" >" + (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>") + "</a>")
+    end
+
+
     def formatted_uploads(uploads)
       uploads.map { |upload| link_to "#{upload.blob.filename} (opens in new tab)", upload.blob, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" if upload.blob.present? }.join("<br>")
     end

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -125,8 +125,12 @@ module Notifications
       (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
     end
 
-    def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, product_id)
-      "<a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{product_id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join('<br>')}</a>"
+    def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
+      hyperlinks = ""
+      risk_assessment_list.each_with_index do |risk, index|
+        hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
+      end
+      hyperlinks
     end
 
     def formatted_uploads(uploads)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -122,7 +122,6 @@ module Notifications
     end
 
     def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id)
-
       if notification_id.nil?
         (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
       else
@@ -130,11 +129,11 @@ module Notifications
         if risk_assessment_list.nil?
           "Not Provided"
         else
-        hyperlinks = ""
-        risk_assessment_list.each_with_index do |risk, index|
-          hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
-        end
-        hyperlinks
+          hyperlinks = ""
+          risk_assessment_list.each_with_index do |risk, index|
+            hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
+          end
+          hyperlinks
         end
       end
     end

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -122,7 +122,7 @@ module Notifications
     end
 
     def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
-      if notification_id.nil?  && risk_assessment_list.nil?
+      if notification_id.nil? && risk_assessment_list.nil?
         (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
       else
         hyperlinks = ""

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -126,9 +126,8 @@ module Notifications
     end
 
     def formatted_risk_assessments_hyperlink(prism_risk_assessments, risk_assessments, notification_id, product_id)
-      ("<a class=\"govuk-link\" href=\"/cases/"+ notification_id +"/risk-assessments/#{product_id} \" >" + (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>") + "</a>")
+      "<a class=\"govuk-link\" href=\"/cases/#{notification_id}/risk-assessments/#{product_id} \" >#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")}</a>"
     end
-
 
     def formatted_uploads(uploads)
       uploads.map { |upload| link_to "#{upload.blob.filename} (opens in new tab)", upload.blob, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" if upload.blob.present? }.join("<br>")

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -121,15 +121,21 @@ module Notifications
       test_results.map { |test_result| link_to "#{test_result.document.blob.filename} (opens in new tab)", test_result.document.blob, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" if test_result.document.blob.present? }.join("<br>")
     end
 
-    def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id, risk_assessment_list)
-      if notification_id.nil? && risk_assessment_list.nil?
+    def formatted_risk_assessments(prism_risk_assessments, risk_assessments, notification_id)
+
+      if notification_id.nil?
         (prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact.join("<br>")
       else
+        risk_assessment_list = Investigation.find_by(pretty_id: notification_id).risk_assessments
+        if risk_assessment_list.nil?
+          "Not Provided"
+        else
         hyperlinks = ""
         risk_assessment_list.each_with_index do |risk, index|
           hyperlinks += "<div><a class='govuk-link' href='/cases/#{notification_id}/risk-assessments/#{risk.id}'>#{(prism_risk_assessments.decorate + risk_assessments.decorate).map(&:supporting_information_full_title).compact[index]}<br></a></div>"
         end
         hyperlinks
+        end
       end
     end
 

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -158,7 +158,7 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { href: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
+              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
               actions: [
                 {
                   text: "Change",

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -158,7 +158,7 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
+              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, nil, nil).html_safe.presence || "Not provided" },
               actions: [
                 {
                   text: "Change",

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -158,7 +158,7 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, nil, nil).html_safe.presence || "Not provided" },
+              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, nil).html_safe.presence || "Not provided" },
               actions: [
                 {
                   text: "Change",

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -158,7 +158,7 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
+              value: { href: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
               actions: [
                 {
                   text: "Change",

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -166,7 +166,7 @@
     <%= govuk_button_link_to "Add business", new_investigation_business_types_path(@notification), secondary: true %>
     <h2 class="govuk-heading-m">Evidence</h2>
     <% @notification.investigation_products.decorate.each do |investigation_product| %>
-      <% risk_assessment = Product.find(investigation_product.product_id).risk_assessments %>
+      <% risk_assessment = Investigation.find_by(pretty_id: @notification.pretty_id).risk_assessments %>
       <%= risk_assessment.first.id %>
       <% risk_text = "" %>
       <% if risk_assessment.nil? %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -166,6 +166,13 @@
     <%= govuk_button_link_to "Add business", new_investigation_business_types_path(@notification), secondary: true %>
     <h2 class="govuk-heading-m">Evidence</h2>
     <% @notification.investigation_products.decorate.each do |investigation_product| %>
+      <% risk_assessment_id = Product.find(investigation_product.product_id).risk_assessments.find_by(investigation_id: investigation_product.id) %>
+      <% risk_text = "" %>
+      <% if risk_assessment_id.nil? %>
+        <% risk_text = "Not provided" %>
+      <% else %>
+        <% risk_text = formatted_risk_assessments_hyperlink(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, @notification.pretty_id, risk_assessment_id.id || 0).html_safe.presence %>
+      <% end %>
       <%=
         govuk_summary_list(
           card: { title: investigation_product.product.name_with_brand },
@@ -183,7 +190,8 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments).html_safe.presence || "Not provided" },
+              value: { text: risk_text.html_safe.presence,
+              },
               actions: show_edit_link? ? [
                 {
                   text: "Change",

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -166,14 +166,6 @@
     <%= govuk_button_link_to "Add business", new_investigation_business_types_path(@notification), secondary: true %>
     <h2 class="govuk-heading-m">Evidence</h2>
     <% @notification.investigation_products.decorate.each do |investigation_product| %>
-      <% risk_assessment = Investigation.find_by(pretty_id: @notification.pretty_id).risk_assessments %>
-      <%= risk_assessment.first.id %>
-      <% risk_text = "" %>
-      <% if risk_assessment.nil? %>
-        <% risk_text = "Not provided" %>
-      <% else %>
-        <% risk_text = formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments.order(created_at: :asc), @notification.pretty_id, risk_assessment).html_safe.presence %>
-      <% end %>
       <%=
         govuk_summary_list(
           card: { title: investigation_product.product.name_with_brand },
@@ -191,7 +183,7 @@
             },
             {
               key: { text: "Risk assessments" },
-              value: { text: risk_text.html_safe.presence,
+              value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments.order(created_at: :asc), @notification.pretty_id).html_safe.presence,
               },
               actions: show_edit_link? ? [
                 {

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -166,12 +166,12 @@
     <%= govuk_button_link_to "Add business", new_investigation_business_types_path(@notification), secondary: true %>
     <h2 class="govuk-heading-m">Evidence</h2>
     <% @notification.investigation_products.decorate.each do |investigation_product| %>
-      <% risk_assessment_id = Product.find(investigation_product.product_id).risk_assessments.find_by(investigation_id: investigation_product.id) %>
+      <% risk_assessment = Product.find(investigation_product.product_id).risk_assessments %>
       <% risk_text = "" %>
-      <% if risk_assessment_id.nil? %>
+      <% if risk_assessment.nil? %>
         <% risk_text = "Not provided" %>
       <% else %>
-        <% risk_text = formatted_risk_assessments_hyperlink(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, @notification.pretty_id, risk_assessment_id.id || 0).html_safe.presence %>
+        <% risk_text = formatted_risk_assessments_hyperlink(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, @notification.pretty_id, risk_assessment).html_safe.presence %>
       <% end %>
       <%=
         govuk_summary_list(

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -153,7 +153,7 @@
             },
             {
               key: { text: "Address" },
-              value: { text: formatted_business_address(investigation_business.business.locations.find_by(name: "Registered office address")).html_safe.presence || "Not provided" }
+              value: { text: "Not provided" || "Not provided" }
             },
             {
               key: { text: "Contact details" },
@@ -167,11 +167,12 @@
     <h2 class="govuk-heading-m">Evidence</h2>
     <% @notification.investigation_products.decorate.each do |investigation_product| %>
       <% risk_assessment = Product.find(investigation_product.product_id).risk_assessments %>
+      <%= risk_assessment.first.id %>
       <% risk_text = "" %>
       <% if risk_assessment.nil? %>
         <% risk_text = "Not provided" %>
       <% else %>
-        <% risk_text = formatted_risk_assessments_hyperlink(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, @notification.pretty_id, risk_assessment).html_safe.presence %>
+        <% risk_text = formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments.order(created_at: :asc), @notification.pretty_id, risk_assessment).html_safe.presence %>
       <% end %>
       <%=
         govuk_summary_list(

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -153,7 +153,7 @@
             },
             {
               key: { text: "Address" },
-              value: { text: "Not provided" || "Not provided" }
+              value: { text: formatted_business_address(investigation_business.business.locations.find_by(name: "Registered office address")).html_safe.presence || "Not provided" }
             },
             {
               key: { text: "Contact details" },

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,9 +7,11 @@ default: &default
 development:
   <<: *default
   database: psd_development
+  password: "password"
 test:
   <<: *default
   database: psd_test<%= ENV['TEST_ENV_NUMBER'] %>
+  password: "password"
 
 
 production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,11 +7,10 @@ default: &default
 development:
   <<: *default
   database: psd_development
-  password: "password"
+
 test:
   <<: *default
   database: psd_test<%= ENV['TEST_ENV_NUMBER'] %>
-  password: "password"
 
 
 production:

--- a/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
+++ b/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     existing_product
   end
 
-
   scenario "Creating a notification with the normal flow" do
     visit "/notifications/create"
     expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
@@ -280,7 +279,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     expect(page).to have_content("Notification submitted")
     click_link "Edit submitted notification"
     expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}/)
-    #the risk link is displayed as risk level: (brand of product) + (product name)
+    # the risk link is displayed as risk level: (brand of product) + (product name)
     click_link "High risk: #{existing_product.brand} #{existing_product.name}"
     expect(page).to have_current_path(/\/cases\/\d{4}-\d{4}\/risk-assessments\/\d/)
   end

--- a/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
+++ b/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
@@ -283,5 +283,4 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_link "High risk: #{existing_product.brand} #{existing_product.name}"
     expect(page).to have_current_path(/\/cases\/\d{4}-\d{4}\/risk-assessments\/\d/)
   end
-
 end

--- a/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
+++ b/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
   before do
     sign_in(user)
 
-    @current_product = existing_product
+    existing_product
   end
 
 
@@ -281,7 +281,7 @@ RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_m
     click_link "Edit submitted notification"
     expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}/)
     #the risk link is displayed as risk level: (brand of product) + (product name)
-    click_link "High risk: #{@current_product.brand} #{@current_product.name}"
+    click_link "High risk: #{existing_product.brand} #{existing_product.name}"
     expect(page).to have_current_path(/\/cases\/\d{4}-\d{4}\/risk-assessments\/\d/)
   end
 

--- a/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
+++ b/spec/features/visit_risk_assessment_from_notification_task_list_page_spec.rb
@@ -1,0 +1,288 @@
+require "rails_helper"
+
+RSpec.feature "Notification task list", :with_stubbed_antivirus, :with_stubbed_mailer, :with_opensearch, :with_product_form_helper do
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let(:existing_product) { create(:product) }
+  let(:new_product_attributes) do
+    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
+  end
+  let(:image_file) { Rails.root.join "test/fixtures/files/testImage.png" }
+  let(:text_file) { Rails.root.join "test/fixtures/files/attachment_filename.txt" }
+
+  before do
+    sign_in(user)
+
+    @current_product = existing_product
+  end
+
+
+  scenario "Creating a notification with the normal flow" do
+    visit "/notifications/create"
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
+    expect(page).to have_content("Create a product safety notification")
+    expect(page).to have_selector(:id, "task-list-0-0-status", text: "Not yet started")
+
+    click_link "Search for or add a product"
+    click_button "Select", match: :first
+
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-0-0-status", text: "Completed")
+    expect(page).to have_content("You have completed 1 of 6 sections.")
+
+    click_link "Add notification details"
+    fill_in "Notification title", with: "Fake name"
+    fill_in "Notification summary", with: "This is a fake summary"
+    within_fieldset("Why are you creating the notification?") do
+      choose "A product is unsafe or non-compliant"
+    end
+    click_button "Save and continue"
+
+    within_fieldset "What specific issues make the product unsafe or non-compliant?" do
+      check "Product harm"
+      select "Chemical", from: "What is the primary harm?"
+      fill_in "Provide additional information about the product harm", with: "Fake description"
+    end
+
+    within_fieldset "Was the safety issue reported by an overseas regulator?" do
+      choose "Yes"
+      select "France", from: "Country"
+    end
+
+    within_fieldset "Do you want to add your own reference number?" do
+      choose "Yes"
+      fill_in "Reference number", with: "123456"
+    end
+
+    click_button "Save and continue"
+
+    choose "Unknown"
+    click_button "Save and complete tasks in this section"
+
+    expect(page).to have_selector(:id, "task-list-1-0-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-1-1-status", text: "Completed")
+    expect(page).to have_selector(:id, "task-list-1-2-status", text: "Completed")
+    expect(page).to have_content("You have completed 2 of 6 sections.")
+
+    click_link "Search for or add a business"
+    click_link "Add a new business"
+    fill_in "Trading name", with: "Trading name"
+    fill_in "Registered or legal name (optional)", with: "Legal name"
+    click_button "Save and continue"
+
+    fill_in "Address line 1", with: "123 Fake St"
+    fill_in "Address line 2", with: "Fake Heath"
+    fill_in "Town or city", with: "Faketon"
+    fill_in "County", with: "Fake County"
+    fill_in "Post code", with: "FA1 2KE"
+    select "United Kingdom", from: "Country"
+    click_button "Save and continue"
+
+    fill_in "Full name", with: "Max Mustermann"
+    fill_in "Job title or role description", with: "Manager"
+    fill_in "Email", with: "max@example.com"
+    fill_in "Phone", with: "+441121121212"
+    click_button "Save and continue"
+
+    click_button "Use business details"
+
+    check "Retailer"
+    click_button "Save and continue"
+
+    within_fieldset "Do you need to add another business?" do
+      choose "No"
+    end
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-2-0-status", text: "Completed")
+    expect(page).to have_content("You have completed 3 of 6 sections.")
+
+    # Ensure that all of section 4 and the first task of section are enabled once section 3 is completed
+    expect(page).to have_selector(:id, "task-list-3-0-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-1-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-2-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-3-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-4-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-3-5-status", text: "Not yet started")
+    expect(page).to have_selector(:id, "task-list-4-0-status", text: "Not yet started")
+
+    click_link "Add product identification details"
+    click_link "Add batch numbers"
+    fill_in "batch_number", with: "1234, 5678"
+    click_button "Save"
+    click_button "Continue"
+
+    click_link "Add test reports"
+    choose "Yes"
+    click_button "Save and continue"
+
+    fill_in "What is the trading standards officer sample reference number?", with: "12345678"
+    fill_in "Day", with: "12"
+    fill_in "Month", with: "5"
+    fill_in "Year", with: "2023"
+    click_button "Save and continue"
+
+    select "ATEX 2016", from: "Under which legislation?"
+    fill_in "Which standard was the product tested against?", with: "EN71"
+    fill_in "Day", with: "12"
+    fill_in "Month", with: "5"
+    fill_in "Year", with: "2023"
+
+    within_fieldset "What was the result?" do
+      choose "Fail"
+      fill_in "How the product failed", with: "Because it did"
+    end
+
+    attach_file "Test report attachment", image_file
+    click_button "Add test report"
+
+    expect(page).to have_content("You have added 1 test report.")
+
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-3-0-status", text: "Completed")
+
+    click_link "Add supporting images"
+
+    attach_file "image_upload[file_upload]", image_file
+    click_button "Upload image"
+
+    expect(page).to have_content("Supporting image uploaded successfully")
+
+    click_button "Finish uploading images"
+
+    expect(page).to have_selector(:id, "task-list-3-1-status", text: "Completed")
+
+    click_link "Add supporting documents"
+
+    fill_in "Document title", with: "Fake title"
+    attach_file "document_form[document]", text_file
+    click_button "Upload document"
+
+    expect(page).to have_content("Supporting document uploaded successfully")
+
+    click_button "Finish uploading documents"
+
+    expect(page).to have_selector(:id, "task-list-3-2-status", text: "Completed")
+
+    click_link "Add risk assessments"
+    click_link "Add legacy risk assessment"
+
+    within_fieldset "Date of assessment" do
+      fill_in "Day", with: "12"
+      fill_in "Month", with: "5"
+      fill_in "Year", with: "2023"
+    end
+
+    within_fieldset "What was the risk level?" do
+      choose "High risk"
+    end
+
+    within_fieldset "Who completed the assessment?" do
+      choose "Someone else"
+      fill_in "Organisation name", with: "Fake org"
+    end
+
+    attach_file "risk_assessment_form[risk_assessment_file]", text_file
+
+    click_button "Add risk assessment"
+
+    expect(page).to have_content("You have added 1 risk assessment.")
+
+    within_fieldset "Do you need to add another risk assessment?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-3-3-status", text: "Completed")
+
+    click_link "Evaluate notification risk level"
+
+    expect(page).to have_content("This notification has 1 risk assessment added, assessing the risk as high.")
+
+    choose "Medium risk"
+
+    click_button "Save and complete tasks in this section"
+
+    expect(page).to have_selector(:id, "task-list-3-4-status", text: "Completed")
+    expect(page).to have_content("You have completed 4 of 6 sections.")
+
+    click_link "Record a corrective action"
+
+    within_fieldset "Have you taken a corrective action for the unsafe or non-compliant product(s)?" do
+      choose "Yes"
+    end
+
+    click_button "Save and continue"
+
+    within_fieldset "What action is being taken?" do
+      choose "Recall of the product from end users"
+    end
+
+    within_fieldset "Has the business responsible published product recall information online?" do
+      choose "Yes"
+      fill_in "Location of recall information", with: "https://www.example.com"
+    end
+
+    within_fieldset "What date did the action come in to effect?" do
+      fill_in "Day", with: "9"
+      fill_in "Month", with: "2"
+      fill_in "Year", with: "2024"
+    end
+
+    select "ATEX 2016", from: "Under which legislation?"
+    select "Consumer Protection Act 1987", from: "Under which legislation?"
+
+    within_fieldset "Which business is responsible?" do
+      choose "Trading name (Retailer)"
+      # TODO: add test here once business selection is possible
+    end
+
+    within_fieldset "Is the corrective action mandatory?" do
+      choose "Yes"
+    end
+
+    within_fieldset "In which geographic regions has this corrective action been taken?" do
+      check "Great Britain"
+      check "European Economic Area (EEA)"
+    end
+
+    within_fieldset "Are there any files related to the action?" do
+      choose "Yes"
+      attach_file "corrective_action_form[document]", text_file
+    end
+
+    click_button "Add corrective action"
+
+    expect(page).to have_content("You have added 1 corrective action.")
+
+    within_fieldset "Do you need to add another corrective action?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_selector(:id, "task-list-4-0-status", text: "Completed")
+    expect(page).to have_content("You have completed 5 of 6 sections.")
+
+    click_link "Check the notification details and submit"
+    click_button "Submit notification"
+
+    expect(page).to have_content("Notification submitted")
+    click_link "Edit submitted notification"
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}/)
+    #the risk link is displayed as risk level: (brand of product) + (product name)
+    click_link "High risk: #{@current_product.brand} #{@current_product.name}"
+    expect(page).to have_current_path(/\/cases\/\d{4}-\d{4}\/risk-assessments\/\d/)
+  end
+
+end


### PR DESCRIPTION

This Branch addresses the Jira ticket PSD-2481: https://regulatorydelivery.atlassian.net/jira/software/c/projects/PSD/boards/57?selectedIssue=PSD-2481

Description
I have changed the text adjacent to Risk assessments in the Notification page to a hyperlink that when clicked would redirect the user straight to the show page of that risk assessment

Screen-shots or screen-capture of UI changes

![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/b02816d0-0b56-4e16-93bc-14a6d21ae7eb)

![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/5869109b-db11-4cd6-8fc0-ffcb4af4cd4c)

