### PR TITLE
refactor/PSD-2854-Update_to_documents_form

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,16 +1,16 @@
 <% title = "Edit attachment" %>
 <% page_title title, errors: @document_form.errors.any? %>
-<%= form_with model: @document_form, scope: :document, builder: ApplicationFormBuilder, url: associated_document_path(@parent, @file), method: :patch do |form| %>
+<%= form_with model: @document_form, scope: :document, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: associated_document_path(@parent, @file), method: :patch do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@document_form.errors, %i[title description])%>
+      <%= form.govuk_error_summary %>
       <%= render "page_heading", title: "Edit attachment" %>
       <%= render "documents/document_preview", document: @file, dimensions: [480, 320] %>
 
-      <%= form.govuk_input :title, label_classes: "govuk-label--m", label: "Document title" %>
-      <%= form.govuk_text_area :description, label: "Description", attributes: { maxlength: 10_000 } %>
+      <%= form.govuk_text_field :title, label: { text: "Document title", size: "m" } %>
+      <%= form.govuk_text_area :description, label: { text: "Description" }, maxchars: 10_000 %>
 
-      <%= govukButton text: "Update attachment" %>
+      <%= form.govuk_submit "Update attachment" %>
     </div>
   </div>
 <% end %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -1,9 +1,9 @@
 <% title = "Add attachment" %>
 <%= page_title title, errors: @document_form.errors.any? %>
-<%= form_with model: @document_form, scope: :document, builder: ApplicationFormBuilder, url: associated_documents_path(@parent) do |form| %>
+<%= form_with model: @document_form, scope: :document, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: associated_documents_path(@parent) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@document_form.errors, %i[document title description])%>
+      <%= form.govuk_error_summary %>
       <span class="govuk-caption-l"><%= @parent.pretty_description %></span>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
 
@@ -11,13 +11,21 @@
         <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the notification images page." : "Image files will be saved to the product images." %>
         <div class="govuk-hint govuk-!-margin-bottom-8"><%= hint_text %></div>
       <% end %>
+      <% if form.object.document.present? %>
+        <%= form.hidden_field :document, value: form.object.document.id %>
+        <%= form.govuk_fieldset legend: { text: "Upload a file" } do %>
+          <%= form.govuk_file_field :document, label: { text: "", hidden: true } %>
+          <%= render partial: "active_storage/blobs/blob", locals: { blob: form.object.document } %>
+        <% end %>
+      <% else %>
+        <%= form.govuk_file_field :document, label: { text: "Upload a file" } %>
+      <% end %>
 
-      <%= render "upload_file_component", form: form, old_file: nil, field_name: :document, legend: "Upload a file", label: "Upload a file", hint: nil %>
 
-      <%= form.govuk_input :title, label_classes: "govuk-label--m", label: "Document title" %>
-      <%= form.govuk_text_area :description, label: "Description", attributes: { maxlength: 10_000 } %>
+      <%= form.govuk_text_field :title, label: { text: "Document title", size: "m" } %>
+      <%= form.govuk_text_area :description, label: { text: "Description" }, attributes: { maxlength: 10_000 } %>
 
-      <%= govukButton text: "Save attachment" %>
+      <%= form.govuk_submit "Save attachment" %>
     </div>
   </div>
 <% end %>

--- a/app/views/documents/remove.html.erb
+++ b/app/views/documents/remove.html.erb
@@ -43,6 +43,6 @@
   </div>
 </div>
 
-<%= form_with url: associated_document_path(@parent, @file), method: :delete do |form| %>
-  <%= form.submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
+<%= form_with url: associated_document_path(@parent, @file), builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :delete do |form| %>
+  <%= form.govuk_submit "Delete attachment", class: "govuk-button govuk-button--warning" %>
 <% end %>


### PR DESCRIPTION
Updated Documents form to use GOVUK form builder instead of application form builder., made changes to form to display errors in correct order and to store file preventing user from having to rerenter it