### PR TITLE
refactor/PSD-2670-Update_to_accidents_or_incidents_form

### DIFF
--- a/app/controllers/investigations/accident_or_incidents_controller.rb
+++ b/app/controllers/investigations/accident_or_incidents_controller.rb
@@ -10,6 +10,8 @@ module Investigations
 
     def create
       @accident_or_incident_form = AccidentOrIncidentForm.new(accident_or_incident_params)
+      @accident_or_incident_form.date = @accident_or_incident_form.send(:set_date) if @accident_or_incident_form.is_date_known
+
       return render(:new) if @accident_or_incident_form.invalid?
 
       AddAccidentOrIncidentToNotification.call!(
@@ -40,7 +42,10 @@ module Investigations
       @accident_or_incident = @investigation.unexpected_events.find(params[:id])
       @accident_or_incident_form = AccidentOrIncidentForm.from(@accident_or_incident)
       @accident_or_incident_form.assign_attributes(accident_or_incident_params)
-
+      @accident_or_incident_form.date_year = params[:accident_or_incident_form]["date(1i)"]
+      @accident_or_incident_form.date_month = params[:accident_or_incident_form]["date(2i)"]
+      @accident_or_incident_form.date_day = params[:accident_or_incident_form]["date(3i)"]
+      @accident_or_incident_form.date = @accident_or_incident_form.send(:set_date)
       if @accident_or_incident_form.valid?
         UpdateAccidentOrIncident.call!(
           @accident_or_incident_form.serializable_hash.merge({
@@ -64,7 +69,7 @@ module Investigations
     end
 
     def accident_or_incident_params
-      params.require(:accident_or_incident_form).permit(:is_date_known, :severity, :severity_other, :additional_info, :usage, :investigation_product_id, :type, date: %i[day month year])
+      params.require(:accident_or_incident_form).permit(:is_date_known, :severity, :severity_other, :additional_info, :usage, :investigation_product_id, :type, :date, "date(1i)", "date(2i)", "date(3i)")
     end
   end
 end

--- a/app/views/investigations/accident_or_incidents/_form.html.erb
+++ b/app/views/investigations/accident_or_incidents/_form.html.erb
@@ -1,26 +1,44 @@
-<%= form.govuk_radios :is_date_known, legend: "Do you know when the #{form.object.type.downcase} happened?", items: [{ text: "Yes", value: "true", conditional: { html: form.govuk_date_input(:date, legend: "Date of #{form.object.type.downcase}", hint: "For example, 12 11 2020", classes: "govuk-fieldset__legend") } }, { text: "No", value: "false" }] %>
-
+<%= form.govuk_radio_buttons_fieldset(:is_date_known, legend: { size: 'm', text: "Do you know when the #{form.object.type.downcase} happened?" }) do %>
+  <%= form.govuk_radio_button :is_date_known, 'true', label: { text: 'Yes' }, link_errors: true do %>
+    <%= form.govuk_date_field :date, date: true, legend: { text: "Date of #{form.object.type.downcase}" }, hint: {text: "For example, 12 11 2020"} %>
+  <% end %>
+  <%= form.govuk_radio_button :is_date_known, 'false', label: { text: 'No' } %>
+<% end %>
 <% if investigation.products.uniq.one? %>
   <h2 class="govuk-heading-m"><%= "Product involved" %></h2>
   <p class="govuk-body"><%= investigation.products.first.name %></p>
   <%= form.hidden_field :investigation_product_id, value: investigation.investigation_products.first.id %>
 <% else %>
-  <%= form.govuk_select :investigation_product_id, label: "Which product was involved?", label_classes: "govuk-label--m", items: [{ text: "", value: "" }] + investigation.investigation_products.map { |investigation_product| { text: "#{investigation_product.name} (#{investigation_product.psd_ref})", value: investigation_product.id } } %>
+  <h2 class="govuk-heading-m"><%= "Which product was involved?" %></h2>
+  <%= form.govuk_collection_select :investigation_product_id,
+                                   [OpenStruct.new(value: "", text: "")] + investigation.investigation_products.map { |investigation_product| OpenStruct.new(value: investigation_product.id, text: "#{investigation_product.name} (#{investigation_product.psd_ref})" ) },
+                                   :value,
+                                   :text,
+                                   label: {text: "Which product was involved?", hidden: true} %>
 <% end %>
 
 <% other = capture do %>
-<%= govukInput(
-  key: :severity_other,
-  form: form,
-  classes: "govuk-!-width-one-third",
-  label: { text: "Other type", classes: "govuk-visually-hidden" }
-) %>
+  <%= form.govuk_text_field :severity_other,
+                            label: { text: "Other type", hidden: true }, width: "one-third" %>
 <% end %>
 
-<%= form.govuk_radios :usage, legend: "How was the product being used?", items: [{ text: "Normal use", value: "during_normal_use" },  { text: "Misuse", value: "during_misuse" }, { text: "With the supervision of an adult", value: "with_adult_supervision" }, { text: "Without the supervision of an adult", value: "without_adult_supervision" }, { text: "Unknown use", value: "unknown_usage" }] %>
+<%= form.govuk_collection_radio_buttons :usage,
+                                        [{ text: "Normal use", value: "during_normal_use" },  { text: "Misuse", value: "during_misuse" }, { text: "With the supervision of an adult", value: "with_adult_supervision" }, { text: "Without the supervision of an adult", value: "without_adult_supervision" }, { text: "Unknown use", value: "unknown_usage" }].map{|x| OpenStruct.new(value: x[:value], text: x[:text])},
+                                        :value,
+                                        :text,
+                                        legend: {text: "How was the product being used?"} %>
 
-<%= form.govuk_radios :severity, legend: "Indicate the severity", items: [{ text: "Serious", value: "serious" },  { text: "High", value: "high" }, { text: "Medium", value: "medium" }, { text: "Low", value: "low" }, { text: "Unknown", value: "unknown_severity" }, { text: "Other", value: "other", conditional: { html: other } }] %>
+<%= form.govuk_radio_buttons_fieldset(:severity, legend: { text: "Indicate the severity" }) do %>
+  <%= form.govuk_radio_button :severity, 'serious', label: { text: 'Serious' }, link_errors: true%>
+  <%= form.govuk_radio_button :severity, 'high', label: { text: 'High' } %>
+  <%= form.govuk_radio_button :severity, 'medium', label: { text: 'Medium' } %>
+  <%= form.govuk_radio_button :severity, 'low', label: { text: 'Low' } %>
+  <%= form.govuk_radio_button :severity, 'unknown_severity', label: { text: 'Unknown' } %>
+  <%= form.govuk_radio_button :severity, 'other', label: { text: 'Other' } do %>
+    <%= other %>
+  <% end %>
+<% end %>
 
-<%= form.govuk_text_area :additional_info, label: "Additional information (optional)", attributes: { maxlength: 32_767 } %>
+<%= form.govuk_text_area :additional_info, label: {text: "Additional information (optional)"}, max_chars: 32_767 %>
 
 <%= form.hidden_field :type, value: form.object.type %>

--- a/app/views/investigations/accident_or_incidents/edit.html.erb
+++ b/app/views/investigations/accident_or_incidents/edit.html.erb
@@ -2,15 +2,15 @@
 <% page_title page_heading %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @accident_or_incident_form, url: investigation_accident_or_incident_path(@investigation, @accident_or_incident), method: :patch, builder: ApplicationFormBuilder) do |form| %>
-      <%= error_summary(@accident_or_incident_form.errors, %i[is_date_known date investigation_product_id usage severity severity_other]) %>
+    <%= form_with(model: @accident_or_incident_form, url: investigation_accident_or_incident_path(@investigation, @accident_or_incident), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorSummaryPresenter)  %>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
       <%= render "form", form: form, accident_or_incident_form: @accident_or_incident_form, investigation: @investigation, type: @accident_or_incident.type %>
 
-      <%= govukButton text: "Update #{@accident_or_incident.type.downcase}" %>
+      <%= form.govuk_submit "Update #{@accident_or_incident.type.downcase}" %>
     <% end %>
   </div>
 </div>

--- a/app/views/investigations/accident_or_incidents/new.html.erb
+++ b/app/views/investigations/accident_or_incidents/new.html.erb
@@ -1,16 +1,16 @@
 <% page_heading = "Record an #{@accident_or_incident_form.type.downcase}" %>
 <%= page_title page_heading, errors: @accident_or_incident_form.errors.any? %>
-<%= form_with model: @accident_or_incident_form, scope: :accident_or_incident_form, builder: ApplicationFormBuilder, method: :post, url: investigation_accident_or_incidents_path(@investigation.pretty_id) do |form| %>
+<%= form_with model: @accident_or_incident_form, scope: :accident_or_incident_form, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post, url: investigation_accident_or_incidents_path(@investigation.pretty_id) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@accident_or_incident_form.errors, %i[is_date_known date investigation_product_id usage severity severity_other])%>
+      <%= form.govuk_error_summary(presenter: ErrorSummaryPresenter)  %>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
       <%= render "form", form: form, accident_or_incident_form: @accident_or_incident_form, investigation: @investigation, type: @accident_or_incident_form.type %>
 
-      <%= govukButton text: "Add #{@accident_or_incident_form.type.downcase}" %>
+      <%= form.govuk_submit "Add #{@accident_or_incident_form.type.downcase}" %>
     </div>
   </div>
 <% end %>

--- a/app/views/investigations/accident_or_incidents_type/new.html.erb
+++ b/app/views/investigations/accident_or_incidents_type/new.html.erb
@@ -1,16 +1,19 @@
 <% page_heading = "Are you recording an accident or incident?" %>
 <% page_title page_heading, errors: @accident_or_incident_type_form.errors.any? %>
-<%= form_with scope: :investigation, model: @accident_or_incident_type_form, url: investigation_accident_or_incidents_type_index_path(@investigation), builder: ApplicationFormBuilder, method: :post do |form| %>
+<%= form_with scope: :investigation, model: @accident_or_incident_type_form, url: investigation_accident_or_incidents_type_index_path(@investigation), builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @accident_or_incident_type_form.errors %>
+      <%= form.govuk_error_summary %>
 
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
-      <%= form.govuk_radios :type, legend: nil, items: [{ text: "Accident", value: "Accident", id: "accident_type" }, { text: "Incident", value: "Incident", id: "incident_type" }] %>
-
+      <%= form.govuk_collection_radio_buttons :type,
+                                              [{ text: "Accident", value: "Accident", id: "accident_type" }, { text: "Incident", value: "Incident", id: "incident_type" }].map{|x| OpenStruct.new(value: x[:value], text: x[:text])},
+                                              :value,
+                                              :text,
+                                              legend: {text: "", hidden: true}%>
       <div class="govuk-form-group">
-        <%= govukButton(text: "Continue") %>
+        <%= form.govuk_submit "Continue" %>
         <p><%= link_to "Cancel", investigation_supporting_information_index_path(@investigation), class: "govuk-link--no-visited-state" %></p>
       </div>
     </div>

--- a/spec/forms/accident_or_incident_form_spec.rb
+++ b/spec/forms/accident_or_incident_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AccidentOrIncidentForm, :with_test_queue_adapter do
   let(:notification) { create(:notification) }
   let(:user) { create(:user) }
 
-  let(:date) { { day: "1", month: "2", year: "2020" } }
+  let(:date) { Date.new(2020, 2, 1) }
   let(:is_date_known) { "true" }
   let(:severity) { "serious" }
   let(:severity_other) { "" }
@@ -20,7 +20,10 @@ RSpec.describe AccidentOrIncidentForm, :with_test_queue_adapter do
       severity_other:,
       usage:,
       investigation_product_id:,
-      type:
+      type:,
+      "date(1i)" => 2020,
+      "date(2i)" => 2,
+      "date(3i)" => 1,
     }
   end
 

--- a/spec/helpers/error_summary_presenter_spec.rb
+++ b/spec/helpers/error_summary_presenter_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
 
     context "when the form submitted is an AccidentOrIncident form" do
       let(:accident_or_incident_form) { AccidentOrIncidentForm.new(type: "accident", date: { year: "", month: "", day: "" }) }
-      let(:accident_or_incident_form_with_date) { AccidentOrIncidentForm.new(type: "accident", is_date_known: "yes", date: Date.new(2022, 2, 11)) }
+      let(:accident_or_incident_form_with_date) { AccidentOrIncidentForm.new(type: "accident", is_date_known: "yes", date: Date.new(2022, 2, 11), "date(1i)" => 2022, "date(2i)" => 2, "date(3i)" => 11) }
       let(:accident_or_incident_form_with_usage) { AccidentOrIncidentForm.new(type: "accident", usage: "during_normal_use") }
       let(:accident_or_incident_form_with_severity) { AccidentOrIncidentForm.new(type: "accident", severity: "serious") }
-      let(:accident_or_incident_form_complete) { AccidentOrIncidentForm.new(type: "accident", investigation_product_id: create(:investigation_product).id, is_date_known: "yes", date: Date.new(2022, 2, 11), usage: "during_normal_use", severity: "serious") }
+      let(:accident_or_incident_form_complete) { AccidentOrIncidentForm.new(type: "accident", investigation_product_id: create(:investigation_product).id, is_date_known: "yes", date: Date.new(2022, 2, 11), "date(1i)" => 2022, "date(2i)" => 2, "date(3i)" => 11, usage: "during_normal_use", severity: "serious") }
 
       before do
         accident_or_incident_form.invalid?

--- a/spec/helpers/error_summary_presenter_spec.rb
+++ b/spec/helpers/error_summary_presenter_spec.rb
@@ -79,5 +79,66 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
         end
       end
     end
+
+    context "when the form submitted is an AccidentOrIncident form" do
+      let(:accident_or_incident_form) { AccidentOrIncidentForm.new(type: "accident", date: { year: "", month: "", day: "" }) }
+      let(:accident_or_incident_form_with_date) { AccidentOrIncidentForm.new(type: "accident", is_date_known: "yes", date: Date.new(2022, 2, 11)) }
+      let(:accident_or_incident_form_with_usage) { AccidentOrIncidentForm.new(type: "accident", usage: "during_normal_use") }
+      let(:accident_or_incident_form_with_severity) { AccidentOrIncidentForm.new(type: "accident", severity: "serious") }
+      let(:accident_or_incident_form_complete) { AccidentOrIncidentForm.new(type: "accident", investigation_product_id: create(:investigation_product).id, is_date_known: "yes", date: Date.new(2022, 2, 11), usage: "during_normal_use", severity: "serious") }
+
+      before do
+        accident_or_incident_form.invalid?
+        accident_or_incident_form_with_date.invalid?
+        accident_or_incident_form_with_usage.invalid?
+        accident_or_incident_form_with_severity.invalid?
+        accident_or_incident_form_complete.invalid?
+      end
+
+      context "when no parameters supplied" do
+        it "returns the expected errors" do
+          presenter = described_class.new(accident_or_incident_form.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = [[:is_date_known, "Select yes if you know when the accident happened"], [:investigation_product_id, "Select the product involved in the accident"], [:usage, "Select how the product was being used"], [:severity, "Select the severity of the accident"]]
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+
+      context "when date is known parameter and date parameter supplied" do
+        it "does not have date error when parameter is filled" do
+          presenter = described_class.new(accident_or_incident_form_with_date.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = [[:investigation_product_id, "Select the product involved in the accident"], [:usage, "Select how the product was being used"], [:severity, "Select the severity of the accident"]]
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+
+      context "when :usage parameter is supplied" do
+        it "does not have :usage error" do
+          presenter = described_class.new(accident_or_incident_form_with_usage.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = [[:is_date_known, "Select yes if you know when the accident happened"], [:investigation_product_id, "Select the product involved in the accident"], [:severity, "Select the severity of the accident"]]
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+
+      context "when :severity parameter is supplied" do
+        it "does not have :severity error" do
+          presenter = described_class.new(accident_or_incident_form_with_severity.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = [[:is_date_known, "Select yes if you know when the accident happened"], [:investigation_product_id, "Select the product involved in the accident"], [:usage, "Select how the product was being used"]]
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+
+      context "when all parameters supplied" do
+        it "does not have errors" do
+          presenter = described_class.new(accident_or_incident_form_complete.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = []
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Description
Refactored Accidents or Incidents form to use the new GOVUK form builder instead of application builder, made changes to the controller to deal with the forms date fields, and made changes to accident_or_incidents_form.spec.rb to address the HTML changes.

Added extra context to spec/helpers/error_summary_presenter_spec.rb.
