### PR TITLE
chore/PSD-2864-Adding_missing_validation_to_form

### DIFF
--- a/app/forms/change_notification_details_form.rb
+++ b/app/forms/change_notification_details_form.rb
@@ -9,7 +9,7 @@ class ChangeNotificationDetailsForm
   attribute :current_user
   attribute :notification_id
 
-  validates :user_title, :reported_reason, presence: true, length: {maximum: 100}
+  validates :user_title, :reported_reason, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 10_000 }
   validate :unique_user_title_within_team
 

--- a/app/forms/change_notification_details_form.rb
+++ b/app/forms/change_notification_details_form.rb
@@ -9,7 +9,7 @@ class ChangeNotificationDetailsForm
   attribute :current_user
   attribute :notification_id
 
-  validates :user_title, :reported_reason, presence: true
+  validates :user_title, :reported_reason, presence: true, length: {maximum: 100}
   validates :description, length: { maximum: 10_000 }
   validate :unique_user_title_within_team
 

--- a/app/forms/change_notification_details_form.rb
+++ b/app/forms/change_notification_details_form.rb
@@ -9,7 +9,8 @@ class ChangeNotificationDetailsForm
   attribute :current_user
   attribute :notification_id
 
-  validates :user_title, :reported_reason, presence: true, length: { maximum: 100 }
+  validates :user_title, presence: true, length: { maximum: 100 }
+  validates :reported_reason, presence: true
   validates :description, length: { maximum: 10_000 }
   validate :unique_user_title_within_team
 


### PR DESCRIPTION
previous team forgot to add maximum length validation to notification user title of notification name in the notification tasklist journey, if the user entered a notification name longer than 100 characters they would be given a 422 error.
