### PR TITLE
feat/PSD-2482-view-prod-summary-from-notif-summary

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -65,7 +65,7 @@ module Notifications
         end
     end
 
-    def number_of_affected_units(investigation_products)
+    def number_of_affected_units(investigation_products, is_link: false)
       investigation_products.map { |investigation_product|
         units = case investigation_product.affected_units_status
                 when "exact"
@@ -79,8 +79,20 @@ module Notifications
                 else
                   "Not provided"
                 end
-        "#{investigation_product.product.decorate.name_with_brand}: #{units}"
+        if is_link
+          investigation_product_units_with_link(investigation_product, units)
+        else
+          investigation_product_units(investigation_product, units)
+        end
       }.join("<br>")
+    end
+
+    def investigation_product_units_with_link(investigation_product, units)
+      "#{link_to investigation_product.product.decorate.name_with_brand, product_path(investigation_product.product_id) }  #{units}"
+    end
+
+    def investigation_product_units(investigation_product, units)
+      "#{investigation_product.product.decorate.name_with_brand}: #{units}"
     end
 
     def investigation_products_options
@@ -110,7 +122,17 @@ module Notifications
     end
 
     def formatted_business_address(location)
-      [location.address_line_1, location.address_line_2, location.city, location.county, location.postal_code, country_from_code(location.country)].map(&:presence).compact.join("<br>")
+      address_parts = [
+        location&.address_line_1,
+        location&.address_line_2,
+        location&.city,
+        location&.county,
+        location&.postal_code,
+        location&.country.nil? ? nil : country_from_code(location.country)
+      ]
+
+      formatted_address = address_parts.compact.join("<br>")
+      formatted_address.presence || "Address not available"
     end
 
     def formatted_business_contact(contact)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -66,10 +66,10 @@ module Notifications
     end
 
     def number_of_affected_units(investigation_products, is_link: false)
-      investigation_products.map do |investigation_product|
+      investigation_products.map { |investigation_product|
         units_text = units_text_for_product(investigation_product)
         is_link ? with_link(investigation_product, units_text) : without_link(investigation_product, units_text)
-      end.join("<br>")
+      }.join("<br>")
     end
 
     def units_text_for_product(investigation_product)
@@ -88,7 +88,7 @@ module Notifications
     end
 
     def with_link(investigation_product, units_text)
-      "#{link_to (investigation_product.product.psd_ref + " - " + investigation_product.product.decorate.name_with_brand), product_path(investigation_product.product_id) }  #{units_text}"
+      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id)}  #{units_text}"
     end
 
     def without_link(investigation_product, units_text)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -88,7 +88,7 @@ module Notifications
     end
 
     def with_link(investigation_product, units_text)
-      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id), target: '_blank', rel: 'nofollow noopener'}  #{units_text}"
+      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id), target: '_blank', rel: 'nofollow noopener'}:  #{units_text}"
     end
 
     def without_link(investigation_product, units_text)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -66,33 +66,33 @@ module Notifications
     end
 
     def number_of_affected_units(investigation_products, is_link: false)
-      investigation_products.map { |investigation_product|
-        units = case investigation_product.affected_units_status
-                when "exact"
-                  investigation_product.number_of_affected_units
-                when "approx"
-                  "Approximately #{investigation_product.number_of_affected_units}"
-                when "unknown"
-                  "Unknown"
-                when "not_relevant"
-                  "Not relevant"
-                else
-                  "Not provided"
-                end
-        if is_link
-          investigation_product_units_with_link(investigation_product, units)
-        else
-          investigation_product_units(investigation_product, units)
-        end
-      }.join("<br>")
+      investigation_products.map do |investigation_product|
+        units_text = units_text_for_product(investigation_product)
+        is_link ? with_link(investigation_product, units_text) : without_link(investigation_product, units_text)
+      end.join("<br>")
     end
 
-    def investigation_product_units_with_link(investigation_product, units)
-      "#{link_to investigation_product.product.decorate.name_with_brand, product_path(investigation_product.product_id) }  #{units}"
+    def units_text_for_product(investigation_product)
+      case investigation_product.affected_units_status
+      when "exact"
+        investigation_product.number_of_affected_units
+      when "approx"
+        "Approximately #{investigation_product.number_of_affected_units}"
+      when "unknown"
+        "Unknown"
+      when "not_relevant"
+        "Not relevant"
+      else
+        "Not provided"
+      end
     end
 
-    def investigation_product_units(investigation_product, units)
-      "#{investigation_product.product.decorate.name_with_brand}: #{units}"
+    def with_link(investigation_product, units_text)
+      "#{link_to (investigation_product.product.psd_ref + " - " + investigation_product.product.decorate.name_with_brand), product_path(investigation_product.product_id) }  #{units_text}"
+    end
+
+    def without_link(investigation_product, units_text)
+      "#{investigation_product.product.decorate.name_with_brand}: #{units_text}"
     end
 
     def investigation_products_options

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -88,7 +88,7 @@ module Notifications
     end
 
     def with_link(investigation_product, units_text)
-      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id), target: "_blank", rel: "nofollow"}  #{units_text}"
+      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id), target: '_blank', rel: 'nofollow noopener'}  #{units_text}"
     end
 
     def without_link(investigation_product, units_text)

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -88,7 +88,7 @@ module Notifications
     end
 
     def with_link(investigation_product, units_text)
-      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id)}  #{units_text}"
+      "#{link_to "#{investigation_product.product.psd_ref} - #{investigation_product.product.decorate.name_with_brand}", product_path(investigation_product.product_id), target: "_blank", rel: "nofollow"}  #{units_text}"
     end
 
     def without_link(investigation_product, units_text)

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -83,7 +83,7 @@
         # TODO: implement change link that leads to a single page for all investigation products
         summary_list.with_row do |row|
           row.with_key(text: "Number of affected products")
-          row.with_value(text: number_of_affected_units(@notification.investigation_products).html_safe)
+          row.with_value(text: number_of_affected_units(@notification.investigation_products, is_link: true).html_safe)
         end
       end
     %>

--- a/docker/env.psd
+++ b/docker/env.psd
@@ -1,6 +1,6 @@
 # Note: These are DEVELOPMENT values only - not used in production
 
-DATABASE_URL=postgresql://postgres:password@db:5432
+DATABASE_URL=postgres://postgres:password@db:5432/
 
 # OPTIONAL: To test email and text message sending
 NOTIFY_API_KEY=

--- a/docker/env.psd
+++ b/docker/env.psd
@@ -1,6 +1,6 @@
 # Note: These are DEVELOPMENT values only - not used in production
 
-DATABASE_URL=postgres://postgres:password@db:5432/
+DATABASE_URL=postgresql://postgres:password@db:5432
 
 # OPTIONAL: To test email and text message sending
 NOTIFY_API_KEY=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
As a PSD user I want to view product from a notification summary post submission so that I can check Product details without navigating away from the summary page

## Screen-shots or screen-capture of UI changes

### Before:
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/72029455/68017c3b-87bb-411a-b4ef-05c5b07c15ec)

### After:

![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/72029455/4b231755-833e-4a03-8573-979fc9f1f73b)
