### PR TITLE
Refactor/PSD-2988:Update_to_products_duplicate_checks_forms

### DIFF
--- a/app/forms/email_correspondence_form.rb
+++ b/app/forms/email_correspondence_form.rb
@@ -35,6 +35,7 @@ class EmailCorrespondenceForm
   attribute :id
 
   validates :correspondence_date,
+            presence: true,
             real_date: true,
             complete_date: true,
             not_in_future: true,

--- a/app/forms/email_correspondence_form.rb
+++ b/app/forms/email_correspondence_form.rb
@@ -40,7 +40,6 @@ class EmailCorrespondenceForm
             complete_date: true,
             not_in_future: true,
             recent_date: { on_or_before: false }
-  validate :date_fields_presence
 
   validate :validate_email_file_and_content
 
@@ -135,15 +134,5 @@ private
 
   def email_file_missing
     email_file.nil? && email_file_id.nil?
-  end
-
-  def date_fields_presence
-    year = @correspondence_date_year
-    month = @correspondence_date_month
-    day = @correspondence_date_day
-
-    errors.add(:correspondence_date, "Enter the date sent") if year.blank? && month.blank? && day.blank?
-  rescue ArgumentError
-    errors.add(:correspondence_date, "Date is invalid")
   end
 end

--- a/app/forms/email_correspondence_form.rb
+++ b/app/forms/email_correspondence_form.rb
@@ -35,11 +35,11 @@ class EmailCorrespondenceForm
   attribute :id
 
   validates :correspondence_date,
-            presence: true,
             real_date: true,
             complete_date: true,
             not_in_future: true,
             recent_date: { on_or_before: false }
+  validate :date_fields_presence
 
   validate :validate_email_file_and_content
 
@@ -134,5 +134,15 @@ private
 
   def email_file_missing
     email_file.nil? && email_file_id.nil?
+  end
+
+  def date_fields_presence
+    year = @correspondence_date_year
+    month = @correspondence_date_month
+    day = @correspondence_date_day
+
+    errors.add(:correspondence_date, "Enter the date sent") if year.blank? && month.blank? && day.blank?
+  rescue ArgumentError
+    errors.add(:correspondence_date, "Date is invalid")
   end
 end

--- a/app/forms/phone_call_correspondence_form.rb
+++ b/app/forms/phone_call_correspondence_form.rb
@@ -3,12 +3,12 @@ class PhoneCallCorrespondenceForm
   include ActiveModel::Attributes
 
   validates :correspondence_date,
-            presence: true,
             real_date: true,
             complete_date: true,
             not_in_future: true,
             recent_date: { on_or_before: false }
 
+  validate :date_fields_presence
   validate :validate_transcript_and_content
 
   attr_accessor :correspondence_date_year, :correspondence_date_month, :correspondence_date_day
@@ -93,5 +93,15 @@ private
 
   def strip_line_feed_from_textarea
     details&.strip!
+  end
+
+  def date_fields_presence
+    year = @correspondence_date_year
+    month = @correspondence_date_month
+    day = @correspondence_date_day
+
+    errors.add(:correspondence_date, "Enter the date of call") if year.blank? && month.blank? && day.blank?
+  rescue ArgumentError
+    errors.add(:correspondence_date, "Date is invalid")
   end
 end

--- a/app/forms/phone_call_correspondence_form.rb
+++ b/app/forms/phone_call_correspondence_form.rb
@@ -9,8 +9,6 @@ class PhoneCallCorrespondenceForm
             not_in_future: true,
             recent_date: { on_or_before: false }
 
-  validate :date_fields_presence
-
   validate :validate_transcript_and_content
 
   attr_accessor :correspondence_date_year, :correspondence_date_month, :correspondence_date_day
@@ -95,15 +93,5 @@ private
 
   def strip_line_feed_from_textarea
     details&.strip!
-  end
-
-  def date_fields_presence
-    year = @correspondence_date_year
-    month = @correspondence_date_month
-    day = @correspondence_date_day
-
-    errors.add(:correspondence_date, "Enter the date of call") if year.blank? && month.blank? && day.blank?
-  rescue ArgumentError
-    errors.add(:correspondence_date, "Date is invalid")
   end
 end

--- a/app/forms/phone_call_correspondence_form.rb
+++ b/app/forms/phone_call_correspondence_form.rb
@@ -3,6 +3,7 @@ class PhoneCallCorrespondenceForm
   include ActiveModel::Attributes
 
   validates :correspondence_date,
+            presence: true,
             real_date: true,
             complete_date: true,
             not_in_future: true,

--- a/app/helpers/error_summary_presenter.rb
+++ b/app/helpers/error_summary_presenter.rb
@@ -4,8 +4,13 @@ class ErrorSummaryPresenter
   end
 
   def formatted_error_messages
-    @error_messages = @error_messages.each.map { |y| y.to_a.map { |x| [x[0], x[1].join] } }
-    @error_messages = @error_messages[0] + @error_messages[1] if @error_messages.length == 2
-    @error_messages[0]
+    store = []
+    @error_messages.each do |hash|
+      hash.each do |key, arr|
+        arr = arr.map { |x| [key, x] }
+        store += arr
+      end
+    end
+    @error_messages = store
   end
 end

--- a/app/views/products/duplicate_checks/new.html.erb
+++ b/app/views/products/duplicate_checks/new.html.erb
@@ -1,56 +1,21 @@
 <%= page_title "Do you have a barcode number?", errors: @product_duplicate_check_form.errors.any? %>
-<%= form_with model: @product_duplicate_check_form, url: duplicate_check_products_path(@product_duplicate_check_form), builder: ApplicationFormBuilder do |f| %>
-  <%= error_summary(@product_duplicate_check_form.errors, %i[barcode]) %>
-
+<%= form_with model: @product_duplicate_check_form, url: duplicate_check_products_path(@product_duplicate_check_form), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary(presenter: ErrorSummaryPresenter) %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <div class="govuk-form-group <%= class_names("govuk-form-group--error") if @product_duplicate_check_form&.errors[:has_barcode].present? %>">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">Do you have the product barcode number?</h1>
-          </legend>
-          <% if @product_duplicate_check_form&.errors[:has_barcode].present? %>
-            <p id="barcode-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> Select yes if you have the product barcode number
-            </p>
+        <%= f.govuk_radio_buttons_fieldset(:has_barcode, legend: { size: "l", text: "Do you have the product barcode number?", style: "margin-bottom: 25px" }) do %>
+          <%= f.govuk_radio_button :has_barcode, "true", label: { text: 'Yes' }, link_errors: true do %>
+            <%= f.govuk_text_field :barcode, width: "one-third", label: { text: "Barcode number (GTIN, EAN or UPC)" }, hint: { text: "It is normally 13 digits, although older products may have a 12 digit number.", style: "font-size: 1rem !important;" } %>
           <% end %>
-
-          <div class="govuk-radios govuk-!-padding-top-3 govuk-!-padding-bottom-1" data-module="govuk-radios">
-            <div class="govuk-radios__item">
-              <%= f.radio_button :has_barcode, true, class: "govuk-radios__input", aria: { controls: "conditional-barcode", expanded: "true" }, data: { cy: "barcode-yes" }, id: "has_barcode" %>
-              <%= f.label :has_barcode, "Yes", class: "govuk-label govuk-radios__label", for: "has_barcode" %>
-            </div>
-
-            <div class="govuk-radios__conditional" id="conditional-barcode">
-              <div class="govuk-form-group <%= class_names("govuk-form-group--error") if @product_duplicate_check_form.errors.any? %>">
-                <%= f.label :barcode, class: "govuk-label", for: "barcode" do %>
-                  Barcode number (<abbr title="Global Trade Item Number">GTIN</abbr>, <abbr title="European Article Number">EAN</abbr> or <abbr title="Universal Product Code">UPC</abbr>)
-
-                  <div id="barnumber-hint" class="govuk-hint govuk-!-font-size-16">
-                    It is normally 13 digits, although older products may have a 12 digit number.
-                  </div>
-
-                  <% if @product_duplicate_check_form&.errors[:barcode].any? %>
-                    <p id="barcode-error" class="govuk-error-message">
-                      <span class="govuk-visually-hidden">Error:</span> Enter a valid barcode number
-                    </p>
-                  <% end %>
-                <% end %>
-
-                <%= f.text_field :barcode, class: "govuk-input govuk-!-width-one-third", aria: { describedby: "barnumber-hint" }, autocomplete: "off", spellcheck: "false", data: { cy: "barcode" }, id: "barcode" %>
-              </div>
-            </div>
-
-            <div class="govuk-radios__item">
-              <%= f.radio_button :has_barcode, false, class: "govuk-radios__input", data: { cy: "barcode-no" }, id: "has_barcode_no" %>
-              <%= f.label :has_barcode, "No", class: "govuk-label govuk-radios__label", for: "has_barcode_no" %>
-            </div>
-          </div>
-        </fieldset>
+          <%= f.govuk_radio_button :has_barcode, "false", label: { text: 'No' } %>
+        <% end %>
       </div>
 
-      <%= f.submit "Continue", class: "govuk-button", data: { cy: "continue" }, role: "button" %>
+      <%= f.govuk_submit "Continue" %>
     </div>
+
+
     <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-s govuk-visually-hidden">Barcode example</h2>
       <figure class="govuk-!-margin-top-9">

--- a/app/views/products/duplicate_checks/show.html.erb
+++ b/app/views/products/duplicate_checks/show.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Is this the same product?", errors: @product_duplicate_confirmation_form.errors.any? %>
-<%= form_with model: @product_duplicate_confirmation_form, url: confirm_product_duplicate_checks_path(product_id: @product.id), builder: ApplicationFormBuilder do |f| %>
-  <%= error_summary(@product_duplicate_confirmation_form.errors, %i[correct]) %>
+<%= form_with model: @product_duplicate_confirmation_form, url: confirm_product_duplicate_checks_path(product_id: @product.id), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -66,24 +66,11 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds govuk-radios govuk-!-padding-top-3 govuk-!-padding-bottom-1">
               <div class="govuk-form-group <%= class_names("govuk-form-group--error" => @product_duplicate_confirmation_form.errors.any?) %>">
-                <% if @product_duplicate_confirmation_form.errors.any? %>
-                  <p id="is-product-error" class="govuk-error-message">
-                    <span class="govuk-visually-hidden">Error:</span> Select yes if this is the same product
-                  </p>
-                <% end %>
-
                 <%= f.hidden_field :correct, value: '' %>
-                <div class="govuk-radios__item">
-                  <%= f.radio_button :correct, 'yes', class: "govuk-radios__input", id: "correct", data: { cy: "confirm-yes" } %>
-                  <%= f.label :correct, class: "govuk-label govuk-radios__label", for: "correct" do %>
-                    Yes &nbsp;&ndash;&nbsp; use this product record instead
-                  <% end %>
-                </div>
-
-                <div class="govuk-radios__item">
-                  <%= f.radio_button :correct, 'no', class: "govuk-radios__input", id: "correct_no", data: { cy: "confirm-no" }  %>
-                  <%= f.label :correct, "No", class: "govuk-label govuk-radios__label", for: "correct_no" %>
-                </div>
+                <%= f.govuk_radio_buttons_fieldset(:correct, legend: { size: "m", text: nil, hidden: true }) do %>
+                  <%= f.govuk_radio_button :correct, "yes", label: { text: "Yes –  use this product record instead" }, link_errors: true %>
+                  <%= f.govuk_radio_button :correct, "no", label: { text: "No" } %>
+                <% end %>
               </div>
             </div>
           </div>
@@ -94,7 +81,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= f.submit "Continue", class: "govuk-button", role: "button", data: {module: "govuk-button", cy: "continue"} %>
+      <%= f.govuk_submit "Continue" %>
     </div>
   </div>
 <% end %>

--- a/spec/forms/email_correspondence_form_spec.rb
+++ b/spec/forms/email_correspondence_form_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe EmailCorrespondenceForm, :with_stubbed_mailer do
 
   describe "validations" do
     context "when a correspondence date is missing" do
-      let(:correspondence_date) { nil }
+      let(:correspondence_date) { {} }
 
       it "is not valid and contains an error message", :aggregate_failures do
         expect(form).not_to be_valid

--- a/spec/helpers/error_summary_presenter_spec.rb
+++ b/spec/helpers/error_summary_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
   describe "testing GOVUK forms with date fields" do
     context "when the form submitted is an Correspondence Email form" do
-      let(:email_correspondence_form) { EmailCorrespondenceForm.new }
+      let(:email_correspondence_form) { EmailCorrespondenceForm.new(correspondence_date: nil) }
       let(:email_correspondence_form_with_date) { EmailCorrespondenceForm.new(correspondence_date: Date.new(2023, 2, 11), "correspondence_date(1i)" => 2020, "correspondence_date(2i)" => 1, "correspondence_date(3i)" => 20) }
       let(:email_correspondence_form_complete) { EmailCorrespondenceForm.new(correspondence_date: Date.new(2023, 2, 11), "correspondence_date(1i)" => 2020, "correspondence_date(2i)" => 1, "correspondence_date(3i)" => 20, email_file: Rack::Test::UploadedFile.new("spec/fixtures/files/email.txt")) }
 
@@ -17,7 +17,7 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
         it "returns the expected errors" do
           presenter = described_class.new(email_correspondence_form.errors.to_hash(full_messages: true))
           formatted_errors = presenter.formatted_error_messages
-          expected_errors = [[:correspondence_date, "Enter the date sent"], [:base, "Please provide either an email file or a subject and body"]]
+          expected_errors = [[:correspondence_date, "Enter the date sent"], [:correspondence_date, "Enter the date sent"], [:base, "Please provide either an email file or a subject and body"]]
           expect(formatted_errors).to eq(expected_errors)
         end
       end
@@ -42,7 +42,7 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
     end
 
     context "when the form submitted is an Correspondence Phone Call form" do
-      let(:phone_call_correspondence_form) { PhoneCallCorrespondenceForm.new }
+      let(:phone_call_correspondence_form) { PhoneCallCorrespondenceForm.new(correspondence_date: nil) }
       let(:phone_call_correspondence_form_with_date) { PhoneCallCorrespondenceForm.new(correspondence_date: Date.new(2023, 2, 11), "correspondence_date(1i)" => 2020, "correspondence_date(2i)" => 1, "correspondence_date(3i)" => 20) }
       let(:phone_call_correspondence_form_complete) { PhoneCallCorrespondenceForm.new(correspondence_date: Date.new(2023, 2, 11), "correspondence_date(1i)" => 2020, "correspondence_date(2i)" => 1, "correspondence_date(3i)" => 20, transcript: Rack::Test::UploadedFile.new("spec/fixtures/files/new_phone_call_transcript.txt")) }
 
@@ -56,7 +56,7 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
         it "returns the expected errors" do
           presenter = described_class.new(phone_call_correspondence_form.errors.to_hash(full_messages: true))
           formatted_errors = presenter.formatted_error_messages
-          expected_errors = [[:correspondence_date, "Enter the date of call"], [:overview, "Please provide either a transcript or complete the summary and notes fields"]]
+          expected_errors = [[:correspondence_date, "Enter the date of call"], [:correspondence_date, "Enter the date of call"], [:overview, "Please provide either a transcript or complete the summary and notes fields"]]
           expect(formatted_errors).to eq(expected_errors)
         end
       end

--- a/spec/helpers/error_summary_presenter_spec.rb
+++ b/spec/helpers/error_summary_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
         it "returns the expected errors" do
           presenter = described_class.new(email_correspondence_form.errors.to_hash(full_messages: true))
           formatted_errors = presenter.formatted_error_messages
-          expected_errors = [[:correspondence_date, "Enter the date sentEnter the date sent"], [:base, "Please provide either an email file or a subject and body"]]
+          expected_errors = [[:correspondence_date, "Enter the date sent"], [:base, "Please provide either an email file or a subject and body"]]
           expect(formatted_errors).to eq(expected_errors)
         end
       end
@@ -56,7 +56,7 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
         it "returns the expected errors" do
           presenter = described_class.new(phone_call_correspondence_form.errors.to_hash(full_messages: true))
           formatted_errors = presenter.formatted_error_messages
-          expected_errors = [[:correspondence_date, "Enter the date of callEnter the date of call"], [:overview, "Please provide either a transcript or complete the summary and notes fields"]]
+          expected_errors = [[:correspondence_date, "Enter the date of call"], [:overview, "Please provide either a transcript or complete the summary and notes fields"]]
           expect(formatted_errors).to eq(expected_errors)
         end
       end
@@ -136,6 +136,25 @@ RSpec.describe ErrorSummaryPresenter, :with_test_queue_adapter do
           presenter = described_class.new(accident_or_incident_form_complete.errors.to_hash(full_messages: true))
           formatted_errors = presenter.formatted_error_messages
           expected_errors = []
+          expect(formatted_errors).to eq(expected_errors)
+        end
+      end
+    end
+  end
+
+  describe "testing GOVUK forms with multiple errors attached to one attribute" do
+    context "when the form submitted is a Product duplicate check form" do
+      let(:product_duplicate_check_form) { ProductDuplicateCheckForm.new(has_barcode: true) }
+
+      before do
+        product_duplicate_check_form.invalid?
+      end
+
+      context "when has_barcode: yes parameter supplied but no barcode is written" do
+        it "returns both barcode errors" do
+          presenter = described_class.new(product_duplicate_check_form.errors.to_hash(full_messages: true))
+          formatted_errors = presenter.formatted_error_messages
+          expected_errors = [[:barcode, "The barcode must be between 5 and 15 digits"], [:barcode, "Barcode cannot be blank"]]
           expect(formatted_errors).to eq(expected_errors)
         end
       end


### PR DESCRIPTION
Description
Refactored product duplicate check form top use GOVUK Form Builder, made changes to Error Summary Presenter helper, it was not displaying all the errors a form attribute had separately but merging them together in a long string and showing the error on frontend, added extra test case to Error Summary presenter spec. 