### PR TITLE
PSD-2569: Refactor Products Form

### DIFF
--- a/app/controllers/notifications/edit_controller.rb
+++ b/app/controllers/notifications/edit_controller.rb
@@ -311,7 +311,7 @@ module Notifications
     end
 
     def set_notification
-      @notification = Investigation::Notification.includes(:creator_user).where(pretty_id: params[:notification_pretty_id], creator_user: { id: current_user.id }).first!
+      @notification = Investigation::Notification.includes(:creator_user).where(pretty_id: params[:notification_pretty_id], creator_user: { id: current_user.id }).first
 
       if @notification.nil?
         redirect_to "/404"

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -118,7 +118,7 @@ class ProductForm
 private
 
   def markings_validity
-    markings.delete("")
+    markings.delete("") unless markings.nil?
     if markings.blank? || !markings.all? { |value| Product::MARKINGS.include?(value) }
       errors.add(:markings, :blank)
     end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -118,6 +118,7 @@ class ProductForm
 private
 
   def markings_validity
+    markings.delete("")
     if markings.blank? || !markings.all? { |value| Product::MARKINGS.include?(value) }
       errors.add(:markings, :blank)
     end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,25 +1,16 @@
 <% label_class = "govuk-label--m" %>
 
-<%= govukSelect(
-  formGroup: { classes: class_names("govuk-form-group--error" => product_form.errors[:category].any?) },
-  choices: product_categories,
-  key: :category,
-  form: form,
-  include_blank: true,
-  id: "category",
-  aria_describedby: "report-product-category-hint",
-  label: { text: "Product category", classes: label_class },
-  hint: { text: "The product category will be permanent for this product record", classes: "govuk-!-font-size-16" },
-  attributes: { disabled: local_assigns[:disable_permanent_fields] }
-) %>
+<% category_items = [OpenStruct.new(value: "", text: "")] + product_categories.map{|x| OpenStruct.new(value: x, text: x)}  %>
+<%= form.govuk_collection_select :category,
+                                 category_items,
+                                 :value,
+                                 :text,
+                                 label: { text: "Product category", size: "m" },
+                                 hint: { text: "The product category will be permanent for this product record" } %>
+<%= form.govuk_text_field :subcategory, label: { text: 'Product subcategory', size: 'm' }, hint: { text: "For example, 'Face mask' or 'Washing machine'" } %>
 
-<%= govukInput(
-  key: :subcategory,
-  form: form,
-  id: "subcategory",
-  label: { text: "Product subcategory", classes: label_class },
-  hint: { text: "For example, 'Face mask' or 'Washing machine'" }
-) %>
+
+<%= form.govuk_text_field :subcategory, label: {text: "Product subcategory"}, hint: { text: "For example, 'Face mask' or 'Washing machine'" } %>
 
 <% if product_form.authenticity_unsure? %>
   <fieldset class="govuk-fieldset">
@@ -27,33 +18,40 @@
     <p class="govuk-body">The original record was recorded as 'unsure'</p>
   </fieldset>
 <% else %>
-  <%= form.govuk_radios :authenticity,
-                        legend: "Is the product counterfeit?",
-                        hint: { text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", classes: "govuk-!-font-size-16" },
-                        items: conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]) %>
+  <% counterfeit_radio_items =  conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]).map{|x| OpenStruct.new(value: x.value, text: x.key)}%>
+  <%= form.govuk_collection_radio_buttons :authenticity,
+                                          counterfeit_radio_items,
+                                          :value,
+                                          :text,
+                                          legend: {text: "Is the product counterfeit?"},
+                                          hint: {text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", size: "16"}%>
+  <%= conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]) %>
 <% end %>
 
 <% product_marking_fields = capture do %>
-  <%= form.govuk_checkboxes :markings,
-                            legend: "Select product marking",
-                            legend_classes: "govuk-fieldset__legend--s",
-                            items: Product::MARKINGS.map { |value| { text: value, value: value, disable_ghost: true} } %>
+  <% markings = Product::MARKINGS.map{|x| OpenStruct.new(value: x, text: x)} %>
+  <%= form.govuk_collection_check_boxes :markings,
+                                        markings,
+                                        :value,
+                                        :text,
+                                        caption: nil,
+                                        legend: {text: "Select product marking"} %>
 <% end %>
 
-<%= form.govuk_radios :has_markings,
-  legend: "Does the product have UKCA, UKNI, or CE marking?",
-  items: [
-    { text: "Yes", value: "markings_yes", conditional: { html: product_marking_fields } },
-    { text: "No", value: "markings_no" },
-    { text: "Unknown", value: "markings_unknown" }
-  ]
-%>
 
+<%= form.govuk_radio_buttons_fieldset(:has_markings, legend: {text: "Does the product have UKCA, UKNI, or CE marking?"}) do %>
+  <%= form.govuk_radio_button :has_markings, 'markings_yes', label: {text: "Yes"} do %>
+    <%= product_marking_fields %>
+  <%= end %>
+  <%= form.govuk_radio_button :has_markings, 'markings_no', label: {text: "No"} %>
+  <%= form.govuk_radio_button :has_markings, 'markings_unknown', label: {text: "Unknown"} %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= opss_aside title: "Number of units affected?", text: "The number of units affected is notification related data (and has now moved to the notification page).", classes: "govuk-!-margin-top-5 govuk-!-margin-bottom-9" %>
   </div>
 </div>
+
 
 <%= govukInput(
   key: :brand,
@@ -62,6 +60,11 @@
   hint: { html: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe },
   attributes: { disabled: local_assigns[:disable_permanent_fields] }
 ) %>
+
+<%= form.govuk_text_field :brand,
+                          label: {text: "Manufacturer's brand name"},
+                          hint: {text: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe}
+%>
 
 <%= govukInput(
   key: :name,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -14,14 +14,12 @@
     <p class="govuk-body">The original record was recorded as 'unsure'</p>
   </fieldset>
 <% else %>
-  <% counterfeit_radio_items =  conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]).map{|x| OpenStruct.new(value: x[:value], text: x[:text])}%>
-  <%= form.govuk_collection_radio_buttons :authenticity,
-                                          counterfeit_radio_items,
-                                          :value,
-                                          :text,
-                                          legend: {text: "Is the product counterfeit?"},
-                                          hint: {text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", size: "16"},
-                                          disabled: local_assigns[:disable_permanent_fields]%>
+  <% counterfeit_radio_items =  conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]).map{|x| OpenStruct.new(value: x[:value], text: x[:text], disabled: x[:disabled])}%>
+  <%= form.govuk_radio_buttons_fieldset(:authenticity, legend: {text: "Is the product counterfeit?"}, hint: {text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", size: "16"}) do %>
+    <%= form.govuk_radio_button :authenticity, counterfeit_radio_items[0].value, label: {text: counterfeit_radio_items[0].text}, link_errors: true, disabled: counterfeit_radio_items[0].disabled %>
+    <%= form.govuk_radio_button :authenticity, counterfeit_radio_items[1].value, label: {text: counterfeit_radio_items[1].text}, disabled: counterfeit_radio_items[1].disabled %>
+    <%= form.govuk_radio_button :authenticity, counterfeit_radio_items[2].value, label: {text: counterfeit_radio_items[2].text}, disabled: counterfeit_radio_items[2].disabled %>
+  <% end %>
 <% end %>
 
 <% markings_list = [OpenStruct.new(id: "UKCA", name: "UKCA"), OpenStruct.new(id: "UKNI", name: "UKNI"), OpenStruct.new(id: "CE", name: "CE")] %>
@@ -47,14 +45,14 @@
 <%= form.govuk_text_field :brand,
                           label: {text: "Manufacturer's brand name", size: 'm'},
                           hint: {text: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe},
-                          disabled: true
+                          disabled: local_assigns[:disable_permanent_fields]
 %>
 
 
 <%= form.govuk_text_field :name,
                           label: {text: "Product name", size: 'm'},
                           hint: {text: 'Include model name and model number, for example \'PlayStation 5\'<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The product name will be permanent for this product record</span>'.html_safe},
-                          disabled: true
+                          disabled: local_assigns[:disable_permanent_fields]
 %>
 
 <% if !local_assigns[:disable_image_upload] %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -56,13 +56,9 @@
 %>
 
 <% if !local_assigns[:disable_image_upload] %>
-<<<<<<< HEAD
-  <%= render "upload_file_component", form: form, old_file: nil, field_name: :image, legend: "Upload a product image", label: "Upload a product image" , hint: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF."%>
-=======
   <%= form.govuk_file_field :image,
                             label: { text: 'Upload a product image', size: 'm' },
                             hint: { text: 'Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.' } %>
->>>>>>> 72885a6bc (Refactored Product Form)
 <% end %>
 
 

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,16 +1,12 @@
-<% label_class = "govuk-label--m" %>
-
 <% category_items = [OpenStruct.new(value: "", text: "")] + product_categories.map{|x| OpenStruct.new(value: x, text: x)}  %>
 <%= form.govuk_collection_select :category,
                                  category_items,
                                  :value,
                                  :text,
                                  label: { text: "Product category", size: "m" },
-                                 hint: { text: "The product category will be permanent for this product record" } %>
+                                 hint: { text: "The product category will be permanent for this product record" },
+                                 disabled: local_assigns[:disable_permanent_fields] %>
 <%= form.govuk_text_field :subcategory, label: { text: 'Product subcategory', size: 'm' }, hint: { text: "For example, 'Face mask' or 'Washing machine'" } %>
-
-
-<%= form.govuk_text_field :subcategory, label: {text: "Product subcategory"}, hint: { text: "For example, 'Face mask' or 'Washing machine'" } %>
 
 <% if product_form.authenticity_unsure? %>
   <fieldset class="govuk-fieldset">
@@ -18,33 +14,29 @@
     <p class="govuk-body">The original record was recorded as 'unsure'</p>
   </fieldset>
 <% else %>
-  <% counterfeit_radio_items =  conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]).map{|x| OpenStruct.new(value: x.value, text: x.key)}%>
+  <% counterfeit_radio_items =  conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]).map{|x| OpenStruct.new(value: x[:value], text: x[:text])}%>
   <%= form.govuk_collection_radio_buttons :authenticity,
                                           counterfeit_radio_items,
                                           :value,
                                           :text,
                                           legend: {text: "Is the product counterfeit?"},
-                                          hint: {text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", size: "16"}%>
-  <%= conditionally_disabled_items_for_authenticity(product_form, disable_all_items: local_assigns[:disable_permanent_fields]) %>
+                                          hint: {text: local_assigns[:disable_permanent_fields] ? "The counterfeit status will be permanent for this product record. You can create an alternative product record if required" : "The counterfeit status will be permanent for this product record. You can create the product record later, or create an alternative product record when required", size: "16"},
+                                          disabled: local_assigns[:disable_permanent_fields]%>
 <% end %>
 
-<% product_marking_fields = capture do %>
-  <% markings = Product::MARKINGS.map{|x| OpenStruct.new(value: x, text: x)} %>
-  <%= form.govuk_collection_check_boxes :markings,
-                                        markings,
-                                        :value,
-                                        :text,
-                                        caption: nil,
-                                        legend: {text: "Select product marking"} %>
-<% end %>
+<% markings_list = [OpenStruct.new(id: "UKCA", name: "UKCA"), OpenStruct.new(id: "UKNI", name: "UKNI"), OpenStruct.new(id: "CE", name: "CE")] %>
 
-
-<%= form.govuk_radio_buttons_fieldset(:has_markings, legend: {text: "Does the product have UKCA, UKNI, or CE marking?"}) do %>
-  <%= form.govuk_radio_button :has_markings, 'markings_yes', label: {text: "Yes"} do %>
-    <%= product_marking_fields %>
-  <%= end %>
-  <%= form.govuk_radio_button :has_markings, 'markings_no', label: {text: "No"} %>
-  <%= form.govuk_radio_button :has_markings, 'markings_unknown', label: {text: "Unknown"} %>
+<%= form.govuk_radio_buttons_fieldset(:has_markings, legend: { size: 'm', text: "Does the product have UKCA, UKNI, or CE marking?" }) do %>
+  <%= form.govuk_radio_button :has_markings, 'markings_yes', label: { text: "Yes" }, link_errors: true do %>
+      <%= form.govuk_collection_check_boxes :markings,
+                                            markings_list,
+                                            :id,
+                                            :name,
+                                            hint_text: "Select all markings that apply",
+                                            legend: { text: "Select product marking", size: 's' } %>
+  <% end %>
+  <%= form.govuk_radio_button :has_markings, 'markings_no', label: { text: "No" } %>
+  <%= form.govuk_radio_button :has_markings, 'markings_unknown', label: { text: "Unknown" } %>
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -52,42 +44,40 @@
   </div>
 </div>
 
-
-<%= govukInput(
-  key: :brand,
-  form: form,
-  label: { text: "Manufacturer's brand name", classes: label_class },
-  hint: { html: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe },
-  attributes: { disabled: local_assigns[:disable_permanent_fields] }
-) %>
-
 <%= form.govuk_text_field :brand,
-                          label: {text: "Manufacturer's brand name"},
-                          hint: {text: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe}
+                          label: {text: "Manufacturer's brand name", size: 'm'},
+                          hint: {text: 'For example, Dyson or Sony<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The manufacturer\'s brand name will be permanent for this product record</span>'.html_safe},
+                          disabled: true
 %>
 
-<%= govukInput(
-  key: :name,
-  form: form,
-  label: { text: "Product name", classes: label_class },
-  id: "name",
-  hint: { html: 'Include model name and model number, for example \'PlayStation 5\'<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The product name will be permanent for this product record</span>'.html_safe },
-  attributes: { disabled: local_assigns[:disable_permanent_fields] }
-) %>
+
+<%= form.govuk_text_field :name,
+                          label: {text: "Product name", size: 'm'},
+                          hint: {text: 'Include model name and model number, for example \'PlayStation 5\'<span class="govuk-visually-hidden">.</span><br><span class="govuk-!-font-size-16">The product name will be permanent for this product record</span>'.html_safe},
+                          disabled: true
+%>
 
 <% if !local_assigns[:disable_image_upload] %>
+<<<<<<< HEAD
   <%= render "upload_file_component", form: form, old_file: nil, field_name: :image, legend: "Upload a product image", label: "Upload a product image" , hint: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF."%>
+=======
+  <%= form.govuk_file_field :image,
+                            label: { text: 'Upload a product image', size: 'm' },
+                            hint: { text: 'Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.' } %>
+>>>>>>> 72885a6bc (Refactored Product Form)
 <% end %>
 
-<%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
 
-<%= govukInput(
-  key: :barcode,
-  id: "barcode",
-  form: form,
-  label: { text: "Barcode number (GTIN, EAN or UPC)", classes: label_class },
-  hint: {text: "Normally 8, 12, or 13 digits"}
-) %>
+<%= form.govuk_collection_radio_buttons :when_placed_on_market,
+                                        items_for_before_2021_radio(product_form).map{|x| OpenStruct.new(value: x[:value], text: x[:text])},
+                                        :value,
+                                        :text, legend: {text: "Was the product placed on the market before 1 January 2021?"}%>
+
+
+<%= form.govuk_number_field :barcode,
+                          label: {text: "Barcode number (GTIN, EAN or UPC)", size: 'm'},
+                          hint: {text: "Normally 8, 12, or 13 digits"}
+%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -95,29 +85,17 @@
   </div>
 </div>
 
-<%= govukTextarea(
-  key: :product_code,
-  form: form,
-  label: { text: "Other product identifiers", classes: label_class },
-  hint: { text: "For example, serial number, Amazon ID (ASIN) or eBay ID. Use a comma to separate multiple identifiers, and a hyphen to indicate ranges." }
-) %>
+<%= form.govuk_text_area :product_code, label: { text: 'Other product identifiers', size: 'm' }, hint: { text: "For example, serial number, Amazon ID (ASIN) or eBay ID. Use a comma to separate multiple identifiers, and a hyphen to indicate ranges." } %>
 
-<%= govukInput(
-  key: :webpage,
-  form: form,
-  label: { text: "Webpage", classes: label_class },
-  hint: { text: "The manufacturer's page for the product, or a link to where it can be bought" }
-) %>
+<%= form.govuk_text_field :webpage, label: { text: 'Webpage', size: 'm' }, hint: { text: "The manufacturer's page for the product, or a link to where it can be bought" } %>
 
-<%= govukSelect(
-  form: form,
-  key: :country_of_origin,
-  id: "country_of_origin",
-  items: options_for_country_of_origin(countries, product_form),
-  include_blank: true,
-  label: { text: "Country of origin", classes: label_class },
-  hint: { text: "Where the product was manufactured" }
-) %>
+
+<%= form.govuk_collection_select :country_of_origin,
+                                 [OpenStruct.new(value: "", text: "")] + options_for_country_of_origin(countries, product_form).map{|x| OpenStruct.new(value: x[:value], text: x[:text])},
+                                 :value,
+                                 :text,
+                                 label: { text: "Country of origin", size: "m" },
+                                 hint: { text: "Where the product was manufactured" } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -125,14 +103,9 @@
   </div>
 </div>
 
-<%= govukTextarea(
-  key: :description,
-  form: form,
-  attributes: { maxlength: 10_000 },
-  label: { text: "Description of product", classes: label_class },
-  hint: { text: "Details about the product you haven't included above. For example, colour, size, packaging description. Do not include details of damage or incidents" }
-) %>
+
+<%= form.govuk_text_area :description, label: { text: "Description of product", size: 'm' }, hint: { text: "Details about the product you haven't included above. For example, colour, size, packaging description. Do not include details of damage or incidents" } %>
 
 <%= form.hidden_field :notification_pretty_id, value: product_form.notification_pretty_id || params[:notification_pretty_id] %>
 
-<%= form.submit local_assigns[:submit_text] || "Save", class: "govuk-button", data: { cy: "save" } %>
+<%= form.govuk_submit local_assigns[:submit_text] || "Save", class: "govuk-button", data: { cy: "save" } %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Edit product", errors: @product_form.errors.any? %>
-<%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings when_placed_on_market name]) %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "Create a product record", errors: @product_form.errors.any? %>
-<%= form_with model: @product_form, scope: :product, url: products_path(@investigation), builder: ApplicationFormBuilder do |form| %>
+<%= form_with model: @product_form, scope: :product, url: products_path(@investigation), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings name when_placed_on_market barcode]) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,6 @@ default: &default
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  password: "password"
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  password: "password"
 
 development:
   <<: *default

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
   let(:user)              { create(:user, :activated, has_viewed_introduction: true) }
   let(:other_user)        { create(:user, :activated, has_viewed_introduction: true) }
   let(:brand)             { Faker::Appliance.brand }
-  let(:country_of_origin) { "France" }
+  let(:country_of_origin) { "country:FR" }
   let(:investigation)     { create(:notification, creator: user) }
   let(:product) do
     create(:product,
@@ -144,7 +144,6 @@ RSpec.feature "Editing a product", :with_opensearch, :with_stubbed_mailer, :with
       # expect(page).to have_link "Change product details"
 
       visit "/products/#{product.id}"
-
       click_link "Edit this product record"
 
       expect(page).to have_select("Product category", selected: product.category, disabled: true)

--- a/spec/features/product_versioning_spec.rb
+++ b/spec/features/product_versioning_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Product versioning", :with_stubbed_antivirus, :with_stubbed_maile
   let(:initial_product_description) { "Widget" }
   let(:new_product_description) { "Sausage" }
   let(:creation_time) { 1.day.ago }
-  let(:product) { create(:product, :with_antivirus_checked_image_upload, description: initial_product_description, owning_team: user.team) }
+  let(:product) { create(:product, :with_antivirus_checked_image_upload, description: initial_product_description, owning_team: user.team, country_of_origin: "country:BS") }
   let(:first_investigation) { create(:notification, creator: user, products: [product]) }
   let(:second_investigation) { create(:notification, creator: user) }
 

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, type: :feature d
            brand: "MyBrand",
            name: "Washing machine",
            category: "Electrical appliances and equipment",
+           country_of_origin: "country:AL",
            subcategory: "washing machine",
            product_code: "MBWM01",
            webpage: "http://example.com/mybrand/washing-machines",


### PR DESCRIPTION
Description
Refactored Products Form to use GOVUKDesignSystemFormBuilder instead of  ApplicationFormBuilder and made changes to the product related rspecs where necessary
