### PR TITLE
chore/PSD-2794-issue_with_app-views-products

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -38,16 +38,16 @@ class ProductForm
 
   validates :barcode, allow_nil: true, numericality: { only_integer: true }
   validates :barcode, allow_nil: true, length: { minimum: 5, maximum: 15 }, if: -> { barcode =~ /\A\d+\z/ }
-  validates :authenticity, inclusion: { in: Product.authenticities.keys }
   validates :category, presence: true
   validates :subcategory, presence: true
+  validates :authenticity, inclusion: { in: Product.authenticities.keys }
+  validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validates :name, presence: true
-  validates :country_of_origin, presence: true
   validates :when_placed_on_market, presence: true
+  validates :country_of_origin, presence: true
   validates :description, length: { maximum: 10_000 }
   validate :acceptable_image
 
-  validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validate :markings_validity, if: -> { has_markings == "markings_yes" }
 
   # members

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -36,14 +36,15 @@ class ProductForm
   before_validation { trim_whitespace(:brand) }
   before_validation { nilify_blanks(:barcode, :brand) }
 
-  validates :barcode, allow_nil: true, numericality: { only_integer: true }
-  validates :barcode, allow_nil: true, length: { minimum: 5, maximum: 15 }, if: -> { barcode =~ /\A\d+\z/ }
+
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :authenticity, inclusion: { in: Product.authenticities.keys }
   validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validates :name, presence: true
   validates :when_placed_on_market, presence: true
+  validates :barcode, allow_nil: true, numericality: { only_integer: true }
+  validates :barcode, allow_nil: true, length: { minimum: 5, maximum: 15 }, if: -> { barcode =~ /\A\d+\z/ }
   validates :country_of_origin, presence: true
   validates :description, length: { maximum: 10_000 }
   validate :acceptable_image

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -36,7 +36,6 @@ class ProductForm
   before_validation { trim_whitespace(:brand) }
   before_validation { nilify_blanks(:barcode, :brand) }
 
-
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :authenticity, inclusion: { in: Product.authenticities.keys }

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -2,7 +2,7 @@
 <%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings when_placed_on_market name]) %>
+      <%= form.govuk_error_summary  %>
     </div>
   </div>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -2,7 +2,7 @@
 <%= form_with model: @product_form, scope: :product, url: products_path(@investigation), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings name when_placed_on_market barcode]) %>
+      <%= form.govuk_error_summary  %>
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Create a product record</h1>
       <p class="govuk-body govuk-!-margin-bottom-7 opss-secondary-text">If a record of a product does not already exist in the Product Safety Database (<%= psd_abbr title: false %>), you can create a product record for the product. This will also generate a new <%= psd_abbr %> product record reference number.</p>


### PR DESCRIPTION
While refactoring the form I forgot to change the error summary to form.govuk_error_summary, this meant when the user clicked on the error messages that were present at the top, they would not be redirected to the field that caused the error message to occur.