### PR TITLE
fix/PSD-2702-PDF-images-stacked-vertically

### DIFF
--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -5,6 +5,7 @@ class GenerateProductRecallPdf
     @params = params
     @product = product
     @file = file
+    preload_fonts
   end
 
   def self.generate_pdf(params, product, file)
@@ -21,26 +22,22 @@ class GenerateProductRecallPdf
       CreationDate: Time.zone.now
     }
     pdf = Prawn::Document.new(page_size: "A4", font_size: 11, info: metadata)
-    # rubocop:disable Rails/SaveBang
-    pdf.font_families.update(
-      "Arial" => {
-        normal: { file: Rails.root.join("app/assets/fonts/arial.ttf"), font: "Arial" },
-        bold: { file: Rails.root.join("app/assets/fonts/arial-bold.ttf"), font: "Arial-Bold" },
-      }
-    )
-    # rubocop:enable Rails/SaveBang
+
+    update_font_families(pdf)
+
     pdf.font("Arial")
+
+    # Header
     pdf.table([
-      [{ image: File.open(Rails.root.join("app/assets/images/opss-logo.jpg")), fit: [140, 140] }, { content: title, text_color: "FF0000", font_style: :bold, size: 20, align: :right, valign: :bottom }],
+      [{ image: File.open(Rails.root.join("app/assets/images/opss-logo.jpg")), fit: [140, 140] },
+       { content: title, text_color: "FF0000", font_style: :bold, size: 20, align: :right, valign: :bottom }]
     ], width: pdf.bounds.width, cell_style: { borders: [] })
 
+    # Main Content
     pdf.table([
       [{ content: params["pdf_title"], colspan: 2, font_style: :bold, size: 14 }],
       [{ content: "Aspect", font_style: :bold }, { content: "Details", font_style: :bold }],
-      [
-        { content: "Images", font_style: :bold },
-        build_sub_table(pdf)
-      ],
+      [{ content: "Images", font_style: :bold }, build_sub_table(pdf)],
       [{ content: "Alert Number", font_style: :bold }, params["alert_number"]],
       [{ content: "Product Type", font_style: :bold }, [params["product_type"], params["subcategory"]].compact.join(" - ")],
       [{ content: "Product Identifiers", font_style: :bold }, params["product_identifiers"]],
@@ -52,18 +49,34 @@ class GenerateProductRecallPdf
       [{ content: "Risk Description", font_style: :bold }, params["risk_description"]],
       [{ content: "Corrective Measures", font_style: :bold }, params["corrective_actions"]],
       [{ content: "Online Marketplace", font_style: :bold }, online_marketplace],
-      [{ content: "Notifier", font_style: :bold }, params["notified_by"]],
+      [{ content: "Notifier", font_style: :bold }, params["notified_by"]]
     ].compact, width: pdf.bounds.width, column_widths: { 0 => 120 })
 
+    # Footer
     pdf.repeat :all do
       pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 25], width: pdf.bounds.width do
         pdf.text_box 'The OPSS Product Safety Alerts, Reports and Recalls Site can be accessed at the following link: <color rgb="#0000FF"><u><link href="https://www.gov.uk/guidance/product-recalls-and-alerts">https://www.gov.uk/guidance/product-recalls-and-alerts</link></u></color>', inline_format: true
       end
     end
+
     pdf.render(file)
   end
 
 private
+
+  def preload_fonts
+    @arial_font = Rails.root.join("app/assets/fonts/arial.ttf")
+    @arial_bold_font = Rails.root.join("app/assets/fonts/arial-bold.ttf")
+  end
+
+  def update_font_families(pdf)
+    pdf.font_families.update(
+      "Arial" => {
+        normal: { file: @arial_font, font: "Arial" },
+        bold: { file: @arial_bold_font, font: "Arial-Bold" }
+      }
+    )
+  end
 
   def product_safety_report?
     params["type"] == "product_safety_report"
@@ -75,25 +88,18 @@ private
 
   def build_sub_table(pdf)
     rows = image_rows
-    if rows.present?
+    return if rows.blank?
 
-      flattened_array = rows.flatten(1)
-      new_array = flattened_array.each_slice(3).to_a
+    flattened_array = rows.flatten(1)
+    new_array = flattened_array.each_slice(3).to_a
 
-      pdf.make_cell(new_array, width: pdf.bounds.width - 120)
-    end
+    pdf.make_cell(new_array, width: pdf.bounds.width - 120)
   end
 
   def image_rows
-    if params["product_image_ids"].present?
+    return if params["product_image_ids"].blank?
 
-      rows = []
-      image_ids = params["product_image_ids"].reject(&:blank?)
-      image_ids.each do |image_id|
-        rows << [image_cell(image_id)]
-      end
-      rows
-    end
+    params["product_image_ids"].reject(&:blank?).map { |image_id| [image_cell(image_id)] }
   end
 
   def image_cell(id)
@@ -110,20 +116,20 @@ private
   end
 
   def country_from_code(code)
-    country = Country.all.find { |c| c[1] == code }
-    (country && country[0]) || code
+    Country.all.find { |c| c[1] == code }&.first || code
   end
 
   def counterfeit
-    return "Unknown" if params["counterfeit"].nil?
-
-    { "counterfeit" => "Yes", "genuine" => "No", "unsure" => "Unsure" }[params["counterfeit"]]
+    { "counterfeit" => "Yes", "genuine" => "No", "unsure" => "Unsure" }[params["counterfeit"]] || "Unknown"
   end
 
   def online_marketplace
-    return "N/A" if params["online_marketplace"].nil?
-    return "No" unless params["online_marketplace"]
-
-    params["other_marketplace_name"].presence || params["online_marketplace_id"]
+    if params["online_marketplace"].nil?
+      "N/A"
+    elsif params["online_marketplace"]
+      params["other_marketplace_name"].presence || params["online_marketplace_id"] || "Yes"
+    else
+      "No"
+    end
   end
 end

--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -74,11 +74,15 @@ private
   end
 
   def build_sub_table(pdf)
-    rows = image_rows
-    flattened_array = rows.flatten(1)
-    new_array = flattened_array.each_slice(3).to_a
 
-    pdf.make_cell(new_array, width: pdf.bounds.width - 120)
+    rows = image_rows
+    if rows.present?
+
+      flattened_array = rows.flatten(1)
+      new_array = flattened_array.each_slice(3).to_a
+
+      pdf.make_cell(new_array, width: pdf.bounds.width - 120)
+    end
   end
 
   def image_rows

--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -33,12 +33,13 @@ class GenerateProductRecallPdf
     pdf.table([
       [{ image: File.open(Rails.root.join("app/assets/images/opss-logo.jpg")), fit: [140, 140] }, { content: title, text_color: "FF0000", font_style: :bold, size: 20, align: :right, valign: :bottom }],
     ], width: pdf.bounds.width, cell_style: { borders: [] })
+
     pdf.table([
       [{ content: params["pdf_title"], colspan: 2, font_style: :bold, size: 14 }],
       [{ content: "Aspect", font_style: :bold }, { content: "Details", font_style: :bold }],
       [
         { content: "Images", font_style: :bold },
-        pdf.make_cell(image_rows, width: pdf.bounds.width - 120)
+        build_sub_table(pdf)
       ],
       [{ content: "Alert Number", font_style: :bold }, params["alert_number"]],
       [{ content: "Product Type", font_style: :bold }, [params["product_type"], params["subcategory"]].compact.join(" - ")],
@@ -53,6 +54,7 @@ class GenerateProductRecallPdf
       [{ content: "Online Marketplace", font_style: :bold }, online_marketplace],
       [{ content: "Notifier", font_style: :bold }, params["notified_by"]],
     ].compact, width: pdf.bounds.width, column_widths: { 0 => 120 })
+
     pdf.repeat :all do
       pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 25], width: pdf.bounds.width do
         pdf.text_box 'The OPSS Product Safety Alerts, Reports and Recalls Site can be accessed at the following link: <color rgb="#0000FF"><u><link href="https://www.gov.uk/guidance/product-recalls-and-alerts">https://www.gov.uk/guidance/product-recalls-and-alerts</link></u></color>', inline_format: true
@@ -69,6 +71,14 @@ private
 
   def title
     product_safety_report? ? "Product Safety Report" : "Product Recall"
+  end
+
+  def build_sub_table(pdf)
+    rows = image_rows
+    flattened_array = rows.flatten(1)
+    new_array = flattened_array.each_slice(3).to_a
+
+    pdf.make_cell(new_array, width: pdf.bounds.width - 120)
   end
 
   def image_rows
@@ -88,7 +98,7 @@ private
     return if image_upload.blank?
 
     image_upload.file_upload.blob.open do |file|
-      { image: File.open(file.path), fit: [200, 200], borders: [] }
+      { image: File.open(file.path), fit: [100, 100], borders: [] }
     end
   end
 

--- a/app/services/generate_product_recall_pdf.rb
+++ b/app/services/generate_product_recall_pdf.rb
@@ -74,7 +74,6 @@ private
   end
 
   def build_sub_table(pdf)
-
     rows = image_rows
     if rows.present?
 

--- a/spec/services/generate_product_recall_pdf_spec.rb
+++ b/spec/services/generate_product_recall_pdf_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+require "prawn"
+require "prawn/table"
+
+RSpec.describe GenerateProductRecallPdf, type: :service do
+  let(:params) do
+    {
+      "pdf_title" => "Test PDF Title",
+      "alert_number" => "12345",
+      "product_type" => "Toy",
+      "subcategory" => "Stuffed Animals",
+      "product_identifiers" => "123-ABC",
+      "product_description" => "A fluffy stuffed bear.",
+      "country_of_origin" => "GB",
+      "counterfeit" => "counterfeit",
+      "risk_type" => "Choking Hazard",
+      "risk_level" => "High",
+      "risk_description" => "Small parts may be ingested.",
+      "corrective_actions" => "Remove from shelves.",
+      "online_marketplace" => true,
+      "other_marketplace_name" => "Etsy",
+      "notified_by" => "John Doe",
+      "type" => "product_safety_report",
+      "product_image_ids" => %w[1 2]
+    }
+  end
+
+  let(:product) { instance_double(Product, id: 1, owning_team: instance_double(Team, name: "Safety Team")) }
+  let(:file) { Tempfile.new(["product_recall", ".pdf"]) }
+
+  let(:generate_product_recall_pdf) { described_class.new(params, product, file) }
+
+  after do
+    file.close
+    file.unlink
+  end
+
+  describe ".generate_pdf" do
+    it "calls the instance method generate_pdf" do
+      instance = described_class.new(params, product, file)
+      allow(instance).to receive(:generate_pdf)
+      instance.generate_pdf
+      expect(instance).to have_received(:generate_pdf)
+    end
+  end
+
+  describe "#generate_pdf" do
+    let(:pdf) { Prawn::Document.new }
+
+    let(:document_options) do
+      {
+        page_size: "A4",
+        font_size: 11,
+        info: {
+          Title: "OPSS - Product Safety Report - Test PDF Title",
+          Author: "Safety Team",
+          Subject: "Product Safety Report",
+          Creator: "Product Safety Database",
+          Producer: "Prawn",
+          CreationDate: kind_of(Time)
+        }
+      }
+    end
+
+    let(:expected_metadata) do
+      {
+        Title: "OPSS - Product Safety Report - Test PDF Title",
+        Author: "Safety Team",
+        Subject: "Product Safety Report",
+        Creator: "Product Safety Database",
+        Producer: "Prawn",
+        CreationDate: kind_of(Time)
+      }
+    end
+
+    before do
+      allow(Prawn::Document).to receive(:new).and_return(pdf)
+      allow(pdf).to receive(:font_families).and_return({})
+      allow(pdf).to receive(:font)
+      allow(pdf).to receive(:table)
+      allow(pdf).to receive(:repeat)
+      allow(pdf).to receive(:render)
+      allow(pdf).to receive(:bounding_box)
+      allow(pdf).to receive(:text_box)
+      allow(pdf).to receive(:make_cell)
+      allow(File).to receive(:open).and_call_original
+      generate_product_recall_pdf.generate_pdf
+    end
+
+    it "creates a new PDF document" do
+      expect(Prawn::Document).to have_received(:new).with(hash_including(page_size: "A4"))
+    end
+
+    it "sets the correct font size" do
+      expect(Prawn::Document).to have_received(:new).with(hash_including(font_size: 11))
+    end
+
+    it "includes the correct metadata" do
+      expect(Prawn::Document).to have_received(:new).with(hash_including(info: hash_including(expected_metadata)))
+    end
+  end
+
+  describe "private methods" do
+    describe "#title" do
+      it 'returns "Product Safety Report" when type is product_safety_report' do
+        expect(generate_product_recall_pdf.send(:title)).to eq("Product Safety Report")
+      end
+
+      it 'returns "Product Recall" for other types' do
+        params["type"] = "other"
+        expect(generate_product_recall_pdf.send(:title)).to eq("Product Recall")
+      end
+    end
+
+    describe "#country_from_code" do
+      it "returns the country name from the code" do
+        allow(Country).to receive(:all).and_return([["United Kingdom", "GB"]])
+        expect(generate_product_recall_pdf.send(:country_from_code, "GB")).to eq("United Kingdom")
+      end
+
+      it "returns the code if the country is not found" do
+        allow(Country).to receive(:all).and_return([["United Kingdom", "GB"]])
+        expect(generate_product_recall_pdf.send(:country_from_code, "FR")).to eq("FR")
+      end
+    end
+
+    describe "#counterfeit" do
+      it 'returns "Yes" for counterfeit' do
+        expect(generate_product_recall_pdf.send(:counterfeit)).to eq("Yes")
+      end
+
+      it 'returns "No" for genuine' do
+        params["counterfeit"] = "genuine"
+        expect(generate_product_recall_pdf.send(:counterfeit)).to eq("No")
+      end
+
+      it 'returns "Unsure" for unsure' do
+        params["counterfeit"] = "unsure"
+        expect(generate_product_recall_pdf.send(:counterfeit)).to eq("Unsure")
+      end
+
+      it 'returns "Unknown" for nil' do
+        params["counterfeit"] = nil
+        expect(generate_product_recall_pdf.send(:counterfeit)).to eq("Unknown")
+      end
+    end
+
+    describe "#online_marketplace" do
+      it 'returns "N/A" if online_marketplace is nil' do
+        params["online_marketplace"] = nil
+        expect(generate_product_recall_pdf.send(:online_marketplace)).to eq("N/A")
+      end
+
+      it 'returns "No" if online_marketplace is false' do
+        params["online_marketplace"] = false
+        expect(generate_product_recall_pdf.send(:online_marketplace)).to eq("No")
+      end
+
+      it "returns the other marketplace name if present" do
+        expect(generate_product_recall_pdf.send(:online_marketplace)).to eq("Etsy")
+      end
+
+      it "returns the online marketplace id if other marketplace name is not present" do
+        params["other_marketplace_name"] = nil
+        params["online_marketplace_id"] = "123"
+        expect(generate_product_recall_pdf.send(:online_marketplace)).to eq("123")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Added function to ensure more than 3 images are displayed in a row (3 per row) with any extra stacking below in a new row.

![image](https://github.com/user-attachments/assets/93640777-e78a-4545-a9dc-bdaa83d3ec56)


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
