### PR TITLE
chore/PSD-2869:PSD2.0_rearrange_Corrective_Action_messages

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -228,6 +228,7 @@ class BulkProductsController < ApplicationController
 
     if request.put?
       @bulk_products_create_corrective_action_form = CorrectiveActionForm.new(bulk_products_create_corrective_action_params.merge(duration: "unknown"))
+      @bulk_products_create_corrective_action_form.date_decided = @bulk_products_create_corrective_action_form.send(:set_date)
       @bulk_products_create_corrective_action_form.legislation.reject!(&:blank?)
       @bulk_products_create_corrective_action_form.geographic_scopes.reject!(&:blank?)
       @file_blob = @bulk_products_create_corrective_action_form.document
@@ -342,6 +343,6 @@ private
       geographic_scopes: [],
       file: %i[file description],
       date_decided: %i[day month year]
-    ).with_defaults(legislation: [], geographic_scopes: [])
+    ).with_defaults(legislation: [], geographic_scopes: []).merge("date_decided(1i)" => params[:corrective_action]["date_decided(1i)"]).merge("date_decided(2i)" => params[:corrective_action]["date_decided(2i)"]).merge("date_decided(3i)" => params[:corrective_action]["date_decided(3i)"])
   end
 end

--- a/app/controllers/concerns/corrective_actions_concern.rb
+++ b/app/controllers/concerns/corrective_actions_concern.rb
@@ -17,8 +17,7 @@ module CorrectiveActionsConcern
       :existing_document_file_id,
       legislation: [],
       geographic_scopes: [],
-      file: %i[file description],
-      date_decided: %i[day month year]
-    ).with_defaults(legislation: [], geographic_scopes: [])
+      file: %i[file description]
+    ).with_defaults(legislation: [], geographic_scopes: []).merge("date_decided(1i)" => params[:corrective_action]["date_decided(1i)"]).merge("date_decided(2i)" => params[:corrective_action]["date_decided(2i)"]).merge("date_decided(3i)" => params[:corrective_action]["date_decided(3i)"])
   end
 end

--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -10,10 +10,12 @@ module Investigations
     end
 
     def create
-      @corrective_action_form = CorrectiveActionForm.new(corrective_action_params.merge(duration: "unknown"))
+      @corrective_action_form = CorrectiveActionForm.new(corrective_action_params.merge(duration: "unknown").merge(params["date_decided(1i)"]))
       @corrective_action_form.legislation.reject!(&:blank?)
       @corrective_action_form.geographic_scopes.reject!(&:blank?)
       @file_blob = @corrective_action_form.document
+      @corrective_action_form.date_decided = @corrective_action_form.send(:set_date)
+
       return render :new if @corrective_action_form.invalid?(:add_corrective_action)
 
       result = AddCorrectiveActionToNotification.call(
@@ -47,9 +49,14 @@ module Investigations
       @corrective_action_form = CorrectiveActionForm.from(corrective_action)
       @file_blob              = corrective_action.document_blob
 
-      @corrective_action_form.assign_attributes(corrective_action_params.merge(duration: "unknown"))
+      @corrective_action_form.assign_attributes(corrective_action_params)
+      @corrective_action_form.date_decided_year = params[:corrective_action]["date_decided(1i)"]
+      @corrective_action_form.date_decided_month = params[:corrective_action]["date_decided(2i)"]
+      @corrective_action_form.date_decided_day = params[:corrective_action]["date_decided(3i)"]
+
       @corrective_action_form.legislation.reject!(&:blank?)
       @corrective_action_form.geographic_scopes.reject!(&:blank?)
+      @corrective_action_form.date_decided = @corrective_action_form.send(:set_date)
       return render :edit if @corrective_action_form.invalid?(:edit_corrective_action)
 
       UpdateCorrectiveAction.call!(

--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -68,8 +68,7 @@ module Investigations
             changes: @corrective_action_form.changes
           )
       )
-
-      ahoy.track "Updated corrective action", { notification_id: @investigation.id }
+      ahoy.track "Updated corrective action", { notification_id: @investigation.id } if @corrective_action_form.changes != { "date_decided(1i)" => [nil, params[:corrective_action]["date_decided(1i)"]], "date_decided(2i)" => [nil, params[:corrective_action]["date_decided(2i)"]], "date_decided(3i)" => [nil, params[:corrective_action]["date_decided(3i)"]] }
 
       if params[:bulk_products_upload_id].present?
         redirect_to check_corrective_actions_bulk_upload_products_path(bulk_products_upload_id: params[:bulk_products_upload_id])

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -96,7 +96,7 @@ module Investigations
             user: current_user
           })
         )
-        ahoy.track "Updated risk assessment", { notification_id: @investigation_object.id }
+        ahoy.track "Updated risk assessment", { notification_id: @investigation_object.id } if @risk_assessment.changes != {}
 
         # If the risk level has not been set for the investigation, set it to the same
         # as the risk assessment. This will force the redirect to the supporting information

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -254,6 +254,7 @@ module Notifications
           return render :record_a_corrective_action_taken
         elsif params[:investigation_product_ids].present?
           @corrective_action_form = CorrectiveActionForm.new
+          @corrective_action_form.date_decided = @corrective_action_form.send(:set_date)
           @investigation_products = @notification.investigation_products.where(id: params[:investigation_product_ids])
 
           return redirect_to wizard_path(:record_a_corrective_action) if @investigation_products.blank?
@@ -569,6 +570,7 @@ module Notifications
           end
         elsif params[:investigation_product_ids].present?
           @corrective_action_form = CorrectiveActionForm.new(record_a_corrective_action_details_params.merge(duration: "unknown"))
+          @corrective_action_form.date_decided = @corrective_action_form.send(:set_date)
           @investigation_products = @notification.investigation_products.where(id: params[:investigation_product_ids])
 
           if @corrective_action_form.valid?
@@ -888,6 +890,7 @@ module Notifications
       @corrective_action = @notification.corrective_actions.find(params[:entity_id])
       if request.patch? || request.put?
         @corrective_action_form = CorrectiveActionForm.new(record_a_corrective_action_details_params.merge(duration: "unknown"))
+        @corrective_action_form.date_decided = @corrective_action_form.send(:set_date)
 
         if @corrective_action_form.valid?
           UpdateCorrectiveAction.call!(
@@ -916,6 +919,9 @@ module Notifications
         end
       else
         @corrective_action_form = CorrectiveActionForm.from(@corrective_action)
+        @corrective_action_form.date_decided_year = params[:corrective_action]["date_decided(1i)"]
+        @corrective_action_form.date_decided_month = params[:corrective_action]["date_decided(2i)"]
+        @corrective_action_form.date_decided_day = params[:corrective_action]["date_decided(3i)"]
         render :record_a_corrective_action_details
       end
     end
@@ -1134,7 +1140,7 @@ module Notifications
     end
 
     def record_a_corrective_action_details_params
-      allowed_params = params.require(:corrective_action_form).permit(:action, :has_online_recall_information, :online_recall_information, :business_id, :measure_type, :details, :related_file, :existing_document_file_id, :document, date_decided: %i[day month year], legislation: [], geographic_scopes: [])
+      allowed_params = params.require(:corrective_action_form).permit(:action, :has_online_recall_information, :online_recall_information, :business_id, :measure_type, :details, :related_file, :existing_document_file_id, :document, legislation: [], geographic_scopes: []).merge("date_decided(1i)" => params[:corrective_action_form]["date_decided(1i)"]).merge("date_decided(2i)" => params[:corrective_action_form]["date_decided(2i)"]).merge("date_decided(3i)" => params[:corrective_action_form]["date_decided(3i)"])
       # The form builder inserts an empty hidden field that needs to be removed before validation and saving
       allowed_params[:legislation].reject!(&:blank?)
       allowed_params[:geographic_scopes].reject!(&:blank?)

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -97,7 +97,7 @@ class CorrectiveActionForm
     assign_file_and_description(document_params)
   end
 
-  private
+private
 
   def other?
     (action || "").inquiry.other?

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -108,15 +108,7 @@ class CorrectiveActionForm
 private
 
   def set_date
-    if @date_decided_year.present? && @date_decided_month.present? && @date_decided_day.present?
-      begin
-        Date.new(@date_decided_year.to_i, @date_decided_month.to_i, @date_decided_day.to_i)
-      rescue ArgumentError
-        { year: @date_decided_year, month: @date_decided_month, day: @date_decided_day }
-      end
-    else
-      { year: @date_decided_year, month: @date_decided_month, day: @date_decided_day }
-    end
+    { year: @date_decided_year, month: @date_decided_month, day: @date_decided_day }
   end
 
   def other?

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -29,6 +29,7 @@ class CorrectiveActionForm
   attribute :file_description
   attribute :further_corrective_action, :boolean
 
+  validates :action, inclusion: { in: CorrectiveAction.actions.keys }
   validates :investigation_product_id, presence: true, on: %i[add_corrective_action edit_corrective_action]
   validates :date_decided,
             presence: true,
@@ -36,8 +37,6 @@ class CorrectiveActionForm
             complete_date: true,
             recent_date: true
   validates :legislation, presence: { message: "Select the legislation relevant to the corrective action" }
-  validates :related_file, inclusion: { in: [true, false], message: "Select whether you want to upload a related file" }
-  validate :related_file_attachment_validation
   validates :has_online_recall_information, inclusion: { in: CorrectiveAction.has_online_recall_informations.keys }
   validate :online_recall_information_validation
   validates :further_corrective_action, inclusion: { in: [true, false] }, on: :ts_flow
@@ -47,10 +46,11 @@ class CorrectiveActionForm
   validates :duration, inclusion: { in: CorrectiveAction::DURATION_TYPES }, if: -> { duration.present? }
   validates :geographic_scopes, presence: true
   validate :geographic_scopes_inclusion
-  validates :action, inclusion: { in: CorrectiveAction.actions.keys }
   validates :other_action, presence: true, length: { maximum: 10_000 }, if: :other?
   validates :other_action, absence: true, unless: :other?
   validates :details, length: { maximum: 32_767 }
+  validates :related_file, inclusion: { in: [true, false], message: "Select whether you want to upload a related file" }
+  validate :related_file_attachment_validation
 
   before_validation { trim_whitespace(:other_action, :details, :file_description, :online_recall_information) }
   before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }
@@ -97,7 +97,7 @@ class CorrectiveActionForm
     assign_file_and_description(document_params)
   end
 
-private
+  private
 
   def other?
     (action || "").inquiry.other?

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -7,8 +7,13 @@ class CorrectiveActionForm
   include SanitizationHelper
   include HasDocumentAttachedConcern
 
+  attr_accessor :date_decided_year, :date_decided_month, :date_decided_day
+
   attribute :id
   attribute :date_decided, :govuk_date
+  attribute "date_decided(1i)"
+  attribute "date_decided(2i)"
+  attribute "date_decided(3i)"
   attribute :investigation_product_id, :integer
   attribute :business_id, :integer
   attribute :legislation, default: []
@@ -86,9 +91,12 @@ class CorrectiveActionForm
     end
   end
 
-  def initialize(*args)
+  def initialize(attributes = {})
     super
     self.online_recall_information = nil unless has_online_recall_information_yes?
+    @date_decided_year = attributes["date_decided(1i)"]
+    @date_decided_month = attributes["date_decided(2i)"]
+    @date_decided_day = attributes["date_decided(3i)"]
   end
 
   def file=(document_params)
@@ -98,6 +106,18 @@ class CorrectiveActionForm
   end
 
 private
+
+  def set_date
+    if @date_decided_year.present? && @date_decided_month.present? && @date_decided_day.present?
+      begin
+        Date.new(@date_decided_year.to_i, @date_decided_month.to_i, @date_decided_day.to_i)
+      rescue ArgumentError
+        { year: @date_decided_year, month: @date_decided_month, day: @date_decided_day }
+      end
+    else
+      { year: @date_decided_year, month: @date_decided_month, day: @date_decided_day }
+    end
+  end
 
   def other?
     (action || "").inquiry.other?

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -18,7 +18,7 @@ class UpdateCorrectiveAction
       if any_changes?
         corrective_action.save!
         update_document_description!
-        create_audit_activity_for_corrective_action_updated!
+        create_audit_activity_for_corrective_action_updated! if changes.size != 3
         send_notification_email unless context.silent
 
         investigation.reindex

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -46,7 +46,7 @@ private
   end
 
   def investigation_products_unchanged?
-    @previous_investigation_product_ids.sort == investigation_product_ids.sort
+    @previous_investigation_product_ids.sort == investigation_product_ids.map(&:to_i).sort
   end
 
   def create_audit_activity

--- a/app/views/investigations/corrective_actions/_form.html.erb
+++ b/app/views/investigations/corrective_actions/_form.html.erb
@@ -1,6 +1,3 @@
-<% date_decided_error = corrective_action.errors.include?(:date_decided) %>
-<% two_weeks_from_now = 2.weeks.from_now.to_date %>
-
 <%= f.hidden_field :has_online_recall_information, value: "has_online_recall_information_not_relevant" %>
 <%= f.govuk_radio_buttons_fieldset :action, legend: { text: "What action is being taken?", size: "m" } do %>
   <%= f.govuk_radio_button :action, "removal_of_the_listing_by_the_online_marketplace", label: { text: "Removal of the listing by the online marketplace" }, link_errors: true %>
@@ -26,40 +23,7 @@
   <%= f.govuk_radio_button :action, "modification_programme", label: { text: "Modification programme" } %>
   <%= f.govuk_radio_button :action, "product_no_longer_available_for_sale", label: { text: "Product is no longer available for sale" } %>
 <% end %>
-
-<%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
-<div class="govuk-form-group<%= date_decided_error ? ' govuk-form-group--error' : '' %>">
-  <fieldset class="govuk-fieldset" aria-describedby="corrective-action-date-decided-hint<%= date_decided_error ? ' corrective-action-date-decided-error' : '' %>">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What date did the action come in to effect?</legend>
-    <div class="govuk-hint" id="corrective-action-date-decided-hint">This may be in the future. For example, <%= "#{two_weeks_from_now.day} #{two_weeks_from_now.month} #{two_weeks_from_now.year}" %>.</div>
-    <% if date_decided_error %>
-    <p class="govuk-error-message" id="corrective-action-date-decided-error">
-      <span class="govuk-visually-hidden">Error: </span><%= corrective_action.errors.full_messages_for(:date_decided).first %>
-    </p>
-    <% end %>
-    <div class="govuk-date-input">
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="corrective_action_date_decided_day">Day</label>
-          <input id="corrective_action_date_decided_day" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action[date_decided][day]" type="text" inputmode="numeric" value="<%= corrective_action.date_decided&.day %>">
-        </div>
-      </div>
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="corrective_action_date_decided_month">Month</label>
-          <input id="corrective_action_date_decided_month" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action[date_decided][month]" type="text" inputmode="numeric" value="<%= corrective_action.date_decided&.month %>">
-        </div>
-      </div>
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="corrective_action_date_decided_year">Year</label>
-          <input id="corrective_action_date_decided_year" class="govuk-input govuk-date-input__input govuk-input--width-4<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action[date_decided][year]" type="text" inputmode="numeric" value="<%= corrective_action.date_decided&.year %>">
-        </div>
-      </div>
-    </div>
-  </fieldset>
-</div>
-
+<%= f.govuk_date_field :date_decided, legend: { text: 'What date did the corrective action come in to effect?' }, hint: { text: 'This may be in the future for example, 15 7 2024.' } %>
 <% if allow_product_linking %>
   <% if investigation.investigation_products.empty? %>
     <h2 class="govuk-heading-m">Which product is subject to action?</h2>

--- a/app/views/notifications/create/record_a_corrective_action_details.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_details.html.erb
@@ -43,7 +43,7 @@
         <%= f.govuk_radio_button :action, "modification_programme", label: { text: "Modification programme" } %>
         <%= f.govuk_radio_button :action, "product_no_longer_available_for_sale", label: { text: "Product is no longer available for sale" } %>
       <% end %>
-      <%= f.govuk_date_field :date_decided, legend: { text: 'Enter your date of birth' }, hint: { text: 'For example, 31 3 1980' } %>
+      <%= f.govuk_date_field :date_decided, legend: { text: 'What date did the action come in to effect?' }, hint: { text: 'This may be in the future for example, 15 7 2024.' } %>
 
       <%= f.govuk_select :legislation, options_for_select([""] + Rails.application.config.legislation_constants["legislation"].sort, @corrective_action_form.legislation), label: { text: "Under which legislation?", size: "m" }, hint: { text: "Search applicable legislation and choose the ones you feel are relevant." }, multiple: true %>
       <%= f.govuk_collection_radio_buttons :business_id, @notification.investigation_businesses.decorate.map { |ib| OpenStruct.new(id: ib.business.id, name: "#{ib.business.trading_name} (#{ib.pretty_relationship})") }, :id, :name, legend: { text: "Which business is responsible?", size: "m" }, hint: { text: "Only businesses already added to the notification are listed." } %>

--- a/app/views/notifications/create/record_a_corrective_action_details.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action_details.html.erb
@@ -43,38 +43,8 @@
         <%= f.govuk_radio_button :action, "modification_programme", label: { text: "Modification programme" } %>
         <%= f.govuk_radio_button :action, "product_no_longer_available_for_sale", label: { text: "Product is no longer available for sale" } %>
       <% end %>
-      <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
-      <div class="govuk-form-group<%= date_decided_error ? ' govuk-form-group--error' : '' %>">
-        <fieldset class="govuk-fieldset" aria-describedby="corrective-action-form-date-decided-hint<%= date_decided_error ? ' corrective-action-form-date-decided-error' : '' %>">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What date did the action come in to effect?</legend>
-          <div class="govuk-hint" id="corrective-action-form-date-decided-hint">This may be in the future. For example, <%= "#{two_weeks_from_now.day} #{two_weeks_from_now.month} #{two_weeks_from_now.year}" %>.</div>
-          <% if date_decided_error %>
-          <p class="govuk-error-message" id="corrective-action-form-date-decided-error">
-            <span class="govuk-visually-hidden">Error: </span><%= @corrective_action_form.errors.full_messages_for(:date_decided).first %>
-          </p>
-          <% end %>
-          <div class="govuk-date-input">
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_day">Day</label>
-                <input id="corrective_action_form_date_decided_day" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][day]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.day %>">
-              </div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_month">Month</label>
-                <input id="corrective_action_form_date_decided_month" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][month]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.month %>">
-              </div>
-            </div>
-            <div class="govuk-date-input__item">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-date-input__label" for="corrective_action_form_date_decided_year">Year</label>
-                <input id="corrective_action_form_date_decided_year" class="govuk-input govuk-date-input__input govuk-input--width-4<%= date_decided_error ? ' govuk-input--error' : '' %>" name="corrective_action_form[date_decided][year]" type="text" inputmode="numeric" value="<%= @corrective_action_form.date_decided&.year %>">
-              </div>
-            </div>
-          </div>
-        </fieldset>
-      </div>
+      <%= f.govuk_date_field :date_decided, legend: { text: 'Enter your date of birth' }, hint: { text: 'For example, 31 3 1980' } %>
+
       <%= f.govuk_select :legislation, options_for_select([""] + Rails.application.config.legislation_constants["legislation"].sort, @corrective_action_form.legislation), label: { text: "Under which legislation?", size: "m" }, hint: { text: "Search applicable legislation and choose the ones you feel are relevant." }, multiple: true %>
       <%= f.govuk_collection_radio_buttons :business_id, @notification.investigation_businesses.decorate.map { |ib| OpenStruct.new(id: ib.business.id, name: "#{ib.business.trading_name} (#{ib.pretty_relationship})") }, :id, :name, legend: { text: "Which business is responsible?", size: "m" }, hint: { text: "Only businesses already added to the notification are listed." } %>
       <%= f.govuk_collection_radio_buttons :measure_type, [OpenStruct.new(id: "mandatory", name: "Yes"), OpenStruct.new(id: "voluntary", name: "No, it’s voluntary")], :id, :name, legend: { text: "Is the corrective action mandatory?", size: "m" } %>

--- a/spec/features/add_corrective_action_spec.rb
+++ b/spec/features/add_corrective_action_spec.rb
@@ -48,12 +48,12 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_antivirus, :
     click_button "Add corrective action"
     expect(page).to have_error_messages
     errors_list = page.find(".govuk-error-summary__list").all("li")
-    expect(errors_list[0].text).to eq "Enter the date the corrective action came into effect"
-    expect(errors_list[1].text).to eq "Select the legislation relevant to the corrective action"
-    expect(errors_list[2].text).to eq "Select whether you want to upload a related file"
+    expect(errors_list[0].text).to eq "Select type of corrective action"
+    expect(errors_list[1].text).to eq "Enter the date the corrective action came into effect"
+    expect(errors_list[2].text).to eq "Select the legislation relevant to the corrective action"
     expect(errors_list[3].text).to eq "You must state whether the action is mandatory or voluntary"
     expect(errors_list[4].text).to eq "Select the geographic scope of the action"
-    expect(errors_list[5].text).to eq "Select type of corrective action"
+    expect(errors_list[5].text).to eq "Select whether you want to upload a related file"
 
     enter_non_numeric_date_and_expect_correct_error_message
 


### PR DESCRIPTION
Description
Rearranged the corrective action form validations so that the appear the the right order on screen based on the fields the user is missing. Removed the manual implementation the OJ guys put for the date fields and used the GOVUK builder field for the date field and created handling for the date fields.
I prevented the corrective actions edit form and risk assessments form from creating a new activity log when nothing in the form was edited and the form was resubmitted, it would create a new activity log due to the 3 date parameters I was passing for the date fields
