### PR TITLE
fix/PR-2557 - Update to the previous fix

### DIFF
--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -128,7 +128,7 @@ module Notifications
         location&.city,
         location&.county,
         location&.postal_code,
-        location&.country.nil? ? nil : country_from_code(location.country)
+        location&.country ? country_from_code(location.country) : nil
       ]
 
       formatted_address = address_parts.compact.join("<br>")


### PR DESCRIPTION
## Description
Picked up ticket PSD-2557 for `undefined method `address_line_1' for nil:NilClass (ActionView::Template::Error)` and found it had been worked on previously as part of PR 3010

Saw a small update to the code which could be done so added that in.