### PR TITLE
chore/PSD-2870:Update_to_Email_Correspondence_form

### DIFF
--- a/app/views/investigations/record_emails/_form_fields.html.erb
+++ b/app/views/investigations/record_emails/_form_fields.html.erb
@@ -25,9 +25,15 @@
   %>
 <% end %>
 
-<%= form.govuk_fieldset legend: { text: "Email content", size: 'm' } do %>
+<% value = @email_correspondence_form.errors.any? && @email_correspondence_form.send(:email_subject_or_body_missing) && @email_correspondence_form.send(:email_file_removed_or_missing) ? "email-correspondence-form-base-field-error" : "email-correspondence-form-base-field"  %>
+<% if @email_correspondence_form.errors.any? && @email_correspondence_form.send(:email_subject_or_body_missing) && @email_correspondence_form.send(:email_file_removed_or_missing) %>
+  <div class="govuk-form-group govuk-form-group--error" base="true">
+<% end %>
+<%= form.govuk_fieldset legend: { text: "Email content", size: 'm' }, id: value do %>
   <span id="email-content-hint" class="govuk-hint">Upload the email as a file, or enter the subject and body below</span>
-
+  <% if @email_correspondence_form.errors.any? && @email_correspondence_form.send(:email_subject_or_body_missing) && @email_correspondence_form.send(:email_file_removed_or_missing) %>
+    <p class="govuk-error-message" id="email-correspondence-form-correspondence-base-error"><span class="govuk-visually-hidden">Error: </span>Please provide either an email file or a subject and body</p>
+  <% end %>
   <% if email.email_file.present? %>
     <p class="govuk-body">
       Current file:
@@ -54,6 +60,9 @@
                            max_chars: 32_767
   %>
 
+<% end %>
+<% if @email_correspondence_form.errors.any? && @email_correspondence_form.send(:email_subject_or_body_missing) && @email_correspondence_form.send(:email_file_removed_or_missing) %>
+  </div>
 <% end %>
 
 <fieldset class="govuk-fieldset">


### PR DESCRIPTION
Description
Added custom handling to correspondence email form that highlights every field in the fieldset in red with the error if an email attachment and email subject and body is not provided, and allows the user to go straight to the error when the message is clicked, you cannot assign an attribute name to a GOVUK fieldset so I had to come with a custom solution.

Before
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/609db508-b344-4d58-9d61-dccbf16b6630)
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/f27753c0-f752-41a3-9865-bf455aff12ef)
After
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/609db508-b344-4d58-9d61-dccbf16b6630)
![image](https://github.com/OfficeForProductSafetyAndStandards/product-safety-database/assets/83423212/327e0b8b-be4f-4c3f-ac06-bc5a11e6b978)
