### PR TITLE
fixed case name bug and updated spec`

### DIFF
--- a/spec/features/create_case_spec.rb
+++ b/spec/features/create_case_spec.rb
@@ -140,10 +140,7 @@ RSpec.feature "Creating a case", :with_stubbed_antivirus, :with_stubbed_mailer, 
 
         visit "/ts_investigation/case_name"
 
-        expect(page).not_to have_css("label", text: "What is the notification name?")
-        expect(page).to have_no_current_path "ts_investigation/case_name"
-
-        expect(page).to have_css("legend", text: "Why are you creating a notification?")
+        expect(page).to have_content("Create a notification")
         expect(page).to have_no_current_path "ts_investigation/reason_for_creating"
       end
     end
@@ -282,10 +279,7 @@ RSpec.feature "Creating a case", :with_stubbed_antivirus, :with_stubbed_mailer, 
 
         visit "/ts_investigation/case_name"
 
-        expect(page).not_to have_css("legend", text: "What is the notification name?")
-        expect(page).to have_no_current_path "ts_investigation/case_name"
-
-        expect(page).to have_css("legend", text: "Why are you creating a notification?")
+        expect(page).to have_content("Create a notification")
         expect(page).to have_no_current_path "ts_investigation/reason_for_creating"
       end
     end


### PR DESCRIPTION
PSD-2841 product id is nil in new notification wizard steps.

## Description
When navigating to `/ts_investigation/case_name` resulted in product id being nil.  Added defensive code to avoid this happening user is redirected to the new notification view explaining how to create a notification for a product.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
