### PR TITLE
fix/PSD-2720 - Interactor failure

### DIFF
--- a/app/controllers/investigations/business_types_controller.rb
+++ b/app/controllers/investigations/business_types_controller.rb
@@ -15,7 +15,7 @@ class Investigations::BusinessTypesController < Investigations::BaseController
       if @business_type_form.is_approved_online_marketplace?
         online_marketplace = @business_type_form.approved_online_marketplace
         online_marketplace.business = Business.create(trading_name: online_marketplace.name)
-        online_marketplace.save
+        online_marketplace.save!
         AddBusinessToNotification.call!(
           business: online_marketplace.business,
           relationship: "online_marketplace",

--- a/app/controllers/investigations/business_types_controller.rb
+++ b/app/controllers/investigations/business_types_controller.rb
@@ -14,7 +14,8 @@ class Investigations::BusinessTypesController < Investigations::BaseController
     if @business_type_form.valid?
       if @business_type_form.is_approved_online_marketplace?
         online_marketplace = @business_type_form.approved_online_marketplace
-
+        online_marketplace.business = Business.create(trading_name: online_marketplace.name)
+        online_marketplace.save
         AddBusinessToNotification.call!(
           business: online_marketplace.business,
           relationship: "online_marketplace",


### PR DESCRIPTION
## Description
PSD 1.0 user journey for adding an online marketplace to an existing notification caused an Interactor error

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
