### PR TITLE
refactor/PSD-3021:Update_to_NTL_test _reports_form

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -507,7 +507,6 @@ module Notifications
 
         return redirect_to wizard_path(:search_for_or_add_a_business)
       when :add_test_reports
-
         @add_another_test_report = if params[:add_test_reports_form].present?
                                      AddTestReportsForm.new(add_test_report_params)
                                    else
@@ -827,8 +826,7 @@ module Notifications
 
           if @test_result.tso_certificate_issue_date.present? || params[:opss_funded] == "false"
             @test_result_form = TestResultForm.new(test_details_params)
-            @test_result_form.load_document_file
-
+            @test_result_form.cache_file!(current_user)
             if @test_result_form.valid?
               UpdateTestResult.call!(
                 investigation: @notification,

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -1,4 +1,4 @@
-<!--/*<%# date_error = test_result_form.errors.include?(:date) %>-->
+<% date_error = test_result_form.errors.include?(:date) %>
 
 <% if allow_product_linking %>
   <% if investigation.investigation_products.empty? %>

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -1,4 +1,4 @@
-<% date_error = test_result_form.errors.include?(:date) %>
+<!--/*<%# date_error = test_result_form.errors.include?(:date) %>-->
 
 <% if allow_product_linking %>
   <% if investigation.investigation_products.empty? %>

--- a/app/views/notifications/create/add_test_reports_details.html.erb
+++ b/app/views/notifications/create/add_test_reports_details.html.erb
@@ -28,7 +28,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Date of test</legend>
           <div class="govuk-hint" id="test-result-form-date-hint">For example, 12 5 2023</div>
           <% if date_error %>
-          <p class="govuk-error-message" id="test-result-form-date-error">
+          <p class="govuk-error-message" id="test-result-form-date-field-error">
             <span class="govuk-visually-hidden">Error: </span><%= @test_result_form.errors.full_messages_for(:date).first %>
           </p>
           <% end %>
@@ -63,11 +63,12 @@
       <% end %>
       <%= f.govuk_text_area :details, label: { text: "Further details", size: "m" }, max_chars: 32_767 %>
       <%= f.hidden_field :existing_document_file_id %>
-      <% if @test_result.document.blob.present? %>
+      <% if @test_result_form.document.present? %>
         <p id="current-attachment-details">
           Currently selected file:
-          <%= link_to "#{@test_result.document.blob.filename} (opens in new tab)", @test_result.document.blob, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" %>
+          <%= link_to "#{@test_result_form.document.filename} (opens in new tab)", @test_result_form.document, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" %>
         </p>
+        <%= f.hidden_field :document, value: @test_result_form.document.id %>
         <%= govuk_details(summary_text: "Replace this file") do %>
           <%= f.govuk_file_field :document, label: { text: "Test report attachment", size: "m" }, hint: { text: "If you have multiple files, compress them in a zip file." } %>
         <% end %>

--- a/app/views/notifications/create/add_test_reports_funding_details.html.erb
+++ b/app/views/notifications/create/add_test_reports_funding_details.html.erb
@@ -23,7 +23,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What date was the test certificate issued?</legend>
           <div class="govuk-hint" id="set-test-result-certificate-on-case-form-tso-certificate-issue-date-hint">For example, 12 5 2023</div>
           <% if tso_certificate_issue_date_error %>
-          <p class="govuk-error-message" id="set-test-result-certificate-on-case-form-tso-certificate-issue-date-error">
+          <p class="govuk-error-message" id="set-test-result-certificate-on-case-form-tso-certificate-issue-date-field-error">
             <span class="govuk-visually-hidden">Error: </span><%= @set_test_result_certificate_on_case_form.errors.full_messages_for(:tso_certificate_issue_date).first %>
           </p>
           <% end %>

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -231,9 +231,9 @@ RSpec.feature "Adding a test result", :with_stubbed_antivirus, :with_stubbed_mai
     errors_list = page.find(".govuk-error-summary__list").all("li")
     expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
     expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
-    expect(errors_list[2].text).to eq "Select result of the test"
-    expect(errors_list[3].text).to eq "Provide the test results file"
-    expect(errors_list[4].text).to eq "Enter date of the test"
+    expect(errors_list[2].text).to eq "Enter date of the test"
+    expect(errors_list[3].text).to eq "Select result of the test"
+    expect(errors_list[4].text).to eq "Provide the test results file"
   end
 
   def expect_summary_to_reflect_values(result:, funded: false)


### PR DESCRIPTION
Description
Made changers to manual implementation to forms to make sure errors redirect to the correct fields, added a caching function to ensure documents are persisted when entered but the form is invalid 
