### PR TITLE
[PSD-2536] - updated the message for risk level validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -266,10 +266,10 @@ en:
       not_validated: "No"
       validated_status: "Validated by %{risk_validated_by} on %{risk_validated_at}"
       page_title: "Risk level validated"
-      validated_success_message: "The notification risk level has updated"
+      validated_success_message: "The notification risk level has been validated"
       validation_removed_success_message: "Notification risk level validation removed"
       activity:
-        added: "The notification risk level has updated"
+        added: "The notification risk level has been validated"
         removed: Notification risk level validation removed
     risk_level:
       show:

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -42,12 +42,12 @@ RSpec.feature "Validate risk level", :with_stubbed_antivirus, :with_stubbed_mail
       click_on "Continue"
 
       expect(page).to have_current_path("/cases/#{notification.pretty_id}")
-      expect_confirmation_banner("The notification risk level has updated")
+      expect_confirmation_banner("The notification risk level has been validated")
       expect(page).to have_css(".govuk-summary-list__value", text: "Validated by #{user.team.name} on #{notification.risk_validated_at}")
       expect(page).not_to have_link("Validate")
 
       click_on "Activity"
-      expect(page).to have_content "The notification risk level has updated"
+      expect(page).to have_content "The notification risk level has been validated"
 
       expect_email_with_correct_details_to_be_set("has been validated")
     end
@@ -66,12 +66,12 @@ RSpec.feature "Validate risk level", :with_stubbed_antivirus, :with_stubbed_mail
       click_on "Continue"
 
       expect(page).to have_current_path("/cases/#{notification.pretty_id}")
-      expect(page).not_to have_content("The notification risk level has updated")
+      expect(page).not_to have_content("The notification risk level has been validated")
       expect(page).not_to have_content("Validated by #{user.team.name} on #{notification.risk_validated_at}")
       expect(page).to have_link("Validate")
 
       click_on "Activity"
-      expect(page).not_to have_content "The notification risk level has updated"
+      expect(page).not_to have_content "The notification risk level has been validated"
     end
 
     scenario "remove validation" do
@@ -106,7 +106,7 @@ RSpec.feature "Validate risk level", :with_stubbed_antivirus, :with_stubbed_mail
       click_on "Continue"
 
       expect(page).to have_current_path("/cases/#{notification.pretty_id}")
-      expect(page).not_to have_content("The notification risk level has updated")
+      expect(page).not_to have_content("The notification risk level has been validated")
       expect(page).not_to have_content("Validated by #{user.team.name} on #{notification.risk_validated_at}")
       expect(page).to have_link("Validate")
 


### PR DESCRIPTION
When a risk is validated by IMT , the messaged shown will be "The notification risk level has been validated"
<img width="280" alt="image" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/163134444/89dcb620-c793-4905-b75e-78e6ebd5c007">

