### PR TITLE
chore/PSD-3036:Update_to_prism_risk_assessments_form

### DIFF
--- a/app/controllers/investigations/prism_risk_assessments_controller.rb
+++ b/app/controllers/investigations/prism_risk_assessments_controller.rb
@@ -55,6 +55,9 @@ module Investigations
       counter = 0
       if params[:select_product_for_prism_form].present?
         counter += params[:select_product_for_prism_form][:counter].to_i
+      else
+        redirect_to choose_product_investigation_prism_risk_assessments_path(counter:)
+        return
       end
       redirect_to choose_product_investigation_prism_risk_assessments_path(counter:) unless params[:select_product_for_prism_form][:product_id].present? && @investigation.products.find_by(id: params[:select_product_for_prism_form][:product_id])
     end


### PR DESCRIPTION
controller fix, added an extra condition that checks if this is the first time the user is accessing that specific view for a prism risk assessment, this will prevent the controller from raising an exception due to the user accessing the view without the needed parameters
