### PR TITLE
Fix notification summary for non-task-list notifications

### DIFF
--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -41,7 +41,7 @@
           row.with_value(text: @notification.safe_and_compliant? ? "Safe and compliant product(s)" : "Unsafe or non-compliant product(s)")
           row.with_action(text: "Change", href: edit_investigation_reported_reason_path(@notification), visually_hidden_text: "notification reason") if show_edit_link?
         end
-        unless @notification.reported_reason.safe_and_compliant?
+        unless @notification.reported_reason&.safe_and_compliant?
           summary_list.with_row do |row|
             row.with_key(text: "Specific product safety issues")
             row.with_value(text: specific_product_safety_issues.html_safe)


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/PSD-2509

## Description

Fixes a condition where non-task-list notifications without a reported reason cause an exception.

## Screen-shots or screen-capture of UI changes

N/A

## Review apps

https://psd-pr-3012.london.cloudapps.digital/
https://psd-pr-3012-support.london.cloudapps.digital/
https://psd-pr-3012-report.london.cloudapps.digital/

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
