### PR TITLE
Fix/psd 2874 bulk upload notif status

### DIFF
--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -25,7 +25,7 @@ class CreateNotification
       notification.build_owner_collaborations_from(user)
 
       notification.save!
-      byebug
+
       AddProductToNotification.call!(notification:, product:, user:, skip_email: true) if product
 
       AddPrismRiskAssessmentToNotification.call!(notification:, product:, prism_risk_assessment:, user:) if prism_risk_assessment

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -12,7 +12,7 @@ class CreateNotification
     notification.creator_user = user
     notification.creator_team = team
     notification.notifying_country = team.country
-    notification.state = "submitted" unless from_task_list
+    notification.state ||= "draft"
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.
@@ -25,7 +25,7 @@ class CreateNotification
       notification.build_owner_collaborations_from(user)
 
       notification.save!
-
+      byebug
       AddProductToNotification.call!(notification:, product:, user:, skip_email: true) if product
 
       AddPrismRiskAssessmentToNotification.call!(notification:, product:, prism_risk_assessment:, user:) if prism_risk_assessment


### PR DESCRIPTION
[PSD-2874](https://regulatorydelivery.atlassian.net/browse/PSD-2874)

## Description
Ensured notification is in submitted state until its actually submitted at the end of the journey.

## Screen-shots or screen-capture of UI changes

![image](https://github.com/user-attachments/assets/45f66be9-5398-4822-9944-c71436aa1211)

![image](https://github.com/user-attachments/assets/c1fd7327-66b1-4400-8100-762949fa0beb)
