### PR TITLE
feat/PSD-2528-Image-orientation-help-text

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -56,7 +56,8 @@
 <% if !local_assigns[:disable_image_upload] %>
   <%= form.govuk_file_field :image,
                             label: { text: 'Upload a product image', size: 'm' },
-                            hint: { text: 'Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.' } %>
+                            hint: { text: '<p style="margin-bottom: 5px;">Please ensure that the image you are uploading is in the correct orientation prior to uploading it</p>
+                            <p>Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.</p>'.html_safe } %>
 <% end %>
 
 

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -56,8 +56,8 @@
 <% if !local_assigns[:disable_image_upload] %>
   <%= form.govuk_file_field :image,
                             label: { text: 'Upload a product image', size: 'm' },
-                            hint: { text: '<p style="margin-bottom: 5px;">Please ensure that the image you are uploading is in the correct orientation prior to uploading it</p>
-                            <p>Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.</p>'.html_safe } %>
+                            hint: { text: 'Please ensure that the image you are uploading is in the correct orientation prior to uploading it.</br>
+                            Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.'.html_safe } %>
 <% end %>
 
 


### PR DESCRIPTION
## Description

PSD-2528 image orientation hint text

## Screen-shots or screen-capture of UI changes

![image](https://github.com/user-attachments/assets/34eda090-ce88-4a0e-a964-82be47c2928c)

![image](https://github.com/user-attachments/assets/fbad3a6c-5d48-4ef9-8d55-1ec6d3af1861)

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [x] Reviewed by Designer (if required)
- [x] Works keyboard only
- [ ] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
