### PR TITLE
chore/PSD-2980:fix_to_notification_name_form

### DIFF
--- a/app/forms/change_notification_name_form.rb
+++ b/app/forms/change_notification_name_form.rb
@@ -6,7 +6,7 @@ class ChangeNotificationNameForm
   attribute :user_title, :string
   attribute :current_user
 
-  validates :user_title, presence: true
+  validates :user_title, presence: true, length: { maximum: 100 }
   validate :unique_user_title_within_team
 
   def unique_user_title_within_team

--- a/app/views/investigations/case_names/_form.html.erb
+++ b/app/views/investigations/case_names/_form.html.erb
@@ -4,4 +4,4 @@
                           label: { text: heading, size: "l", isPageHeading: true },
                           hint: {text: "Give the notification a short descriptive title.", style: "margin-bottom: 5px" },
                           width: "two-thirds",
-                          maxlength: 75%>
+                          maxlength: 100 %>


### PR DESCRIPTION
Changed limiter for notification name input to 100 as thats the amount of characters user is allowed to input there, added validation that ensures user does not go over the limit to prevent ActiveRecord::RecordInvalid error
