### PR TITLE
refactor/PSD-2894:Update_to_businesses_form

### DIFF
--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -92,6 +92,7 @@ class BulkProductsController < ApplicationController
   def add_business_details
     if request.put?
       @bulk_products_add_business_details_form = BulkProductsAddBusinessDetailsForm.new(bulk_products_add_business_details_params)
+      @bulk_products_add_business_details_form.locations_attributes["0"].store(:country, params[:bulk_products_add_business_details_form][:country])
 
       if @bulk_products_add_business_details_form.valid?
         @bulk_products_upload.investigation_business.business.update!(bulk_products_add_business_details_params)
@@ -301,8 +302,8 @@ private
 
   def bulk_products_add_business_details_params
     params.require(:bulk_products_add_business_details_form).permit(
-      :trading_name, :legal_name, :company_number,
-      locations_attributes: %i[id address_line_1 address_line_2 city county postal_code country],
+      :trading_name, :legal_name, :company_number, :country,
+      locations_attributes: %i[id address_line_1 address_line_2 city county postal_code],
       contacts_attributes: %i[id name email phone_number job_title]
     )
   end

--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -92,10 +92,11 @@ class BulkProductsController < ApplicationController
   def add_business_details
     if request.put?
       @bulk_products_add_business_details_form = BulkProductsAddBusinessDetailsForm.new(bulk_products_add_business_details_params)
-      @bulk_products_add_business_details_form.locations_attributes["0"].store(:country, params[:bulk_products_add_business_details_form][:country])
-
       if @bulk_products_add_business_details_form.valid?
-        @bulk_products_upload.investigation_business.business.update!(bulk_products_add_business_details_params)
+        allowed_params = bulk_products_add_business_details_params
+        allowed_params.delete(:country)
+        allowed_params.delete(:locations_attributes)
+        @bulk_products_upload.investigation_business.business.update!(allowed_params.merge(locations_attributes: @bulk_products_add_business_details_form.locations_attributes))
 
         redirect_to upload_products_file_bulk_upload_products_path(@bulk_products_upload)
       end

--- a/app/forms/add_business_to_notification_form.rb
+++ b/app/forms/add_business_to_notification_form.rb
@@ -57,7 +57,7 @@ private
   def validate_country_set_for_location
     return if location_attrs[:country].present?
 
-    errors.add(:base, "Country cannot be blank")
+    errors.add(:country, "Country cannot be blank")
   end
 
   def new_location

--- a/app/forms/bulk_products_add_business_details_form.rb
+++ b/app/forms/bulk_products_add_business_details_form.rb
@@ -23,6 +23,8 @@ class BulkProductsAddBusinessDetailsForm
     self.trading_name = nil if trading_name.start_with?("Auto-generated business for notification")
     self.locations = [Location.new] if locations.empty?
     self.contacts = [Contact.new] if contacts.empty?
+    self.locations_attributes["0"].store(:country, country) if country.present?
+    self.locations << Location.new(self.locations_attributes["0"]) if self.locations_attributes.present?
   end
 
   def primary_location

--- a/app/forms/bulk_products_add_business_details_form.rb
+++ b/app/forms/bulk_products_add_business_details_form.rb
@@ -5,6 +5,7 @@ class BulkProductsAddBusinessDetailsForm
   attribute :trading_name
   attribute :legal_name
   attribute :company_number
+  attribute :country
 
   attribute :locations, default: []
   attribute :contacts, default: []
@@ -55,6 +56,6 @@ private
   def validate_country_set_for_location
     return if locations_attributes["0"][:country].present?
 
-    errors.add(:base, "Select a country")
+    errors.add(:country, "Select a country")
   end
 end

--- a/app/forms/bulk_products_add_business_details_form.rb
+++ b/app/forms/bulk_products_add_business_details_form.rb
@@ -23,8 +23,8 @@ class BulkProductsAddBusinessDetailsForm
     self.trading_name = nil if trading_name.start_with?("Auto-generated business for notification")
     self.locations = [Location.new] if locations.empty?
     self.contacts = [Contact.new] if contacts.empty?
-    self.locations_attributes["0"].store(:country, country) if country.present?
-    self.locations << Location.new(self.locations_attributes["0"]) if self.locations_attributes.present?
+    locations_attributes["0"].store(:country, country) if country.present?
+    locations << Location.new(locations_attributes["0"]) if locations_attributes.present?
   end
 
   def primary_location

--- a/app/views/bulk_products/add_business_details.html.erb
+++ b/app/views/bulk_products/add_business_details.html.erb
@@ -32,7 +32,7 @@
         ) %>
       <% end %>
       <%= form.fields_for :locations, @bulk_products_upload.investigation_business.business.primary_location do |ff| %>
-        <% id_name = @bulk_products_upload.investigation_business.business.primary_location.country.blank? ? "bulk-products-add-business-details-form-country-field-error" : "bulk-products-add-business-details-form-country-field" %>
+        <% id_name = (@bulk_products_upload.investigation_business.business.primary_location.country.blank? && @bulk_products_add_business_details_form.errors[:country].any?) ? "bulk-products-add-business-details-form-country-field-error" : "bulk-products-add-business-details-form-country-field" %>
         <%= ff.govuk_fieldset legend: {text: "Official address", size: 's'} do %>
           <div id="contact-hint" class="govuk-hint govuk-!-font-size-16"><%= t('.legend.hint') %></div>
           <%= ff.govuk_text_field :address_line_1,

--- a/app/views/bulk_products/add_business_details.html.erb
+++ b/app/views/bulk_products/add_business_details.html.erb
@@ -32,7 +32,45 @@
         ) %>
       <% end %>
       <%= form.fields_for :locations, @bulk_products_upload.investigation_business.business.primary_location do |ff| %>
-        <%= render "businesses/locations/address_form", form: ff, countries: @countries %>
+        <% id_name = @bulk_products_upload.investigation_business.business.primary_location.country.blank? ? "bulk-products-add-business-details-form-country-field-error" : "bulk-products-add-business-details-form-country-field" %>
+        <%= ff.govuk_fieldset legend: {text: "Official address", size: 's'} do %>
+          <div id="contact-hint" class="govuk-hint govuk-!-font-size-16"><%= t('.legend.hint') %></div>
+          <%= ff.govuk_text_field :address_line_1,
+                                    width: 'two-thirds',
+                                    label: {text: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>".html_safe }
+          %>
+
+          <%= ff.govuk_text_field :address_line_2,
+                                    width: 'two-thirds',
+                                    label: {text: "Building and street line 2 of 2", hidden: true}
+          %>
+
+          <%= ff.govuk_text_field :city,
+                                    width: 'two-thirds',
+                                    label: {text: "Town or city"}
+          %>
+
+          <%= ff.govuk_text_field :county,
+                                    width: 'two-thirds',
+                                    label: {text: "County"}
+          %>
+
+          <%= ff.govuk_text_field :postal_code,
+                                    width: 'one-quarter',
+                                    label: {text: "Postcode"}
+          %>
+
+          <% items = [OpenStruct.new(value: "", text: "")] + all_countries_with_uk_first.map { |country| OpenStruct.new(value: country[1], text: country[0] )}%>
+          <%= form.govuk_collection_select :country,
+                                           items,
+                                           :value,
+                                           :text,
+                                           id: id_name,
+                                           label: { text: "Country" },
+                                           width: "two-thirds"
+          %>
+
+        <% end %>
       <% end %>
       <%= form.fields_for :contacts, @bulk_products_upload.investigation_business.business.primary_contact do |ff| %>
         <%= render "businesses/contacts/form", form: ff %>

--- a/app/views/businesses/_form.html.erb
+++ b/app/views/businesses/_form.html.erb
@@ -20,7 +20,7 @@
 
 
 <%= form.fields_for :locations, business.primary_location do |ff| %>
-  <%= render "businesses/locations/address_form", form: ff, countries: countries, id_name: business.primary_location.country.blank? ? "business-locations-country-field-error" : "business-locations-country-field" %>
+  <%= render "businesses/locations/address_form", form: ff, countries: countries, id_name: (business.primary_location.country.blank? && business.errors[:country].any?) ? "business-locations-country-field-error" : "business-locations-country-field" %>
 <% end %>
 
 <%= form.fields_for :contacts, business.primary_contact do |ff| %>

--- a/app/views/businesses/_form.html.erb
+++ b/app/views/businesses/_form.html.erb
@@ -20,7 +20,7 @@
 
 
 <%= form.fields_for :locations, business.primary_location do |ff| %>
-  <%= render "businesses/locations/address_form", form: ff, countries: countries, id_name: (business.primary_location.country.blank? && business.errors[:country].any?) ? "business-locations-country-field-error" : "business-locations-country-field" %>
+  <%= render "businesses/locations/address_form", form: ff, countries: countries, id_name: (business.primary_location.country.blank? && (business.errors.full_messages.include? "Country cannot be blank")) ? "business-locations-country-field-error" : "business-locations-country-field" %>
 <% end %>
 
 <%= form.fields_for :contacts, business.primary_contact do |ff| %>

--- a/app/views/businesses/_form.html.erb
+++ b/app/views/businesses/_form.html.erb
@@ -20,7 +20,7 @@
 
 
 <%= form.fields_for :locations, business.primary_location do |ff| %>
-  <%= render "businesses/locations/address_form", form: ff, countries: countries %>
+  <%= render "businesses/locations/address_form", form: ff, countries: countries, id_name: business.primary_location.country.blank? ? "business-locations-country-field-error" : "business-locations-country-field" %>
 <% end %>
 
 <%= form.fields_for :contacts, business.primary_contact do |ff| %>

--- a/app/views/businesses/edit.html.erb
+++ b/app/views/businesses/edit.html.erb
@@ -8,7 +8,7 @@
 <%= form_for @business, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% form.govuk_error_summary %>
+      <%= form.govuk_error_summary %>
     </div>
   </div>
 

--- a/app/views/businesses/locations/_address_form.html.erb
+++ b/app/views/businesses/locations/_address_form.html.erb
@@ -24,7 +24,6 @@
                             width: 'one-quarter',
                             label: {text: "Postcode"}
   %>
-
   <% items = [OpenStruct.new(value: "", text: "")] + all_countries_with_uk_first.map { |country| OpenStruct.new(value: country[1], text: country[0] )}%>
     <%= form.govuk_collection_select :country,
                                      items,

--- a/app/views/businesses/locations/_address_form.html.erb
+++ b/app/views/businesses/locations/_address_form.html.erb
@@ -26,10 +26,12 @@
   %>
 
   <% items = [OpenStruct.new(value: "", text: "")] + all_countries_with_uk_first.map { |country| OpenStruct.new(value: country[1], text: country[0] )}%>
-  <%= form.govuk_collection_select :country,
-                                   items,
-                                   :value,
-                                   :text,
-                                   label: { text: "Country" },
-                                   width: "two-thirds"%>
+    <%= form.govuk_collection_select :country,
+                                     items,
+                                     :value,
+                                     :text,
+                                     id: id_name,
+                                     label: { text: "Country" },
+                                     width: "two-thirds"
+    %>
 <% end %>

--- a/app/views/businesses/locations/_form.html.erb
+++ b/app/views/businesses/locations/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form.govuk_text_field :name,
                           label: {text: "Location name", size: 'm'},
                           hint: {text: "For example, 'Head office', 'Registered office' or 'Northern office'.", size: 'm', style: "font-size: 1rem !important; line-height: 1.25 !important;"} %>
-<%= render "address_form", form: form %>
+<%= render "address_form", form: form, id_name: id_name %>
 
 <%= form.submit "Save", class: "govuk-button" %>

--- a/app/views/businesses/locations/edit.html.erb
+++ b/app/views/businesses/locations/edit.html.erb
@@ -2,8 +2,7 @@
 <%= form_with(model: @location, url: business_location_path(@business, @location), builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= govukErrorSummary form: form %>
-
+      <%= form.govuk_error_summary %>
       <span class="govuk-caption-l"><%= @business.pretty_description %></span>
 
       <h1 class="govuk-heading-l">Edit location</h1>

--- a/app/views/businesses/locations/edit.html.erb
+++ b/app/views/businesses/locations/edit.html.erb
@@ -6,8 +6,8 @@
       <span class="govuk-caption-l"><%= @business.pretty_description %></span>
 
       <h1 class="govuk-heading-l">Edit location</h1>
-
-      <%= render "form", form: form %>
+      <% id_name = (@location.country.blank? && @location.errors[:country].any?) ? "location-country-field-error" : "location-country-field" %>
+      <%= render "form", form: form, id_name: id_name %>
     </div>
   </div>
 <% end %>

--- a/app/views/businesses/locations/new.html.erb
+++ b/app/views/businesses/locations/new.html.erb
@@ -2,8 +2,10 @@
 <%= form_with(model: @location, url: business_locations_path(@business), builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= govukErrorSummary form: form %>
-
+      <%= form.govuk_error_summary %>
+      <% def country_id
+           @location.country.blank? ? "business-locations-country-field-error" : "business-locations-country-field"
+         end %>
       <span class="govuk-caption-l"><%= @business.pretty_description %></span>
 
       <h1 class="govuk-heading-l">Add location</h1>

--- a/app/views/businesses/locations/new.html.erb
+++ b/app/views/businesses/locations/new.html.erb
@@ -3,14 +3,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= form.govuk_error_summary %>
-      <% def country_id
-           @location.country.blank? ? "business-locations-country-field-error" : "business-locations-country-field"
-         end %>
+
+      <% id_name = (@location.country.blank? && @location.errors[:country].any?) ? "location-country-field-error" : "location-country-field" %>
       <span class="govuk-caption-l"><%= @business.pretty_description %></span>
 
       <h1 class="govuk-heading-l">Add location</h1>
 
-      <%= render "form", form: form %>
+      <%= render "form", form: form, id_name: id_name %>
     </div>
   </div>
 <% end %>

--- a/app/views/investigations/businesses/_form.html.erb
+++ b/app/views/investigations/businesses/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with(model: @remove_business_form, url: investigation_business_path(@investigation, @business), method: :delete, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(:remove, legend: {text: t(".remove_business_legend")}) do %>
     <%= form.govuk_radio_button :remove, 'true', label: {text: "Yes", link_errors: true}  do %>
       <% form.govuk_text_area :reason, label: {text: t(".reason_for_removing_the_business_from_the_case")} %>

--- a/app/views/investigations/businesses/new.html.erb
+++ b/app/views/investigations/businesses/new.html.erb
@@ -6,9 +6,11 @@
           url: investigation_businesses_path(@investigation),
           html: { autocomplete: :off }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
 
-      <%= error_summary @business_form.errors %>
+      <%= form.govuk_error_summary %>
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-8">Provide the business details</h1>
+      this should be true
+      <%= @business_form.errors.full_messages %>
       <%= render "businesses/form", form: form, business: @business_form, countries: @countries %>
     <% end %>
   </div>

--- a/app/views/investigations/businesses/new.html.erb
+++ b/app/views/investigations/businesses/new.html.erb
@@ -9,8 +9,6 @@
       <%= form.govuk_error_summary %>
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-8">Provide the business details</h1>
-      this should be true
-      <%= @business_form.errors.full_messages %>
       <%= render "businesses/form", form: form, business: @business_form, countries: @countries %>
     <% end %>
   </div>

--- a/spec/features/add_business_to_a_notification_spec.rb
+++ b/spec/features/add_business_to_a_notification_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Adding and removing business to a notification", :with_stubbed_ma
     expect(page).to have_error_summary("Country cannot be blank")
 
     within_fieldset "Official address" do
-      select country, from: "Country"
+      select country, from: "business-locations-country-field-error"
     end
 
     click_on "Save"
@@ -232,7 +232,7 @@ RSpec.feature "Adding and removing business to a notification", :with_stubbed_ma
     end
 
     within_fieldset "Official address" do
-      select "France", from: "Country"
+      select "France", from: "business-locations-country-field"
     end
 
     click_on "Save"
@@ -277,7 +277,7 @@ RSpec.feature "Adding and removing business to a notification", :with_stubbed_ma
     end
 
     within_fieldset "Official address" do
-      select "France", from: "Country"
+      select "France", from: "business-locations-country-field"
     end
 
     click_on "Save"

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Bulk upload products", :with_stubbed_antivirus, :with_stubbed_mai
     expect(page).to have_content("Provide the business details")
 
     fill_in "Trading name", with: "Fake name"
-    select "United Kingdom", from: "bulk-products-add-business-details-form-locations-attributes-0-country-field", match: :first
+    select "United Kingdom", from: "bulk-products-add-business-details-form-country-field", match: :first
     click_button "Continue"
 
     expect(page).to have_content("Upload products by Excel")

--- a/spec/features/editing_business_details_spec.rb
+++ b/spec/features/editing_business_details_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Editing business details", :with_stubbed_mailer, :with_opensearch
     expect(page).to have_content("Country cannot be blank")
 
     within_fieldset "Official address" do
-      select "France", from: "Country"
+      select "France", from: "business-locations-country-field-error"
     end
 
     click_on "Save"


### PR DESCRIPTION
Description
Changed forms to use GOVUKSystemForm builder, made sure parameters were handled correctly and the country error message redirected to the select box when clicked. The reason for this form being finnicky is due to the forms being nested multiple times and also due to there being multiple forms being rendered at one time as one form.