### PR TITLE
Feat/psd 2800 add imt to notification

### DIFF
--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -24,6 +24,8 @@ module Investigations
           .merge(user: current_user, notification: @investigation)
       )
 
+      add_incident_management_team
+
       if result.success?
         ahoy.track "Added corrective action", { investigation_id: @investigation.id }
         return redirect_to investigation_supporting_information_index_path(@investigation), flash: { success: "The supporting information was updated" }
@@ -68,6 +70,9 @@ module Investigations
             changes: @corrective_action_form.changes
           )
       )
+
+      add_incident_management_team
+
       ahoy.track "Updated corrective action", { notification_id: @investigation.id } if @corrective_action_form.changes != { "date_decided(1i)" => [nil, params[:corrective_action]["date_decided(1i)"]], "date_decided(2i)" => [nil, params[:corrective_action]["date_decided(2i)"]], "date_decided(3i)" => [nil, params[:corrective_action]["date_decided(3i)"]] }
 
       if params[:bulk_products_upload_id].present?
@@ -75,6 +80,10 @@ module Investigations
       else
         redirect_to investigation_supporting_information_index_path(@investigation), flash: { success: "The supporting information was updated" }
       end
+    end
+
+    def add_incident_management_team
+      AddImtToNotification.call!(notification: @investigation, user: current_user)
     end
   end
 end

--- a/app/controllers/investigations/risk_level_controller.rb
+++ b/app/controllers/investigations/risk_level_controller.rb
@@ -15,6 +15,9 @@ module Investigations
       result = ChangeNotificationRiskLevel.call!(
         @risk_level_form.attributes.merge(notification: @investigation, user: current_user)
       )
+
+      add_incident_management_team
+
       ahoy.track "Updated risk level", { notification_id: @investigation.id }
       set_success_flash_message(result)
       redirect_to investigation_path(@investigation)
@@ -28,6 +31,10 @@ module Investigations
       flash[:success] = I18n.t(".success.#{result.change_action}",
                                scope: "investigations.risk_level",
                                level: result.updated_risk_level.downcase)
+    end
+
+    def add_incident_management_team
+      AddImtToNotification.call!(notification: @investigation, user: current_user)
     end
   end
 end

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -686,6 +686,7 @@ module Notifications
         # Manually save, then finish the wizard.
         if @notification.save(context: step)
           if step == :check_notification_details_and_submit && params[:final] == "true"
+            pre_submission_tasks
             @notification.submit!
             return redirect_to confirmation_notification_create_index_path(@notification)
           end
@@ -1239,6 +1240,14 @@ module Notifications
                             else
                               "unknown"
                             end
+    end
+
+    def pre_submission_tasks
+      add_incident_management_team
+    end
+
+    def add_incident_management_team
+      AddImtToNotification.call!(notification: @notification, user: current_user)
     end
   end
 end

--- a/app/services/add_corrective_action_to_notification.rb
+++ b/app/services/add_corrective_action_to_notification.rb
@@ -27,31 +27,9 @@ class AddCorrectiveActionToNotification
       create_audit_activity
       send_notification_email unless context.silent
     end
-
-    add_incident_management_team
   end
 
 private
-
-  def add_incident_management_team
-    # OPSS IMT is automatically added to an notification with edit permissions
-    # on adding a corrective action if either the risk level is serious/high or
-    # the corrective action indicates a recall. If OPSS IMT has already been added,
-    # `AddTeamToNotification` returns silently.
-
-    return unless %w[serious high].include?(notification.risk_level) || action == "recall_of_the_product_from_end_users" || action == "modification_programme"
-
-    team = Team.find_by(name: "OPSS Incident Management")
-    return if team.blank?
-
-    AddTeamToNotification.call!(
-      notification:,
-      team:,
-      collaboration_class: Collaboration::Access::Edit,
-      user:,
-      message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
-    )
-  end
 
   def create_audit_activity
     metadata = AuditActivity::CorrectiveAction::Add.build_metadata(corrective_action)

--- a/app/services/add_imt_to_notification.rb
+++ b/app/services/add_imt_to_notification.rb
@@ -1,0 +1,36 @@
+class AddImtToNotification
+  include Interactor
+  include EntitiesToNotify
+
+  delegate :notification, :user, to: :context
+
+  # OPSS IMT is automatically added to an notification with edit permissions
+  #  if either the risk level is serious/high or
+  # the corrective action indicates a recall or modification programme. If OPSS IMT has already been added,
+  # `AddTeamToNotification` returns silently.
+  def call
+    context.fail!(error: "No notification supplied") unless notification.is_a?(Investigation)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+    actions = notification.corrective_actions&.pluck("action")
+    return unless should_add_team?(actions)
+
+    team = Team.find_by(name: "OPSS Incident Management")
+    return if team.blank?
+
+    AddTeamToNotification.call!(
+      notification:,
+      team:,
+      collaboration_class: Collaboration::Access::Edit,
+      user:,
+      message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
+    )
+  end
+
+private
+
+  def should_add_team?(actions)
+    %w[serious high].include?(notification.risk_level) ||
+      actions&.include?("recall_of_the_product_from_end_users") ||
+      actions&.include?("modification_programme")
+  end
+end

--- a/spec/features/add_team_imt_to_notification_spec.rb
+++ b/spec/features/add_team_imt_to_notification_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Add IMT to Notification", :with_opensearch, :with_product_form_he
   let!(:business_one) { create(:business, :online_marketplace, trading_name: "great value", created_at: 1.day.ago) }
   let!(:opss_imt) { create(:team, name: "OPSS Incident Management") }
 
-
   before do
     sign_in(user)
   end
@@ -14,23 +13,24 @@ RSpec.feature "Add IMT to Notification", :with_opensearch, :with_product_form_he
   scenario "creating a Serious risk notification with the mininum tasklist flow adds IMT to the notification" do
     create_notification_with_mandatory_tasklist
     choose_risk_level("Serious risk")
-    choose_corrective_action_as_No
+    choose_corrective_action_as_no
     submit_notification
     expect(page).to have_content("Notification submitted")
     click_link "Edit submitted notification"
 
-    expect(page).to have_content("OPSS Incident Management")
+    expect(page).to have_content(opss_imt.name)
   end
 
   scenario "creating a High risk notification with the mininum tasklist flow adds IMT to the notification" do
     create_notification_with_mandatory_tasklist
     choose_risk_level("High risk")
-    choose_corrective_action_as_No
+    choose_corrective_action_as_no
     submit_notification
     expect(page).to have_content("Notification submitted")
     click_link "Edit submitted notification"
-
-    expect(page).to have_content("OPSS Incident Management")
+    expect(page).to have_content(existing_product.name)
+    expect(page).to have_content(business_one.trading_name)
+    expect(page).to have_content(opss_imt.name)
   end
 
   scenario "creating a notification with the mininum tasklist flow and product recall as corrective action adds IMT to the notification" do
@@ -40,7 +40,7 @@ RSpec.feature "Add IMT to Notification", :with_opensearch, :with_product_form_he
     expect(page).to have_content("Notification submitted")
     click_link "Edit submitted notification"
 
-    expect(page).to have_content("OPSS Incident Management")
+    expect(page).to have_content(opss_imt.name)
   end
 
   def create_notification_with_mandatory_tasklist
@@ -150,7 +150,7 @@ RSpec.feature "Add IMT to Notification", :with_opensearch, :with_product_form_he
     click_button "Continue"
   end
 
-  def choose_corrective_action_as_No
+  def choose_corrective_action_as_no
     click_link "Record a corrective action"
 
     within_fieldset "Have you taken a corrective action for the unsafe or non-compliant product(s)?" do

--- a/spec/features/add_team_imt_to_notification_spec.rb
+++ b/spec/features/add_team_imt_to_notification_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+RSpec.feature "Add IMT to Notification", :with_opensearch, :with_product_form_helper, :with_stubbed_antivirus, :with_stubbed_mailer do
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let!(:existing_product) { create(:product) }
+  let!(:business_one) { create(:business, :online_marketplace, trading_name: "great value", created_at: 1.day.ago) }
+  let!(:opss_imt) { create(:team, name: "OPSS Incident Management") }
+
+
+  before do
+    sign_in(user)
+  end
+
+  scenario "creating a Serious risk notification with the mininum tasklist flow adds IMT to the notification" do
+    create_notification_with_mandatory_tasklist
+    choose_risk_level("Serious risk")
+    choose_corrective_action_as_No
+    submit_notification
+    expect(page).to have_content("Notification submitted")
+    click_link "Edit submitted notification"
+
+    expect(page).to have_content("OPSS Incident Management")
+  end
+
+  scenario "creating a High risk notification with the mininum tasklist flow adds IMT to the notification" do
+    create_notification_with_mandatory_tasklist
+    choose_risk_level("High risk")
+    choose_corrective_action_as_No
+    submit_notification
+    expect(page).to have_content("Notification submitted")
+    click_link "Edit submitted notification"
+
+    expect(page).to have_content("OPSS Incident Management")
+  end
+
+  scenario "creating a notification with the mininum tasklist flow and product recall as corrective action adds IMT to the notification" do
+    create_notification_with_mandatory_tasklist
+    choose_corrective_action("Recall of the product from end users")
+    submit_notification
+    expect(page).to have_content("Notification submitted")
+    click_link "Edit submitted notification"
+
+    expect(page).to have_content("OPSS Incident Management")
+  end
+
+  def create_notification_with_mandatory_tasklist
+    visit "/notifications/create"
+    click_link "Search for or add a product"
+    click_button "Select", match: :first
+
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    click_link "Add notification details"
+    fill_in "Notification title", with: "Fake name"
+    fill_in "Notification summary", with: "This is a fake summary"
+    within_fieldset("Why are you creating the notification?") do
+      choose "A product is unsafe or non-compliant"
+    end
+    click_button "Save and continue"
+
+    within_fieldset "What specific issues make the product unsafe or non-compliant?" do
+      check "Product harm"
+      select "Chemical", from: "What is the primary harm?"
+      fill_in "Provide additional information about the product harm", with: "Fake description"
+    end
+
+    within_fieldset "Was the safety issue reported by an overseas regulator?" do
+      choose "No"
+    end
+
+    within_fieldset "Do you want to add your own reference number?" do
+      choose "No"
+    end
+    click_button "Save and continue"
+    choose "Unknown"
+    click_button "Save and complete tasks in this section"
+
+    click_link "Search for or add a business"
+    click_button "Select", match: :first
+
+    click_button "Use business details"
+
+    check "Retailer"
+    click_button "Save and continue"
+
+    within_fieldset "Do you need to add another business?" do
+      choose "No"
+    end
+    click_button "Continue"
+  end
+
+  def choose_risk_level(risk_level)
+    click_link "Evaluate notification risk level"
+    choose risk_level
+    click_button "Save and complete tasks in this section"
+  end
+
+  def choose_corrective_action(corrective_action)
+    click_link "Record a corrective action"
+
+    within_fieldset "Have you taken a corrective action for the unsafe or non-compliant product(s)?" do
+      choose "Yes"
+    end
+
+    click_button "Save and continue"
+
+    within_fieldset "What action is being taken?" do
+      choose corrective_action
+    end
+
+    within_fieldset "Has the business responsible published product recall information online?" do
+      choose "Yes"
+      fill_in "Location of recall information", with: "https://www.example.com"
+    end
+
+    within_fieldset "What date did the action come in to effect?" do
+      fill_in "Day", with: "9"
+      fill_in "Month", with: "2"
+      fill_in "Year", with: "2024"
+    end
+
+    select "ATEX 2016", from: "Under which legislation?"
+    select "Consumer Protection Act 1987", from: "Under which legislation?"
+
+    within_fieldset "Which business is responsible?" do
+      choose "great value (Retailer)"
+    end
+
+    within_fieldset "Is the corrective action mandatory?" do
+      choose "Yes"
+    end
+
+    within_fieldset "In which geographic regions has this corrective action been taken?" do
+      check "Great Britain"
+    end
+
+    within_fieldset "Are there any files related to the action?" do
+      choose "No"
+    end
+
+    click_button "Add corrective action"
+    within_fieldset "Do you need to add another corrective action?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+  end
+
+  def choose_corrective_action_as_No
+    click_link "Record a corrective action"
+
+    within_fieldset "Have you taken a corrective action for the unsafe or non-compliant product(s)?" do
+      choose "No"
+      choose "I don't have enough information to take a corrective action"
+    end
+
+    click_button "Save and continue"
+    click_button "Save and complete tasks in this section"
+  end
+
+  def submit_notification
+    click_link "Check the notification details and submit"
+    click_button "Submit notification"
+  end
+end

--- a/spec/services/add_corrective_action_to_notification_spec.rb
+++ b/spec/services/add_corrective_action_to_notification_spec.rb
@@ -56,48 +56,4 @@ RSpec.describe AddCorrectiveActionToNotification, :with_stubbed_mailer, :with_te
   end
 
   it_behaves_like "a service which notifies teams with access"
-
-  context "when the notification risk level is serious" do
-    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
-
-    before do
-      opss_imt
-      notification.risk_level = "serious"
-      notification.save!
-    end
-
-    it "adds OPSS IMT with edit permissions as a collaborator" do
-      expect(result.notification.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
-    end
-  end
-
-  context "when the corrective action indicates a recall" do
-    let(:action_key) { "recall_of_the_product_from_end_users" }
-    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
-
-    before do
-      opss_imt
-      notification.risk_level = "low"
-      notification.save!
-    end
-
-    it "adds OPSS IMT with edit permissions as a collaborator" do
-      expect(result.notification.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
-    end
-  end
-
-  context "when the corrective action indicates a modification programme" do
-    let(:action_key) { "modification_programme" }
-    let(:opss_imt) { create(:team, name: "OPSS Incident Management") }
-
-    before do
-      opss_imt
-      notification.risk_level = "low"
-      notification.save!
-    end
-
-    it "adds OPSS IMT with edit permissions as a collaborator" do
-      expect(result.notification.teams_with_edit_access).to contain_exactly(user.team, opss_imt)
-    end
-  end
 end

--- a/spec/services/add_imt_to_notification_spec.rb
+++ b/spec/services/add_imt_to_notification_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe AddImtToNotification, :with_stubbed_mailer do
+  let(:user) { create(:user) }
+  let(:notification) { create(:notification, risk_level:) }
+  let(:team) { create(:team, name: "OPSS Incident Management") }
+  let(:risk_level) { "serious" }
+  let(:corrective_actions) { [] }
+
+  before do
+    allow(notification).to receive(:corrective_actions).and_return(corrective_actions)
+    allow(Team).to receive(:find_by).with(name: "OPSS Incident Management").and_return(team)
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(notification:, user:) }
+
+    context "when notification is not supplied" do
+      let(:notification) { nil }
+
+      it "fails with an error" do
+        expect(result).to be_a_failure
+        expect(result.error).to eq("No notification supplied")
+      end
+    end
+
+    context "when user is not supplied" do
+      let(:user) { nil }
+
+      it "fails with an error" do
+        expect(result).to be_a_failure
+        expect(result.error).to eq("No user supplied")
+      end
+    end
+
+    context "when risk level is low and no relevant corrective action" do
+      let(:risk_level) { "low" }
+      let(:corrective_actions) { [instance_double(CorrectiveAction, action: "some_other_action")] }
+
+      it "does not add OPSS IMT team to the notification" do
+        expect(AddTeamToNotification).not_to receive(:call!)
+      end
+    end
+
+    context "when team is not found" do
+      before do
+        allow(Team).to receive(:find_by).with(name: "OPSS Incident Management").and_return(nil)
+      end
+
+      it "does not add OPSS IMT team to the notification" do
+        expect(AddTeamToNotification).not_to receive(:call!)
+      end
+    end
+
+    context "when risk level is serious or high" do
+      it "adds OPSS IMT team to the notification" do
+        expect(AddTeamToNotification).to receive(:call!).with(
+          notification:,
+          team:,
+          collaboration_class: Collaboration::Access::Edit,
+          user:,
+          message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
+        )
+        expect(result).to be_a_success
+      end
+    end
+
+    context "when corrective action indicates a recall" do
+      let(:risk_level) { "low" }
+      let(:corrective_actions) { [create(:corrective_action, action: "recall_of_the_product_from_end_users")] }
+
+      it "adds OPSS IMT team to the notification" do
+        expect(AddTeamToNotification).to receive(:call!).with(
+          notification:,
+          team:,
+          collaboration_class: Collaboration::Access::Edit,
+          user:,
+          message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
+        )
+        expect(result).to be_a_success
+      end
+    end
+
+    context "when corrective action indicates a modification programme" do
+      let(:risk_level) { "low" }
+      let(:corrective_actions) { [create(:corrective_action, action: "modification_programme")] }
+
+      it "adds OPSS IMT team to the notification" do
+        expect(AddTeamToNotification).to receive(:call!).with(
+          notification:,
+          team:,
+          collaboration_class: Collaboration::Access::Edit,
+          user:,
+          message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
+        )
+        expect(result).to be_a_success
+      end
+    end
+  end
+end

--- a/spec/services/add_imt_to_notification_spec.rb
+++ b/spec/services/add_imt_to_notification_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe AddImtToNotification, :with_stubbed_mailer do
 
   before do
     allow(notification).to receive(:corrective_actions).and_return(corrective_actions)
+    allow(AddTeamToNotification).to receive(:call!)
     allow(Team).to receive(:find_by).with(name: "OPSS Incident Management").and_return(team)
   end
 
@@ -37,8 +38,13 @@ RSpec.describe AddImtToNotification, :with_stubbed_mailer do
       let(:risk_level) { "low" }
       let(:corrective_actions) { [instance_double(CorrectiveAction, action: "some_other_action")] }
 
+      before do
+        allow(corrective_actions).to receive(:pluck).with("action").and_return(corrective_actions.map(&:action))
+      end
+
       it "does not add OPSS IMT team to the notification" do
-        expect(AddTeamToNotification).not_to receive(:call!)
+        described_class.call(notification:, user:)
+        expect(AddTeamToNotification).not_to have_received(:call!)
       end
     end
 
@@ -48,19 +54,27 @@ RSpec.describe AddImtToNotification, :with_stubbed_mailer do
       end
 
       it "does not add OPSS IMT team to the notification" do
-        expect(AddTeamToNotification).not_to receive(:call!)
+        described_class.call(notification:, user:)
+        expect(AddTeamToNotification).not_to have_received(:call!)
       end
     end
 
     context "when risk level is serious or high" do
+      before do
+        described_class.call(notification:, user:)
+      end
+
       it "adds OPSS IMT team to the notification" do
-        expect(AddTeamToNotification).to receive(:call!).with(
+        expect(AddTeamToNotification).to have_received(:call!).with(
           notification:,
           team:,
           collaboration_class: Collaboration::Access::Edit,
           user:,
           message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
         )
+      end
+
+      it "is successful" do
         expect(result).to be_a_success
       end
     end
@@ -69,14 +83,23 @@ RSpec.describe AddImtToNotification, :with_stubbed_mailer do
       let(:risk_level) { "low" }
       let(:corrective_actions) { [create(:corrective_action, action: "recall_of_the_product_from_end_users")] }
 
+      before do
+        allow(notification).to receive(:corrective_actions).and_return(corrective_actions)
+        allow(corrective_actions).to receive(:pluck).with("action").and_return(corrective_actions.map(&:action))
+        described_class.call(notification:, user:)
+      end
+
       it "adds OPSS IMT team to the notification" do
-        expect(AddTeamToNotification).to receive(:call!).with(
+        expect(AddTeamToNotification).to have_received(:call!).with(
           notification:,
           team:,
           collaboration_class: Collaboration::Access::Edit,
           user:,
           message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
         )
+      end
+
+      it "is successful" do
         expect(result).to be_a_success
       end
     end
@@ -85,14 +108,23 @@ RSpec.describe AddImtToNotification, :with_stubbed_mailer do
       let(:risk_level) { "low" }
       let(:corrective_actions) { [create(:corrective_action, action: "modification_programme")] }
 
+      before do
+        allow(notification).to receive(:corrective_actions).and_return(corrective_actions)
+        allow(corrective_actions).to receive(:pluck).with("action").and_return(corrective_actions.map(&:action))
+        described_class.call(notification:, user:)
+      end
+
       it "adds OPSS IMT team to the notification" do
-        expect(AddTeamToNotification).to receive(:call!).with(
+        expect(AddTeamToNotification).to have_received(:call!).with(
           notification:,
           team:,
           collaboration_class: Collaboration::Access::Edit,
           user:,
           message: "System added OPSS IMT with edit permissions due to either risk level or corrective action."
         )
+      end
+
+      it "is successful" do
         expect(result).to be_a_success
       end
     end


### PR DESCRIPTION
add IMT to Notification with Edit access when the Notification risk level is Serious or High , Or the corrective action is Product recall or Modification programme