### PR TITLE
fix/PSD-2511-update-email-from-beis-to-businessandtrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Product Safety Database is the place to create notifications for unsafe or n
 
 Built by the [Office for Product Safety and Standards](https://www.gov.uk/government/organisations/office-for-product-safety-and-standards).
 
-For enquiries, contact [opss.enquiries@beis.gov.uk](mailto:opss.enquiries@beis.gov.uk).
+For enquiries, contact [opss.enquiries@businessandtrade.gov.uk](mailto:opss.enquiries@businessandtrade.gov.uk).
 
 ## Technical overview
 

--- a/app/views/help/accessibility.html.erb
+++ b/app/views/help/accessibility.html.erb
@@ -17,7 +17,7 @@
 
     <h2 class="govuk-heading-m">Reporting accessibility problems with the Product Safety Database</h2>
 
-    <p class="govuk-body">If you find any problems that are not listed on this page or think we’re not meeting the accessibility requirements, contact <a href="mailto:opss.enquiries@beis.gov.uk">opss.enquiries@beis.gov.uk</a>. If you request a response, we’ll aim to reply within 2 working days.</p>
+    <p class="govuk-body">If you find any problems that are not listed on this page or think we’re not meeting the accessibility requirements, contact <a href="mailto:opss.enquiries@businessandtrade.gov.uk">opss.enquiries@businessandtrade.gov.uk</a>. If you request a response, we’ll aim to reply within 2 working days.</p>
 
     <h2 class="govuk-heading-m">Enforcement procedure</h2>
 

--- a/app/views/help/terms_and_conditions.html.erb
+++ b/app/views/help/terms_and_conditions.html.erb
@@ -117,7 +117,7 @@
     </p>
 
     <p>
-      If you know or suspect that anyone other than you knows your user identification code or password, you must promptly notify us at <%= mail_to "OPSS.enquiries@beis.gov.uk" %>
+      If you know or suspect that anyone other than you knows your user identification code or password, you must promptly notify us at <%= mail_to "opss.enquiries@businessandtrade.gov.uk" %>
     </p>
 
     <h2 class="govuk-heading-m" id="our-material">Our material on the Service</h2>
@@ -172,7 +172,7 @@
     </p>
 
     <p>
-      If you wish to complain about information and materials uploaded by other users please contact us at: <%= mail_to "OPSS.enquiries@beis.gov.uk" %>
+      If you wish to complain about information and materials uploaded by other users please contact us at: <%= mail_to "opss.enquiries@businessandtrade.gov.uk" %>
     </p>
 
     <h2 class="govuk-heading-m" id="do-not-rely">Do not rely on information made available through the Service</h2>
@@ -204,7 +204,7 @@
     </p>
 
     <p>
-      You must contact us at <%= mail_to "OPSS.enquiries@beis.gov.uk" %> for permission if you want to:
+      You must contact us at <%= mail_to "opss.enquiries@businessandtrade.gov.uk" %> for permission if you want to:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -267,7 +267,7 @@
     </ul>
 
     <p>
-      Please contact us at <%= mail_to "OPSS.enquiries@beis.gov.uk" %> to ask for content to be removed. You will need to send us the web address (URL) of the content and explain why you think it should be removed. We will reply to let you know whether we’ll remove it.
+      Please contact us at <%= mail_to "opss.enquiries@businessandtrade.gov.uk" %> to ask for content to be removed. You will need to send us the web address (URL) of the content and explain why you think it should be removed. We will reply to let you know whether we’ll remove it.
     </p>
 
     <p>

--- a/app/views/investigations/cannot_delete.html.erb
+++ b/app/views/investigations/cannot_delete.html.erb
@@ -21,7 +21,7 @@
 
           <div class="govuk-!-margin-top-8">
             <p class="govuk-body">
-              Email <%= mail_to "opss.enquiries@beis.gov.uk", class: "govuk-link govuk-link--no-visited-state" %> if further help is required.
+              Email <%= mail_to "opss.enquiries@businessandtrade.gov.uk", class: "govuk-link govuk-link--no-visited-state" %> if further help is required.
             </p>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  enquiries_email: "opss.enquiries@beis.gov.uk"
+  enquiries_email: "opss.enquiries@businessandtrade.gov.uk"
   mail:
     notification_risk_level_updated:
       verb_with_level:

--- a/prism/README.md
+++ b/prism/README.md
@@ -4,7 +4,7 @@ PRISM is a product safety risk assessment tool used by market surveillance autho
 
 Built by the [Office for Product Safety and Standards](https://www.gov.uk/government/organisations/office-for-product-safety-and-standards).
 
-For enquiries, contact [opss.enquiries@beis.gov.uk](mailto:opss.enquiries@beis.gov.uk).
+For enquiries, contact [opss.enquiries@businessandtrade.gov.uk](mailto:opss.enquiries@businessandtrade.gov.uk).
 
 ## Getting started
 

--- a/prism/app/views/prism/triage/index.html.erb
+++ b/prism/app/views/prism/triage/index.html.erb
@@ -15,7 +15,7 @@
     <h2 class="govuk-heading-m">Before you start</h2>
     <p class="govuk-body">You will need:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>Product Safety Database (PSD) login credentials - we’ll ask you to sign in or <a href="mailto:opss.enquiries@beis.gov.uk" class="govuk-link">request a new account</a> before starting the full risk assessment.</li>
+      <li>Product Safety Database (PSD) login credentials - we’ll ask you to sign in or <a href="mailto:opss.enquiries@businessandtrade.gov.uk" class="govuk-link">request a new account</a> before starting the full risk assessment.</li>
       <li>Information about the product, including details of the manufacturer/supplier, number of products sold, and other information accompanying the product.</li>
       <li>Details of safety concerns associated with the product including number and nature of hazards.</li>
     </ul>

--- a/prism/prism.gemspec
+++ b/prism/prism.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name        = "prism"
   spec.version     = Prism::VERSION
   spec.authors     = ["Office for Product Safety and Standards"]
-  spec.email       = ["opss.enquiries@beis.gov.uk"]
+  spec.email       = ["opss.enquiries@businessandtrade.gov.uk"]
   spec.homepage    = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database"
   spec.summary     = "Product Safety Risk Assessment Methodology"
   spec.description = "PRISM is a product safety risk assessment tool, part of the Product Safety Database (PSD)."

--- a/report_portal/report_portal.gemspec
+++ b/report_portal/report_portal.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name        = "report_portal"
   spec.version     = ReportPortal::VERSION
   spec.authors     = ["Office for Product Safety and Standards"]
-  spec.email       = ["opss.enquiries@beis.gov.uk"]
+  spec.email       = ["opss.enquiries@businessandtrade.gov.uk"]
   spec.homepage    = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database"
   spec.summary     = "OSU Support Portal"
   spec.description = "Support portal for OSU support teams to administer PSD."

--- a/spec/features/invite_user_spec.rb
+++ b/spec/features/invite_user_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Inviting a user", :with_stubbed_mailer, type: :feature do
       end
 
       scenario "shows an error message" do
-        expect(page).to have_summary_error("The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@beis.gov.uk to add it to the approved list.")
+        expect(page).to have_summary_error("The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@businessandtrade.gov.uk to add it to the approved list.")
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.feature "Inviting a user", :with_stubbed_mailer, type: :feature do
         let(:existing_user_team) { create(:team) }
 
         scenario "shows an error message" do
-          expect(page).to have_summary_error("You cannot invite this person to join your team because they are already a member of another team. Contact opss.enquiries@beis.gov.uk if the person’s team needs to be changed.")
+          expect(page).to have_summary_error("You cannot invite this person to join your team because they are already a member of another team. Contact opss.enquiries@businessandtrade.gov.uk if the person’s team needs to be changed.")
         end
       end
 

--- a/spec/forms/invite_user_to_team_form_spec.rb
+++ b/spec/forms/invite_user_to_team_form_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe InviteUserToTeamForm do
       context "with whitelisting enabled" do
         before { set_whitelisting_enabled(true) }
 
-        include_examples "invalid form", [:email, "The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@beis.gov.uk to add it to the approved list."]
+        include_examples "invalid form", [:email, "The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@businessandtrade.gov.uk to add it to the approved list."]
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe InviteUserToTeamForm do
       end
 
       context "when the user is on a different team" do
-        include_examples "invalid form", [:email, "You cannot invite this person to join your team because they are already a member of another team. Contact opss.enquiries@beis.gov.uk if the person’s team needs to be changed."]
+        include_examples "invalid form", [:email, "You cannot invite this person to join your team because they are already a member of another team. Contact opss.enquiries@businessandtrade.gov.uk if the person’s team needs to be changed."]
       end
 
       context "when the user is on the same team" do

--- a/support_portal/README.md
+++ b/support_portal/README.md
@@ -4,7 +4,7 @@ The OSU Support Portal is used by the OSU support teams to administer PSD.
 
 Built by the [Office for Product Safety and Standards](https://www.gov.uk/government/organisations/office-for-product-safety-and-standards).
 
-For enquiries, contact [opss.enquiries@beis.gov.uk](mailto:opss.enquiries@beis.gov.uk).
+For enquiries, contact [opss.enquiries@businessandtrade.gov.uk](mailto:opss.enquiries@businessandtrade.gov.uk).
 
 ## Getting started
 

--- a/support_portal/support_portal.gemspec
+++ b/support_portal/support_portal.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name        = "support_portal"
   spec.version     = SupportPortal::VERSION
   spec.authors     = ["Office for Product Safety and Standards"]
-  spec.email       = ["opss.enquiries@beis.gov.uk"]
+  spec.email       = ["opss.enquiries@businessandtrade.gov.uk"]
   spec.homepage    = "https://github.com/OfficeForProductSafetyAndStandards/product-safety-database"
   spec.summary     = "OSU Support Portal"
   spec.description = "Support portal for OSU support teams to administer PSD."


### PR DESCRIPTION
## Description
Updating the email within the PSD app from opss.enquiries@beis.gov.uk to opss.enquiries@businessandtrade.gov.uk.

## Screen-shots or screen-capture of UI changes
**Before**
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/164185955/8a64791f-42a0-43cb-8927-7074a4796565)

**After**
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/164185955/ad4ce00a-d350-4e05-b397-34ecc6ecf772)
