### PR TITLE
chore/PSD-2936:Update_to_NTL_corrective_actions_form

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -923,7 +923,6 @@ module Notifications
     end
 
     def update_with_entity
-      pry
       @corrective_action = @notification.corrective_actions.find(params[:entity_id])
       if request.patch? || request.put?
         @corrective_action_form = CorrectiveActionForm.new(record_a_corrective_action_details_params.merge(duration: "unknown"))

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -264,6 +264,13 @@ module Notifications
         @risk_level_form = RiskLevelForm.new(risk_level: @notification.risk_level)
         highest_risk_level
       when :record_a_corrective_action
+        if params[:add_another_corrective_action_form].present?
+          @add_a_corrective_action = RecordACorrectiveActionForm.new(add_another_corrective_action: params[:add_another_corrective_action_form][:add_another_corrective_action])
+          @add_a_corrective_action.valid?
+        else
+          @add_a_corrective_action = RecordACorrectiveActionForm.new
+        end
+
         if @notification.corrective_action_taken.blank? || @notification.corrective_action_taken != "yes"
           @corrective_action_taken_form = CorrectiveActionTakenForm.new(
             corrective_action_taken_yes_no: @notification.corrective_action_taken.present? ? @notification.corrective_action_taken_yes? : nil,
@@ -637,10 +644,15 @@ module Notifications
             return render :record_a_corrective_action_details
           end
         elsif @notification.corrective_action_taken == "yes"
-          return redirect_to "#{wizard_path(:record_a_corrective_action)}?add" if params[:add_another_corrective_action] == "true"
-          return redirect_to wizard_path(:record_a_corrective_action) if params[:add_another_corrective_action].blank? && params[:final].present?
+          @add_a_corrective_action = if params[:add_another_corrective_action_form].present?
+                                       RecordACorrectiveActionForm.new(add_a_corrective_action_params)
+                                     else
+                                       RecordACorrectiveActionForm.new
+                                     end
+          return redirect_to "#{wizard_path(:record_a_corrective_action)}?add" if @add_a_corrective_action.add_another_corrective_action == "true"
+          return redirect_to wizard_path(:record_a_corrective_action, add_another_corrective_action_form: add_a_corrective_action_params) if @add_a_corrective_action.add_another_corrective_action.blank? && params[:final].present?
 
-          if params[:add_another_corrective_action].blank?
+          if @add_a_corrective_action.add_another_corrective_action.blank?
             @choose_investigation_products_form = ChooseInvestigationProductsForm.new(record_a_corrective_action_params)
 
             if @choose_investigation_products_form.valid?
@@ -1095,6 +1107,10 @@ module Notifications
 
     def add_test_report_params
       params.require(:add_test_reports_form).permit(:add_another_test_report)
+    end
+
+    def add_a_corrective_action_params
+      params.require(:record_a_corrective_action_form).permit(:add_another_corrective_action)
     end
 
     def add_notification_details_params

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -644,7 +644,7 @@ module Notifications
             return render :record_a_corrective_action_details
           end
         elsif @notification.corrective_action_taken == "yes"
-          @add_a_corrective_action = if params[:add_another_corrective_action_form].present?
+          @add_a_corrective_action = if params[:record_a_corrective_action_form].present?
                                        RecordACorrectiveActionForm.new(add_a_corrective_action_params)
                                      else
                                        RecordACorrectiveActionForm.new

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -923,6 +923,7 @@ module Notifications
     end
 
     def update_with_entity
+      pry
       @corrective_action = @notification.corrective_actions.find(params[:entity_id])
       if request.patch? || request.put?
         @corrective_action_form = CorrectiveActionForm.new(record_a_corrective_action_details_params.merge(duration: "unknown"))
@@ -955,9 +956,6 @@ module Notifications
         end
       else
         @corrective_action_form = CorrectiveActionForm.from(@corrective_action)
-        @corrective_action_form.date_decided_year = params[:corrective_action]["date_decided(1i)"]
-        @corrective_action_form.date_decided_month = params[:corrective_action]["date_decided(2i)"]
-        @corrective_action_form.date_decided_day = params[:corrective_action]["date_decided(3i)"]
         render :record_a_corrective_action_details
       end
     end

--- a/app/forms/record_a_corrective_action_form.rb
+++ b/app/forms/record_a_corrective_action_form.rb
@@ -1,0 +1,8 @@
+class RecordACorrectiveActionForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Serialization
+
+  attribute :add_another_corrective_action
+  validates :add_another_corrective_action, presence: true
+end

--- a/app/views/notifications/create/record_a_corrective_action.html.erb
+++ b/app/views/notifications/create/record_a_corrective_action.html.erb
@@ -18,7 +18,8 @@
           end
         end
       %>
-      <%= form_with url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= form_with model: @add_a_corrective_action, url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+          <%= f.govuk_error_summary %>
         <%= f.govuk_collection_radio_buttons :add_another_corrective_action, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another corrective action?", size: "m" } %>
         <%= f.govuk_submit "Continue", name: "final", value: "true" %>
       <% end %>


### PR DESCRIPTION
Prevented form attributes from being assigned twice causing form to fail when the parameters were not present, the method set_date for the form does that already, added new form model to display errors