### PR TITLE
chore/PSD-2742:Update-to-product-form

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -64,7 +64,7 @@ class ProductForm
 
   def cache_file!(user, product)
     if image.present?
-      unless image.is_a?(ActiveStorage::Blob)
+      unless image.is_a?(ActiveStorage::Blob) || !ACCEPTABLE_IMAGE_TYPES.include?(image.content_type)
         self.image = ActiveStorage::Blob.create_and_upload!(
           io: image,
           filename: image.original_filename,
@@ -73,8 +73,9 @@ class ProductForm
 
         image.analyze_later
       end
-
-      self.existing_image_file_id = image.signed_id
+      self.existing_image_file_id = if ACCEPTABLE_IMAGE_TYPES.include?(image.content_type)
+                                      image.signed_id
+                                    end
     end
 
     if existing_image_file_id.present? && product.present?

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -54,10 +54,20 @@
 %>
 
 <% if !local_assigns[:disable_image_upload] %>
-  <%= form.govuk_file_field :image,
+  <% if form.object.existing_image_file_id.present? %>
+    <%= form.hidden_field :existing_image_file_id, value: form.object.existing_image_file_id %>
+      <%= form.govuk_file_field :image,
+                                label: { text: 'Upload a product image', size: 'm' },
+                                hint: { text: 'Please ensure that the image you are uploading is in the correct orientation prior to uploading it.</br>
+                            Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.'.html_safe } %>
+
+      <%= render partial: "active_storage/blobs/blob", locals: { blob: form.object.image } %>
+  <% else %>
+    <%= form.govuk_file_field :image,
                             label: { text: 'Upload a product image', size: 'm' },
                             hint: { text: 'Please ensure that the image you are uploading is in the correct orientation prior to uploading it.</br>
                             Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF.'.html_safe } %>
+  <% end %>
 <% end %>
 
 


### PR DESCRIPTION
Description
Made sure the uploaded images to a product form are persisted and any unsupported file type isn't and the error is thrown
