### PR TITLE
fix/PSD-2795-undefined_method_persist_issue

### DIFF
--- a/app/views/investigations/test_results/show.html.erb
+++ b/app/views/investigations/test_results/show.html.erb
@@ -18,8 +18,9 @@
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m">Attachment</h2>
 
-    <p class="govuk-body"><%= link_to @test_result.document.filename, @test_result.document, class: "govuk-link" %></p>
-
-    <%= document_placeholder(@test_result.document) %>
+    <% if @test_result&.document.present? %>
+      <p class="govuk-body"><%= link_to @test_result.document.filename, @test_result.document, class: "govuk-link" %></p>
+      <%= document_placeholder(@test_result.document) %>
+    <% end %>
   </div>
 </div>

--- a/spec/features/editing_business_details_spec.rb
+++ b/spec/features/editing_business_details_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch
   scenario "Updating a business's details" do
     sign_in user
     visit "/businesses/#{business.id}"
-    puts "im here"
     expect_to_be_on_business_page(business_id: business.id, business_name: "OldCo")
-    puts "im past this function"
     click_link "Edit details"
 
     expect_to_be_on_edit_business_page(business_id: business.id, business_name: "OldCo")


### PR DESCRIPTION
## Description
Fixing a Sentry issue where it was reporting an error due to a nil object.

Error message: `undefined method 'persisted?' for nil:NilClass`