### PR TITLE
PSD-2694: IMT automatically added to Modification programme corrective actions

### DIFF
--- a/app/services/add_corrective_action_to_notification.rb
+++ b/app/services/add_corrective_action_to_notification.rb
@@ -39,7 +39,7 @@ private
     # the corrective action indicates a recall. If OPSS IMT has already been added,
     # `AddTeamToNotification` returns silently.
 
-    return unless %w[serious high].include?(notification.risk_level) || action == "recall_of_the_product_from_end_users"
+    return unless %w[serious high].include?(notification.risk_level) || action == "recall_of_the_product_from_end_users" || action == "modification_programme"
 
     team = Team.find_by(name: "OPSS Incident Management")
     return if team.blank?

--- a/spec/services/add_corrective_action_to_notification_spec.rb
+++ b/spec/services/add_corrective_action_to_notification_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AddCorrectiveActionToNotification, :with_stubbed_mailer, :with_te
     end
   end
 
-  context "when the corrective action indicates a modification" do
+  context "when the corrective action indicates a modification programme" do
     let(:action_key) { "modification_programme" }
     let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
 

--- a/spec/services/add_corrective_action_to_notification_spec.rb
+++ b/spec/services/add_corrective_action_to_notification_spec.rb
@@ -85,4 +85,19 @@ RSpec.describe AddCorrectiveActionToNotification, :with_stubbed_mailer, :with_te
       expect(result.notification.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
     end
   end
+
+  context "when the corrective action indicates a modification" do
+    let(:action_key) { "modification_programme" }
+    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
+
+    before do
+      opss_imt
+      notification.risk_level = "low"
+      notification.save!
+    end
+
+    it "adds OPSS IMT with edit permissions as a collaborator" do
+      expect(result.notification.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
+    end
+  end
 end


### PR DESCRIPTION
Description
Added change that adds the IMT team to a notification when the corrective action: modification programme is created for a notification.
made changes to the corrective action spec to account for this change

