### PR TITLE
feat/PSD-2006-data_cleansing_businesses

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -4,7 +4,7 @@ class BusinessesController < ApplicationController
   include CountriesHelper
   include BreadcrumbHelper
 
-  before_action :set_search_params, only: %i[index]
+  before_action :set_search_params, only: %i[index your_businesses team_businesses]
   before_action :set_business, only: %i[show edit update]
   before_action :update_business, only: %i[update]
   before_action :set_countries, only: %i[update edit]
@@ -56,11 +56,13 @@ class BusinessesController < ApplicationController
   end
 
   def your_businesses
-    @search = SearchParams.new({ "case_owner" => "me",
-                                 "case_status" => "open_only",
-                                 "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"],
-                                 "page_name" => "your_businesses" })
+    @search = SearchParams.new({
+      "case_owner" => "me",
+      "case_status" => "open_only",
+      "sort_by" => params["sort_by"],
+      "sort_dir" => params["sort_dir"],
+      "page_name" => "your_businesses"
+    })
     @pagy, @results = search_for_businesses
     @count = @pagy.count
     @businesses = BusinessDecorator.decorate_collection(@results)
@@ -70,11 +72,13 @@ class BusinessesController < ApplicationController
   end
 
   def team_businesses
-    @search = SearchParams.new({ "case_owner" => "my_team",
-                                 "case_status" => "open_only",
-                                 "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"],
-                                 "page_name" => "team_businesses" })
+    @search = SearchParams.new({
+      "case_owner" => "my_team",
+      "case_status" => "open_only",
+      "sort_by" => params["sort_by"],
+      "sort_dir" => params["sort_dir"],
+      "page_name" => "team_businesses"
+    })
     @pagy, @results = search_for_businesses
     @count = @pagy.count
     @businesses = BusinessDecorator.decorate_collection(@results)

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -158,8 +158,8 @@ module Notifications
                          .or(Business.where("CONCAT(locations.address_line_1, ' ', locations.address_line_2, ' ', locations.city, ' ', locations.county, ' ', locations.country, ' ', locations.postal_code) ILIKE ?", "%#{@search_query}%"))
                          .or(Business.where(company_number: @search_query))
                          .without_online_marketplaces
-                         .distinct
-                         .order(sort_by)
+                         .select("DISTINCT ON (businesses.trading_name, businesses.company_number) businesses.*")
+                         .order("businesses.trading_name, businesses.company_number, businesses.id")
                      else
                        Business.without_online_marketplaces.order(sort_by)
                      end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -14,6 +14,8 @@ module BusinessesHelper
     query = filter_by_selected_countries(query)
     query = filter_by_case_owner(query, user)
 
+    query = distinct_by_name_and_number(query)
+
     for_export ? query : pagy(query.order(sorting_params))
   end
 
@@ -57,6 +59,12 @@ private
     else
       query
     end
+  end
+
+  def distinct_by_name_and_number(query)
+    subquery = query.select("MIN(businesses.id) as id")
+                    .group("businesses.trading_name, businesses.company_number")
+    Business.where(id: subquery)
   end
 
   def child_records(for_export)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -212,6 +212,39 @@ relationships = %w[retailer online_seller manufacturer exporter importer fulfill
   notification.investigation_businesses.create!(business:, relationship: relationships.sample)
 end
 
+# Duplicate Businesses for Testing
+duplicate_business_params = {
+  trading_name: "Duplicate Business",
+  company_number: "12345678",
+  legal_name: "Duplicate Business Ltd"
+}
+
+3.times do
+  business = Business.create!(duplicate_business_params)
+
+  business.locations << Location.new(
+    name: "Duplicate Location",
+    country: "GB",
+    address_line_1: "123 Fake Street",
+    county: "Test County",
+    postal_code: "AB12 3CD",
+    phone_number: "01234567890",
+    address_line_2: "Suite 1",
+    city: "Test City"
+  )
+
+  business.contacts << Contact.new(
+    name: "Duplicate Contact",
+    email: "duplicate@example.com",
+    phone_number: "01234567890",
+    job_title: "Manager"
+  )
+  business.save!
+
+  notification = Investigation.all.sample
+  notification.investigation_businesses.create!(business:, relationship: relationships.sample)
+end
+
 # Additional teams and users
 organisation = Organisation.create!(name: "Office for Product Safety and Standards")
 trading_standards = Organisation.create!(name: "Trading Standards")

--- a/prism/test/dummy/config/environments/test.rb
+++ b/prism/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/report_portal/test/dummy/config/environments/test.rb
+++ b/report_portal/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/features/businesses_spec.rb
+++ b/spec/features/businesses_spec.rb
@@ -60,10 +60,14 @@ RSpec.feature "Business listing", :with_stubbed_mailer, type: :feature do
 
   scenario "displays cases for business" do
     investigation = business_one.investigations.first
+
+    expect(investigation).not_to be_nil
+    expect(investigation.user_title).not_to be_nil, "Investigation user_title should not be nil for this test"
+
     visit "/businesses/#{business_one.id}"
 
     within "#notifications-1" do
-      expect(page).to have_text(investigation.title)
+      expect(page).to have_text(investigation.user_title)
     end
   end
 

--- a/support_portal/test/dummy/config/environments/test.rb
+++ b/support_portal/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
## Description
This bit of work was to clean up the businesses so we only return 1 business if it has the same name and company number. This is part of a larger bit of work in cleaning up all the businesses which are entered. 

The updates did not require any additional specs but there were some updates to the existing specs, along with some config to clean up the specs. This also includes a refactor of the seeds file which includes an update to how we populate the data and some additional info which was used to test this work. 

## Screen-shots or screen-capture of UI changes
**Before**
<img width="1069" alt="ss-before" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/164185955/779333b2-496d-47cd-b789-682c6ddcb4e0">

**After**
<img width="1053" alt="ss-after" src="https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/164185955/012d14a4-931e-4563-aa42-a879ca718da6">