### PR TITLE
chore/PSD-3050-Update_to__product_recall_pdf_extract 

### DIFF
--- a/app/views/products/recalls/select-images.html.erb
+++ b/app/views/products/recalls/select-images.html.erb
@@ -5,9 +5,14 @@
       <%= form.hidden_field :step, value: @form.step %>
       <div class="govuk-form-group image-select">
         <% if @product.virus_free_images.any? %>
-          <%= form.govuk_check_boxes_fieldset(:product_image_ids, legend: { text: "Select the images to include", size: "l" }) do %>
+          <%= form.govuk_check_boxes_fieldset(:product_image_ids, legend: { text: "Select the images to include", size: "l" }, hint: { text: "<div>Sorry GIFs are not supported by PDF files</div><div>Supported file formats:JPEG, PNG, WEBP or HEIC/HEIF</div>".html_safe}) do %>
             <% @product.virus_free_images.each do |image| %>
-              <%= form.govuk_check_box :product_image_ids, image.id, label: { text: "#{image.file_upload.filename} <div class=\"opss-checkboxes-thumbnails_img\" style=\"background-image: url(#{rails_storage_proxy_path(image.file_upload, only_path: true)})\"></div>".html_safe }, checked: @form.product_image_ids.to_a.include?(image.id) %>
+              <% if image.file_upload.content_type == "image/gif" %>
+                  <%= "<div class='govuk-checkboxes__item'><label style='font-size: 1.1875rem; font-family: \"GDS Transport\", arial, sans-serif'>#{image.file_upload.filename}</label> <div class=\"opss-checkboxes-thumbnails_img\" style=\"background-image: url(#{rails_storage_proxy_path(image.file_upload, only_path: true)})\"></div>
+                  </div>".html_safe %>
+                <% else %>
+                <%= form.govuk_check_box :product_image_ids, image.id, label: { text: "#{image.file_upload.filename} <div class=\"opss-checkboxes-thumbnails_img\" style=\"background-image: url(#{rails_storage_proxy_path(image.file_upload, only_path: true)})\"></div>".html_safe }, checked: @form.product_image_ids.to_a.include?(image.id) %>
+              <% end %>
             <% end %>
           <% end %>
         <% else %>


### PR DESCRIPTION
Description
Disabled the ability for user to select GIF image types for the product Recall PDF, added hint message to explain why they cannot select their gif images.
