### PR TITLE
refactor/PSD-2555-File-upload-component-functionality

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -45,9 +45,13 @@ class ProductForm
   validates :country_of_origin, presence: true
   validates :when_placed_on_market, presence: true
   validates :description, length: { maximum: 10_000 }
+  validate :acceptable_image
 
   validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validate :markings_validity, if: -> { has_markings == "markings_yes" }
+
+  # members
+  ACCEPTABLE_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic", "image/heif"].freeze
 
   def self.from(product)
     new(product.serializable_hash(except: %i[owning_team_id updated_at retired_at]))
@@ -79,6 +83,14 @@ class ProductForm
 
       product.image_upload_ids.push(image_upload.id)
       product.save!
+    end
+  end
+
+  def acceptable_image
+    return if image.blank?
+
+    unless ACCEPTABLE_IMAGE_TYPES.include?(image.content_type)
+      errors.add(:image, I18n.t("errors.messages.invalid_image_type"))
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,19 +46,26 @@ module ApplicationHelper
   end
 
   def replace_uploaded_file_field(form, field_name, label:, label_classes: "govuk-label--m")
-    existing_uploaded_file_id = form.hidden_field "existing_#{field_name}_file_id"
-    file_upload_field         = form.govuk_file_upload(field_name, label:, label_classes:)
+    existing_uploaded_file_id = existing_uploaded_file_field(form, field_name)
+    file_upload_field         = file_upload_field(form, field_name, label, label_classes)
     uploaded_file             = form.object.public_send(field_name)
 
-    return safe_join([existing_uploaded_file_id, file_upload_field]) if uploaded_file.blank?
+    file_fields = existing_uploaded_file_id + file_upload_field
+    return file_fields + render_uploaded_file_partial(uploaded_file) if uploaded_file.present?
 
-    safe_join(
-      [
-        existing_uploaded_file_id,
-        render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file }),
-        govuk_details(summary_text: "Replace this file", text: file_upload_field)
-      ]
-    )
+    file_fields
+  end
+
+  def existing_uploaded_file_field(form, field_name)
+    form.hidden_field("existing_#{field_name}_file_id").to_s
+  end
+
+  def file_upload_field(form, field_name, label, label_classes)
+    form.govuk_file_upload(field_name, label:, label_classes:).to_s
+  end
+
+  def render_uploaded_file_partial(uploaded_file)
+    render(partial: "active_storage/blobs/blob", locals: { blob: uploaded_file })
   end
 
   def date_or_recent_time_ago(datetime)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,6 +470,7 @@ en:
   errors:
     format: "%{message}"
     messages:
+      invalid_image_type: "The selected file must be a JPG, PNG, GIF, WEBP, HEIC or HEIF"
       # Full list available at https://guides.rubyonrails.org/i18n.html#error-message-interpolation
       # with default values at https://github.com/rails/rails/blob/master/activemodel/lib/active_model/locale/en.yml
       inclusion: "%{attribute} is not included in the list"

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
   end
 
+  let(:invalid_image_file) { Rails.root.join("spec/fixtures/files/email.txt") }
+  let(:valid_image_file) { Rails.root.join("spec/fixtures/files/testImage.png") }
+
   before do
     sign_in user
     visit "/products/new"
@@ -181,7 +184,46 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     fill_in "Other product identifiers", with: attributes[:product_code]
     fill_in "Webpage", with: attributes[:webpage]
 
-    attach_file "product[image]", "spec/fixtures/files/testImage.png"
+    attach_file "product[image]", valid_image_file
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
+    within_fieldset("Is the product counterfeit?") do
+      choose counterfeit_answer(attributes[:authenticity])
+    end
+
+    within_fieldset("Does the product have UKCA, UKNI, or CE marking?") do
+      page.find("input[value='#{attributes[:has_markings]}']").choose
+    end
+
+    within_fieldset("Select product marking") do
+      attributes[:markings].each { |marking| check(marking) } if attributes[:has_markings] == "markings_yes"
+    end
+
+    select "Unknown", from: "Country of origin"
+    fill_in "Description of product", with: attributes[:description]
+    click_on "Save"
+
+    expect(page).to have_current_path("/products")
+    expect(page).not_to have_error_messages
+    expect(page).to have_selector("h1", text: "Product record created")
+    click_on "View the product record"
+    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
+  end
+
+  scenario "Adding a product with an invalid image" do
+    select attributes[:category], from: "Product category"
+    fill_in "Product subcategory", with: attributes[:subcategory]
+    fill_in "Manufacturer's brand name", with: attributes[:brand]
+    fill_in "Product name", with: attributes[:name]
+    fill_in "Barcode number (GTIN, EAN or UPC)", with: attributes[:barcode]
+    fill_in "Other product identifiers", with: attributes[:product_code]
+    fill_in "Webpage", with: attributes[:webpage]
+
+    # attach invalid image type
+    attach_file "product[image]", invalid_image_file
 
     within_fieldset("Was the product placed on the market before 1 January 2021?") do
       choose when_placed_on_market_answer(attributes[:when_placed_on_market])
@@ -204,11 +246,9 @@ RSpec.feature "Adding a product", :with_stubbed_antivirus, :with_stubbed_mailer,
     fill_in "Description of product", with: attributes[:description]
     click_on "Save"
 
-    expect(page).to have_current_path("/products")
-    expect(page).not_to have_error_messages
-    expect(page).to have_selector("h1", text: "Product record created")
-
-    click_on "View the product record"
-    expect(page).to have_summary_item(key: "Country of origin", value: "Unknown")
+    # Expected validation errors
+    expect(page).to have_error_messages
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "The selected file must be a JPG, PNG, GIF, WEBP, HEIC or HEIF"
   end
 end


### PR DESCRIPTION
## Description
1. Updates the File Upload control to always display
2. Handled invalid image type with page validation
3. Adds test for invalid image type

## Screen-shots or screen-capture of UI changes
Invalid image type validation message (hyperlinked text that takes you to the file upload control)
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/72029455/732cdbc1-1279-4390-b352-ee60760de331)

File upload control demonstrating UI changes 
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/72029455/0af5e5ce-b1d9-47d8-8c27-665c343ec9de)