### PR TITLE
refactor/PSD-2555 File upload component functionality

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -45,9 +45,13 @@ class ProductForm
   validates :country_of_origin, presence: true
   validates :when_placed_on_market, presence: true
   validates :description, length: { maximum: 10_000 }
+  validate :acceptable_image
 
   validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validate :markings_validity, if: -> { has_markings == "markings_yes" }
+
+  # members
+  ACCEPTABLE_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic", "image/heif"].freeze
 
   def self.from(product)
     new(product.serializable_hash(except: %i[owning_team_id updated_at retired_at]))
@@ -82,6 +86,14 @@ class ProductForm
     end
   end
 
+  def acceptable_image
+    return if image.blank?
+
+    unless ACCEPTABLE_IMAGE_TYPES.include?(image.content_type)
+      errors.add(:image, I18n.t("errors.messages.invalid_image_type"))
+    end
+  end
+
   def authenticity_not_provided?
     return false if id.nil?
 
@@ -103,7 +115,7 @@ class ProductForm
     authenticity == "unsure"
   end
 
-private
+  private
 
   def markings_validity
     if markings.blank? || !markings.all? { |value| Product::MARKINGS.include?(value) }

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -115,7 +115,7 @@ class ProductForm
     authenticity == "unsure"
   end
 
-  private
+private
 
   def markings_validity
     if markings.blank? || !markings.all? { |value| Product::MARKINGS.include?(value) }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,20 +45,37 @@ module ApplicationHelper
     rc.render(sanitized_input).html_safe
   end
 
+  # def replace_uploaded_file_field(form, field_name, label:, label_classes: "govuk-label--m")
+  #   # binding.pry
+  #   existing_uploaded_file_id = form.hidden_field "existing_#{field_name}_file_id"
+  #   file_upload_field         = form.govuk_file_upload(field_name, label:, label_classes:)
+  #   uploaded_file             = form.object.public_send(field_name)
+  #
+  #   return existing_uploaded_file_id.to_s + file_upload_field.to_s + render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file }) if uploaded_file.present?
+  #
+  #   existing_uploaded_file_id.to_s + file_upload_field.to_s
+  # end
   def replace_uploaded_file_field(form, field_name, label:, label_classes: "govuk-label--m")
-    existing_uploaded_file_id = form.hidden_field "existing_#{field_name}_file_id"
-    file_upload_field         = form.govuk_file_upload(field_name, label:, label_classes:)
+    existing_uploaded_file_id = existing_uploaded_file_field(form, field_name)
+    file_upload_field         = file_upload_field(form, field_name, label, label_classes)
     uploaded_file             = form.object.public_send(field_name)
 
-    return safe_join([existing_uploaded_file_id, file_upload_field]) if uploaded_file.blank?
+    file_fields = existing_uploaded_file_id + file_upload_field
+    return file_fields + render_uploaded_file_partial(uploaded_file) if uploaded_file.present?
 
-    safe_join(
-      [
-        existing_uploaded_file_id,
-        render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file }),
-        govuk_details(summary_text: "Replace this file", text: file_upload_field)
-      ]
-    )
+    file_fields
+  end
+
+  def existing_uploaded_file_field(form, field_name)
+    form.hidden_field("existing_#{field_name}_file_id").to_s
+  end
+
+  def file_upload_field(form, field_name, label, label_classes)
+    form.govuk_file_upload(field_name, label:, label_classes:).to_s
+  end
+
+  def render_uploaded_file_partial(uploaded_file)
+    render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file })
   end
 
   def date_or_recent_time_ago(datetime)

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
+  password: 'password'
 development:
   <<: *default
   database: psd_development

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
       team_cases: Team notifications
       your_cases: Your notifications
       assigned_cases: Assigned notifications
-      all_cases: All notifications – Search
+      all_cases: All notifications â€“ Search
     filters:
       teams_added_to_case: "Teams added to notification"
       my_team: "My team"
@@ -470,13 +470,14 @@ en:
   errors:
     format: "%{message}"
     messages:
+      invalid_image_type: "The selected file must be a JPG, PNG, GIF, WEBP, HEIC or HEIF"
       # Full list available at https://guides.rubyonrails.org/i18n.html#error-message-interpolation
       # with default values at https://github.com/rails/rails/blob/master/activemodel/lib/active_model/locale/en.yml
       inclusion: "%{attribute} is not included in the list"
       exclusion: "%{attribute} is reserved"
       invalid: "%{attribute} is invalid"
       taken: "%{attribute} has already been taken"
-      confirmation: "%{attribute} doesn’t match %{attribute}"
+      confirmation: "%{attribute} doesnâ€™t match %{attribute}"
       accepted: "%{attribute} must be accepted"
       empty: "%{attribute} cannot be empty"
       blank: "%{attribute} cannot be blank"
@@ -668,7 +669,7 @@ en:
         correspondence_type_form:
           attributes:
             type:
-              blank: "Select the type of correspondence you’re adding"
+              blank: "Select the type of correspondence youâ€™re adding"
         document_form:
           attributes:
             document:
@@ -690,9 +691,9 @@ en:
               blank: "Enter an email address in the correct format, like name@example.com"
               email: "Enter an email address in the correct format, like name@example.com"
               user_deleted: "Email address belongs to a user that has been deleted. Email OPSS if you would like their account restored."
-              not_whitelisted: "The email address is not recognised. Check you’ve entered it correctly, or email %{opss_enquiries_email} to add it to the approved list."
+              not_whitelisted: "The email address is not recognised. Check youâ€™ve entered it correctly, or email %{opss_enquiries_email} to add it to the approved list."
               already_in_team: "%{email} is already a member of %{team}"
-              existing_user: "You cannot invite this person to join your team because they are already a member of another team. Contact %{opss_enquiries_email} if the person’s team needs to be changed."
+              existing_user: "You cannot invite this person to join your team because they are already a member of another team. Contact %{opss_enquiries_email} if the personâ€™s team needs to be changed."
         risk_level_form:
           attributes:
             risk_level:
@@ -701,7 +702,7 @@ en:
         supporting_information_type_form:
           attributes:
             type:
-              blank: "Select the type of information you’re adding"
+              blank: "Select the type of information youâ€™re adding"
         why_reporting_form:
           attributes:
             hazard_type:
@@ -1070,8 +1071,8 @@ en:
   image_removed: "The image was successfully removed"
   otp_code:
     blank: "Enter the security code"
-    too_short: "You haven’t entered enough numbers"
-    too_long: "You’ve entered too many numbers"
+    too_short: "You havenâ€™t entered enough numbers"
+    too_long: "Youâ€™ve entered too many numbers"
     incorrect: "Incorrect security code"
     expired: "The security code has expired. New code sent."
     numericality: "The code must be 5 numbers"

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
   end
 
+  let(:invalid_image_file) { Rails.root.join("spec/fixtures/files/email.txt") }
+  let(:valid_image_file) { Rails.root.join("spec/fixtures/files/testImage.png") }
+
   before do
     sign_in user
     visit "/products/new"
@@ -181,7 +184,46 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     fill_in "Other product identifiers", with: attributes[:product_code]
     fill_in "Webpage", with: attributes[:webpage]
 
-    attach_file "product[image]", "spec/fixtures/files/testImage.png"
+    attach_file "product[image]", valid_image_file
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
+    within_fieldset("Is the product counterfeit?") do
+      choose counterfeit_answer(attributes[:authenticity])
+    end
+
+    within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
+      page.find("input[value='#{attributes[:has_markings]}']").choose
+    end
+
+    within_fieldset("Select product marking") do
+      attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
+    end
+
+    select "Unknown", from: "Country of origin"
+    fill_in "Description of product", with: attributes[:description]
+    click_on "Save"
+
+    expect(page).to have_current_path("/products")
+    expect(page).not_to have_error_messages
+    expect(page).to have_selector("h1", text: "Product record created")
+    click_on "View the product record"
+    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
+  end
+
+  scenario "Adding a product with an invalid image" do
+    select attributes[:category], from: "Product category"
+    fill_in "Product subcategory", with: attributes[:subcategory]
+    fill_in "Manufacturer's brand name", with: attributes[:brand]
+    fill_in "Product name", with: attributes[:name]
+    fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
+    fill_in "Other product identifiers", with: attributes[:product_code]
+    fill_in "Webpage", with: attributes[:webpage]
+
+    # attach invalid image type
+    attach_file "product[image]", invalid_image_file
 
     within_fieldset("Was the product placed on the market before 1 January 2021?") do
       choose when_placed_on_market_answer(attributes[:when_placed_on_market])
@@ -204,11 +246,9 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     fill_in "Description of product", with: attributes[:description]
     click_on "Save"
 
-    expect(page).to have_current_path("/products")
-    expect(page).not_to have_error_messages
-    expect(page).to have_selector("h1", text: "Product record created")
-
-    click_on "View the product record"
-    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
+    # Expected validation errors
+    expect(page).to have_error_messages
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "The selected file must be a JPG, PNG, GIF, WEBP, HEIC or HEIF"
   end
 end


### PR DESCRIPTION
Implemented fix for incorrect product image upload added unit test and refactored some of the code for better quality from previous PR

Work done for https://regulatorydelivery.atlassian.net/browse/PSD-2555 to fix the image upload validation prompting the user with a validation error when the wrong file type is loaded.

## Description
Modified the rendering the file upload component to display better on the page and ensure page validation works correctly.
Added test for coverage.


## Screen-shots or screen-capture of UI changes
See https://regulatorydelivery.atlassian.net/browse/PSD-2571

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x ] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
