### PR TITLE
refactor/PSD-3321:Make_change_to_overseas_regulator_field_change_notifying_country_field

### DIFF
--- a/app/controllers/investigations/overseas_regulator_controller.rb
+++ b/app/controllers/investigations/overseas_regulator_controller.rb
@@ -32,7 +32,7 @@ module Investigations
     end
 
     def overseas_regulator_params
-      params.require(:investigation).permit(:is_from_overseas_regulator, :overseas_regulator_country)
+      params.require(:investigation).permit(:is_from_overseas_regulator, :notifying_country)
     end
   end
 end

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -368,7 +368,7 @@ module Notifications
           end
           ChangeNotificationOverseasRegulator.call!(
             notification: @notification,
-            is_from_overseas_regulator: add_product_safety_and_compliance_details_params[:is_from_overseas_regulator],
+            is_from_overseas_regulator: add_product_safety_and_compliance_details_params[:is_from_overseas_regulator] == "true",
             notifying_country: add_product_safety_and_compliance_details_params[:notifying_country],
             user: current_user,
             silent: true

--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -140,7 +140,7 @@ module Notifications
           primary_hazard_description: @notification.hazard_description,
           noncompliance_description: @notification.non_compliant_reason,
           is_from_overseas_regulator: @notification.is_from_overseas_regulator,
-          overseas_regulator_country: @notification.overseas_regulator_country,
+          notifying_country: @notification.notifying_country,
           add_reference_number: @notification.complainant_reference.nil? ? nil : @notification.complainant_reference.present?,
           reference_number: @notification.complainant_reference
         )
@@ -369,7 +369,7 @@ module Notifications
           ChangeNotificationOverseasRegulator.call!(
             notification: @notification,
             is_from_overseas_regulator: add_product_safety_and_compliance_details_params[:is_from_overseas_regulator],
-            overseas_regulator_country: add_product_safety_and_compliance_details_params[:overseas_regulator_country],
+            notifying_country: add_product_safety_and_compliance_details_params[:notifying_country],
             user: current_user,
             silent: true
           )
@@ -1137,7 +1137,7 @@ module Notifications
     end
 
     def add_product_safety_and_compliance_details_params
-      params.require(:change_notification_product_safety_compliance_details_form).permit(:unsafe, :noncompliant, :primary_hazard, :primary_hazard_description, :noncompliance_description, :is_from_overseas_regulator, :overseas_regulator_country, :add_reference_number, :reference_number, :draft)
+      params.require(:change_notification_product_safety_compliance_details_form).permit(:unsafe, :noncompliant, :primary_hazard, :primary_hazard_description, :noncompliance_description, :is_from_overseas_regulator, :notifying_country, :add_reference_number, :reference_number, :draft)
     end
 
     def add_number_of_affected_units_params

--- a/app/forms/change_notification_product_safety_compliance_details_form.rb
+++ b/app/forms/change_notification_product_safety_compliance_details_form.rb
@@ -9,7 +9,7 @@ class ChangeNotificationProductSafetyComplianceDetailsForm
   attribute :primary_hazard_description, :string
   attribute :noncompliance_description, :string
   attribute :is_from_overseas_regulator, :boolean
-  attribute :overseas_regulator_country, :string
+  attribute :notifying_country, :string
   attribute :add_reference_number, :boolean
   attribute :reference_number, :string
   attribute :safe_and_compliant, :boolean # Whether the notification has already been marked as "safe and compliant"
@@ -19,7 +19,7 @@ class ChangeNotificationProductSafetyComplianceDetailsForm
   validates :primary_hazard, :primary_hazard_description, presence: true, if: -> { unsafe }, unless: -> { safe_and_compliant }
   validates :noncompliance_description, presence: true, if: -> { noncompliant }, unless: -> { safe_and_compliant }
   validates :is_from_overseas_regulator, inclusion: [true, false]
-  validates :overseas_regulator_country, inclusion: { in: Country.overseas_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
+  validates :notifying_country, inclusion: { in: Country.overseas_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
   validates :add_reference_number, inclusion: [true, false]
   validates :reference_number, presence: true, if: -> { add_reference_number }
   validates :primary_hazard_description, :noncompliance_description, length: { maximum: 10_000 }

--- a/app/forms/overseas_regulator_form.rb
+++ b/app/forms/overseas_regulator_form.rb
@@ -4,12 +4,12 @@ class OverseasRegulatorForm
   include ActiveModel::Serialization
 
   attribute :is_from_overseas_regulator, :boolean, default: nil
-  attribute :overseas_regulator_country, :string
+  attribute :notifying_country, :string
 
   validates :is_from_overseas_regulator, inclusion: { in: [true, false] }
-  validates :overseas_regulator_country, inclusion: { in: Country.overseas_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
+  validates :notifying_country, inclusion: { in: Country.overseas_countries.map(&:last) }, if: -> { is_from_overseas_regulator }
 
   def self.from(investigation)
-    new(is_from_overseas_regulator: investigation.is_from_overseas_regulator, overseas_regulator_country: investigation.overseas_regulator_country)
+    new(is_from_overseas_regulator: investigation.is_from_overseas_regulator, notifying_country: investigation.notifying_country)
   end
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -682,7 +682,7 @@ module InvestigationsHelper
     countries.map do |country|
       text = country[0]
       option = { text:, value: country[1] }
-      option[:selected] = true if overseas_regulator_form.overseas_regulator_country == text
+      option[:selected] = true if overseas_regulator_form.notifying_country == text
       option
     end
   end
@@ -909,7 +909,7 @@ private
   def overseas_regulator_value(investigation)
     return if investigation.is_from_overseas_regulator.nil?
 
-    investigation.is_from_overseas_regulator ? country_from_code(investigation.overseas_regulator_country, Country.overseas_countries) : t("investigations.overseas_regulator.no")
+    investigation.is_from_overseas_regulator ? country_from_code(investigation.notifying_country, Country.overseas_countries) : t("investigations.overseas_regulator.no")
   end
 
   def summary_html(investigation)

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -685,7 +685,7 @@ module InvestigationsHelper
       option[:selected] = true if overseas_regulator_form.notifying_country == text
       option
     end
-    countries.unshift(OpenStruct.new(text: "", value: "None"))
+    countries.unshift(OpenStruct.new(text: "", value: ""))
     countries
   end
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -679,12 +679,14 @@ module InvestigationsHelper
   end
 
   def options_for_overseas_regulator(countries, overseas_regulator_form)
-    countries.map do |country|
+    countries = countries.map do |country|
       text = country[0]
-      option = { text:, value: country[1] }
+      option = OpenStruct.new(text:, value: country[1])
       option[:selected] = true if overseas_regulator_form.notifying_country == text
       option
     end
+    countries.unshift(OpenStruct.new(text: "", value: "None"))
+    countries
   end
 
   def non_search_cases_page_names

--- a/app/models/audit_activity/investigation/change_overseas_regulator.rb
+++ b/app/models/audit_activity/investigation/change_overseas_regulator.rb
@@ -27,12 +27,10 @@ class AuditActivity::Investigation::ChangeOverseasRegulator < AuditActivity::Inv
   end
 
   def previous_country
-    pry
     metadata["updates"]["notifying_country"]&.first || "None"
   end
 
   def new_country
-    pry
     metadata["updates"]["notifying_country"]&.second || "None"
   end
 

--- a/app/models/audit_activity/investigation/change_overseas_regulator.rb
+++ b/app/models/audit_activity/investigation/change_overseas_regulator.rb
@@ -27,17 +27,19 @@ class AuditActivity::Investigation::ChangeOverseasRegulator < AuditActivity::Inv
   end
 
   def previous_country
+    pry
     metadata["updates"]["notifying_country"]&.first || "None"
   end
 
   def new_country
+    pry
     metadata["updates"]["notifying_country"]&.second || "None"
   end
 
 private
 
   def country_from_code(code)
-    country = Country.overseas_countries.find { |c| c[1] == code }
+    country = Country.notifying_countries.find { |c| c[1] == code }
     (country && country[0]) || code
   end
 end

--- a/app/models/audit_activity/investigation/change_overseas_regulator.rb
+++ b/app/models/audit_activity/investigation/change_overseas_regulator.rb
@@ -1,7 +1,6 @@
 class AuditActivity::Investigation::ChangeOverseasRegulator < AuditActivity::Investigation::Base
   def self.build_metadata(investigation)
-    updated_values = investigation.previous_changes.slice(:is_from_overseas_regulator, :overseas_regulator_country)
-
+    updated_values = investigation.previous_changes.slice(:is_from_overseas_regulator, :notifying_country)
     {
       updates: updated_values
     }
@@ -20,19 +19,19 @@ class AuditActivity::Investigation::ChangeOverseasRegulator < AuditActivity::Inv
   end
 
   def previous_from_overseas_regulator
-    metadata["updates"]["is_from_overseas_regulator"]&.first
+    metadata["updates"]["notifying_country"]&.first
   end
 
   def new_from_overseas_regulator
-    metadata["updates"]["is_from_overseas_regulator"]&.second
+    metadata["updates"]["notifying_country"]&.second
   end
 
   def previous_country
-    metadata["updates"]["overseas_regulator_country"]&.first || "None"
+    metadata["updates"]["notifying_country"]&.first || "None"
   end
 
   def new_country
-    metadata["updates"]["overseas_regulator_country"]&.second || "None"
+    metadata["updates"]["notifying_country"]&.second || "None"
   end
 
 private

--- a/app/models/notification_export.rb
+++ b/app/models/notification_export.rb
@@ -192,7 +192,7 @@ private
       if is_other_team
         "Restricted"
       else
-        notification.is_from_overseas_regulator ? country_from_code(notification.overseas_regulator_country).to_s : ""
+        nil
       end, # Country
       is_other_team ? "Restricted" : team&.ts_region, # trading_standards_region
       team&.regulator_name, # regulator_name should never be nil and is never restricted

--- a/app/models/notification_export.rb
+++ b/app/models/notification_export.rb
@@ -189,11 +189,7 @@ private
       else
         notification.is_from_overseas_regulator ? "Yes" : "No"
       end, # overseas_regulator
-      if is_other_team
-        "Restricted"
-      else
-        nil
-      end, # Country
+      is_other_team ? "Restricted" : nil, # Country
       is_other_team ? "Restricted" : team&.ts_region, # trading_standards_region
       team&.regulator_name, # regulator_name should never be nil and is never restricted
       is_other_team ? "Restricted" : restrict_data_for_non_opss_user(team&.team_type == "internal"), # opss_internal_team

--- a/app/services/change_notification_overseas_regulator.rb
+++ b/app/services/change_notification_overseas_regulator.rb
@@ -35,7 +35,7 @@ private
   end
 
   def assign_overseas_regulator
-    country = is_from_overseas_regulator ? notifying_country : nil
+    country = is_from_overseas_regulator ? notifying_country : country_from_code(notification.creator_team.country)
     notification.assign_attributes(is_from_overseas_regulator:, notifying_country: country)
   end
 
@@ -52,5 +52,10 @@ private
         "Overseas regulator edited for notification"
       ).deliver_later
     end
+  end
+
+  def country_from_code(code)
+    country = Country.notifying_countries.find { |c| c[1] == code }
+    (country && country[0]) || code
   end
 end

--- a/app/services/change_notification_overseas_regulator.rb
+++ b/app/services/change_notification_overseas_regulator.rb
@@ -35,7 +35,7 @@ private
   end
 
   def assign_overseas_regulator
-    country = is_from_overseas_regulator ? notifying_country : country_from_code(notification.creator_team.country)
+    country = is_from_overseas_regulator ? notifying_country : notification.creator_team.country
     notification.assign_attributes(is_from_overseas_regulator:, notifying_country: country)
   end
 
@@ -52,10 +52,5 @@ private
         "Overseas regulator edited for notification"
       ).deliver_later
     end
-  end
-
-  def country_from_code(code)
-    country = Country.notifying_countries.find { |c| c[1] == code }
-    (country && country[0]) || code
   end
 end

--- a/app/services/change_notification_overseas_regulator.rb
+++ b/app/services/change_notification_overseas_regulator.rb
@@ -2,14 +2,14 @@ class ChangeNotificationOverseasRegulator
   include Interactor
   include EntitiesToNotify
 
-  delegate :notification, :is_from_overseas_regulator, :overseas_regulator_country, :user, to: :context
+  delegate :notification, :is_from_overseas_regulator, :notifying_country, :user, to: :context
 
   def call
     context.fail!(error: "No notification supplied") unless notification.is_a?(Investigation)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
     assign_overseas_regulator
-    return if notification.changes[:overseas_regulator_country].blank?
+    return if notification.changes[:notifying_country].blank?
 
     ActiveRecord::Base.transaction do
       notification.save!
@@ -23,7 +23,6 @@ private
 
   def create_audit_activity_for_overseas_regulator_changed
     metadata = activity_class.build_metadata(notification)
-
     activity_class.create!(
       added_by_user: user,
       investigation: notification,
@@ -36,12 +35,8 @@ private
   end
 
   def assign_overseas_regulator
-    country = is_from_overseas_regulator ? overseas_regulator_country : nil
-    if country.present?
-      notification.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country, notifying_country: country)
-    else
-      notification.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country)
-    end
+    country = is_from_overseas_regulator ? notifying_country : nil
+    notification.assign_attributes(is_from_overseas_regulator:, notifying_country: country)
   end
 
   def send_notification_email(notification, user)

--- a/app/services/change_notification_overseas_regulator.rb
+++ b/app/services/change_notification_overseas_regulator.rb
@@ -9,7 +9,7 @@ class ChangeNotificationOverseasRegulator
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
     assign_overseas_regulator
-    return if notification.changes.none?
+    return if notification.changes[:overseas_regulator_country].blank?
 
     ActiveRecord::Base.transaction do
       notification.save!
@@ -37,7 +37,11 @@ private
 
   def assign_overseas_regulator
     country = is_from_overseas_regulator ? overseas_regulator_country : nil
-    notification.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country)
+    if country.present?
+      notification.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country, notifying_country: country)
+    else
+      notification.assign_attributes(is_from_overseas_regulator:, overseas_regulator_country: country)
+    end
   end
 
   def send_notification_email(notification, user)

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -11,7 +11,7 @@ class CreateNotification
 
     notification.creator_user = user
     notification.creator_team = team
-    notification.notifying_country = country_from_code(team.country)
+    notification.notifying_country = team.country
     notification.state = "submitted" unless from_task_list
 
     ActiveRecord::Base.transaction do
@@ -77,10 +77,5 @@ private
     return "0000" unless case_number
 
     case_number.split("-").last
-  end
-
-  def country_from_code(code)
-    country = Country.notifying_countries.find { |c| c[1] == code }
-    (country && country[0]) || code
   end
 end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -11,7 +11,7 @@ class CreateNotification
 
     notification.creator_user = user
     notification.creator_team = team
-    notification.notifying_country = team.country
+    notification.notifying_country = country_from_code(team.country)
     notification.state = "submitted" unless from_task_list
 
     ActiveRecord::Base.transaction do
@@ -77,5 +77,10 @@ private
     return "0000" unless case_number
 
     case_number.split("-").last
+  end
+
+  def country_from_code(code)
+    country = Country.notifying_countries.find { |c| c[1] == code }
+    (country && country[0]) || code
   end
 end

--- a/app/views/investigations/activities/investigation/_change_overseas_regulator.html.erb
+++ b/app/views/investigations/activities/investigation/_change_overseas_regulator.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body">
   <% if activity.previous_from_overseas_regulator.nil? && activity.previous_country == "None" %>
-    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_set", new_country: country_from_code(activity.new_country, Country.overseas_countries) ) %>
+    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_set", new_country: country_from_code(activity.new_country, Country.notifying_countries) ) %>
   <% else %>
-    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_changed", previous_country: country_from_code(activity.previous_country, Country.overseas_countries), new_country: country_from_code(activity.new_country, Country.overseas_countries) ) %>
+    <%= I18n.t(".audit_activity.investigation.update_overseas_regulator.body_changed", previous_country: country_from_code(activity.previous_country, Country.notifying_countries), new_country: country_from_code(activity.new_country, Country.notifying_countries) ) %>
   <% end %>
 </p>

--- a/app/views/investigations/overseas_regulator/edit.html.erb
+++ b/app/views/investigations/overseas_regulator/edit.html.erb
@@ -5,13 +5,13 @@
     <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), method: :put do |form| %>
       <%= error_summary @overseas_regulator_form.errors, map_errors: {
         is_from_overseas_regulator: :investigation_is_from_overseas_regulator_true,
-        overseas_regulator_country: :investigation_overseas_regulator_country
+        notifying_country: :investigation_notifying_country
       } %>
 
       <% select_menu_html = capture do %>
         <%= govukSelect(
           form: form,
-          key: :overseas_regulator_country,
+          key: :notifying_country,
           items: options_for_overseas_regulator(Country.overseas_countries, @overseas_regulator_form),
           include_blank: true,
           label: { text: "Select which country" }

--- a/app/views/investigations/overseas_regulator/edit.html.erb
+++ b/app/views/investigations/overseas_regulator/edit.html.erb
@@ -2,35 +2,27 @@
 <% page_title page_heading, errors: @overseas_regulator_form.errors.any? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), method: :put do |form| %>
-      <%= error_summary @overseas_regulator_form.errors, map_errors: {
-        is_from_overseas_regulator: :investigation_is_from_overseas_regulator_true,
-        notifying_country: :investigation_notifying_country
-      } %>
+    <%= form_with scope: :investigation, model: @overseas_regulator_form, url: investigation_overseas_regulator_path(@investigation), builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :put do |form| %>
+      <%= form.govuk_error_summary %>
 
       <% select_menu_html = capture do %>
-        <%= govukSelect(
-          form: form,
-          key: :notifying_country,
-          items: options_for_overseas_regulator(Country.overseas_countries, @overseas_regulator_form),
-          include_blank: true,
-          label: { text: "Select which country" }
-        ) %>
+        <%= form.govuk_collection_select :notifying_country,
+                                         options_for_overseas_regulator(Country.overseas_countries, @overseas_regulator_form),
+                                         :value,
+                                         :text,
+                                         label: { text: "Select which country" } %>
       <% end %>
-      <%= govukRadios(
-        form: form,
-        key: :is_from_overseas_regulator,
-        fieldset: { legend: { html: "<h1 class=\"govuk-fieldset__heading\">Was the allegation made by an overseas regulator?</h1>".html_safe, classes: "govuk-fieldset__legend--l" } },
-        hint: { html: "Select no if the allegation was from the <abbr>UK</abbr>.".html_safe, classes: "govuk-!-margin-bottom-5" },
-        items: [{ text: t("investigations.overseas_regulator.option_yes"),
-                  value: true,
-                  conditional: { html: select_menu_html } },
-                { text: t("investigations.overseas_regulator.option_no"),
-                  value: false }]
-      ) %>
+
+
+      <%= form.govuk_radio_buttons_fieldset(:is_from_overseas_regulator, legend: { size: 'l', text: "<h1 class=\"govuk-fieldset__heading\">Was the allegation made by an overseas regulator?</h1>".html_safe }, hint: { text: "Select no if the allegation was from the <abbr>UK</abbr>.".html_safe }) do %>
+        <%= form.govuk_radio_button :is_from_overseas_regulator, true, label: { text: t("investigations.overseas_regulator.option_yes") }, link_errors: true  do %>
+          <%= select_menu_html %>
+        <% end %>
+        <%= form.govuk_radio_button :is_from_overseas_regulator, false, label: { text: t("investigations.overseas_regulator.option_no") } %>
+      <% end %>
 
       <div class="govuk-button-group">
-        <%= govukButton(text: t("Save")) %>
+        <%= form.govuk_submit "Save" %>
         <%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>

--- a/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
+++ b/app/views/notifications/create/add_product_safety_and_compliance_details.html.erb
@@ -28,7 +28,7 @@
       <% end %>
       <%= f.govuk_radio_buttons_fieldset :is_from_overseas_regulator, legend: { text: "Was the safety issue reported by an overseas regulator?", size: "m" } do %>
         <%= f.govuk_radio_button :is_from_overseas_regulator, true, label: { text: "Yes" }, link_errors: true do %>
-          <%= f.govuk_collection_select :overseas_regulator_country, countries_options, :id, :name, label: { text: "Country" } %>
+          <%= f.govuk_collection_select :notifying_country, countries_options, :id, :name, label: { text: "Country" } %>
         <% end %>
         <%= f.govuk_radio_button :is_from_overseas_regulator, false, label: { text: "No" } %>
       <% end %>

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -44,7 +44,7 @@
         end
         summary_list.with_row do |row|
           row.with_key(text: "Reported by overseas regulator")
-          row.with_value(text: @notification.is_from_overseas_regulator ? "Yes: #{country_from_code(@notification.overseas_regulator_country)}" : "No")
+          row.with_value(text: @notification.is_from_overseas_regulator ? "Yes: #{country_from_code(@notification.notifying_country)}" : "No")
           row.with_action(text: "Change", href: wizard_path(:add_product_safety_and_compliance_details), visually_hidden_text: "reported by overseas regulator")
         end
         summary_list.with_row do |row|

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -50,7 +50,7 @@
         end
         summary_list.with_row do |row|
           row.with_key(text: "Reported by overseas regulator")
-          row.with_value(text: @notification.is_from_overseas_regulator ? "Yes: #{country_from_code(@notification.overseas_regulator_country)}" : "No")
+          row.with_value(text: @notification.is_from_overseas_regulator ? "Yes: #{country_from_code(@notification.notifying_country)}" : "No")
           row.with_action(text: "Change", href: edit_investigation_overseas_regulator_path(@notification), visually_hidden_text: "reported by overseas regulator") if show_edit_link?
         end
         summary_list.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -572,7 +572,7 @@ en:
           attributes:
             is_from_overseas_regulator:
               inclusion: Select yes if the allegation was made by an overseas regulator
-            overseas_regulator_country:
+            notifying_country:
               inclusion: Select which country
         comment_form:
           attributes:
@@ -879,7 +879,7 @@ en:
               too_long: Description of the product non-compliance issues must be %{count} characters or less
             is_from_overseas_regulator:
               inclusion: Choose whether the safety issue was reported by an overseas regulator
-            overseas_regulator_country:
+            notifying_country:
               inclusion: Choose the country of the overseas regulator
             add_reference_number:
               inclusion: Choose whether you want to add your own reference number

--- a/spec/features/change_notification_overseas_regulator_spec.rb
+++ b/spec/features/change_notification_overseas_regulator_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
 
       click_link "Activity"
       expect(page).to have_css("h3", text: "Overseas regulator changed")
-      expect(page).to have_css("p", text: "Overseas regulator changed from test to Armenia")
+      expect(page).to have_css("p", text: "Overseas regulator changed from England to Armenia")
     end
 
     it "can succesfully change the pre-populated overseas regulator" do
@@ -50,7 +50,7 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
 
       click_link "Activity"
       expect(page).to have_css("h3", text: "Overseas regulator changed")
-      expect(page).to have_css("p", text: "Overseas regulator changed from Armenia to None")
+      expect(page).to have_css("p", text: "Overseas regulator changed from Armenia to England")
     end
   end
 

--- a/spec/features/change_notification_overseas_regulator_spec.rb
+++ b/spec/features/change_notification_overseas_regulator_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
 
       click_link "Activity"
       expect(page).to have_css("h3", text: "Overseas regulator changed")
-      expect(page).to have_css("p", text: "Overseas regulator set to Armenia")
+      expect(page).to have_css("p", text: "Overseas regulator changed from test to Armenia")
     end
 
     it "can succesfully change the pre-populated overseas regulator" do
@@ -68,7 +68,11 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
     expect(page.find("dt", text: "Overseas regulator")).to have_sibling("dd", text: country)
     click_link "Change overseas regulator"
     expect(page).to have_css("h1", text: "Was the allegation made by an overseas regulator?")
-    expect(page).to have_select("Select which country", selected: country)
+    if country == ""
+      expect(page).to have_select("investigation[notifying_country]", selected: [])
+    else
+      expect(page).to have_select("investigation[notifying_country]", selected: country)
+    end
     expect_to_have_notification_breadcrumbs
   end
 end

--- a/spec/features/change_notification_overseas_regulator_spec.rb
+++ b/spec/features/change_notification_overseas_regulator_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
     end
 
     it "can succesfully change the pre-populated overseas regulator" do
-      notification.update!(is_from_overseas_regulator: true, overseas_regulator_country: "country:AM")
+      notification.update!(is_from_overseas_regulator: true, notifying_country: "country:AM")
 
       sign_in_and_visit_change_overseas_regulator_page("Armenia")
 
@@ -39,7 +39,7 @@ RSpec.feature "Changing the overseas regulator of a notification", :with_stubbed
     end
 
     it "can succesfully clear the pre-populated overseas regulator" do
-      notification.update!(is_from_overseas_regulator: true, overseas_regulator_country: "country:AM")
+      notification.update!(is_from_overseas_regulator: true, notifying_country: "country:AM")
 
       sign_in_and_visit_change_overseas_regulator_page("Armenia")
 

--- a/spec/models/audit_activity/investigation/change_notifying_country_spec.rb
+++ b/spec/models/audit_activity/investigation/change_notifying_country_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe AuditActivity::Investigation::ChangeNotifyingCountry, :with_stubb
   let(:audit_activity) { described_class.from(investigation) }
 
   let(:user) { create(:user).decorate }
-  let(:investigation) { create(:enquiry, notifying_country: previous_country) }
+  let(:investigation) { notif = create(:enquiry, is_from_overseas_regulator: true)
+  notif.notifying_country = previous_country
+  notif.save!
+  notif }
   let(:previous_country) { "country:GB-ENG" }
   let(:new_country) { "country:GB-SCT" }
 

--- a/spec/models/audit_activity/investigation/change_notifying_country_spec.rb
+++ b/spec/models/audit_activity/investigation/change_notifying_country_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe AuditActivity::Investigation::ChangeNotifyingCountry, :with_stubb
   let(:audit_activity) { described_class.from(investigation) }
 
   let(:user) { create(:user).decorate }
-  let(:investigation) { notif = create(:enquiry, is_from_overseas_regulator: true)
-  notif.notifying_country = previous_country
-  notif.save!
-  notif }
+  let(:investigation) do
+    notif = create(:enquiry, is_from_overseas_regulator: true)
+    notif.notifying_country = previous_country
+    notif.save!
+    notif
+  end
   let(:previous_country) { "country:GB-ENG" }
   let(:new_country) { "country:GB-SCT" }
 

--- a/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
+++ b/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuditActivity::Investigation::ChangeOverseasRegulator, :with_stub
   let(:audit_activity) { described_class.from(investigation) }
 
   let(:user) { create(:user).decorate }
-  let(:investigation) { create(:enquiry, is_from_overseas_regulator: true, overseas_regulator_country: previous_country) }
+  let(:investigation) { create(:enquiry, is_from_overseas_regulator: true, notifying_country: previous_country) }
   let(:previous_country) { "country:AM" }
   let(:new_country) { "country:US" }
   let(:previous_country_human) { "Armenia" }
@@ -14,14 +14,14 @@ RSpec.describe AuditActivity::Investigation::ChangeOverseasRegulator, :with_stub
 
   let(:activity) { described_class.create(metadata:) }
 
-  before { investigation.update!(overseas_regulator_country: new_country) }
+  before { investigation.update!(notifying_country: new_country) }
 
   describe ".build_metadata" do
     context "when the case's overseas regulator has been updated" do
       it "produces a Hash of the change" do
         expect(metadata).to eq({
           updates: {
-            "overseas_regulator_country" => [previous_country, new_country]
+            "notifying_country" => [previous_country, new_country]
           }
         })
       end

--- a/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
+++ b/spec/models/audit_activity/investigation/change_overseas_regulator_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe AuditActivity::Investigation::ChangeOverseasRegulator, :with_stub
   let(:audit_activity) { described_class.from(investigation) }
 
   let(:user) { create(:user).decorate }
-  let(:investigation) { create(:enquiry, is_from_overseas_regulator: true, notifying_country: previous_country) }
+  let(:investigation) do
+    notif = create(:enquiry, is_from_overseas_regulator: true)
+    notif.notifying_country = previous_country
+    notif.save!
+    notif
+  end
   let(:previous_country) { "country:AM" }
   let(:new_country) { "country:US" }
   let(:previous_country_human) { "Armenia" }
@@ -14,7 +19,9 @@ RSpec.describe AuditActivity::Investigation::ChangeOverseasRegulator, :with_stub
 
   let(:activity) { described_class.create(metadata:) }
 
-  before { investigation.update!(notifying_country: new_country) }
+  before do
+    investigation.update!(notifying_country: new_country)
+  end
 
   describe ".build_metadata" do
     context "when the case's overseas regulator has been updated" do

--- a/spec/services/change_notification_overseas_regulator_spec.rb
+++ b/spec/services/change_notification_overseas_regulator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :with_stubbed_mailer, :with_test_queue_adapter do
-  let(:notification) { create(:notification, is_from_overseas_regulator: true, overseas_regulator_country: "country:AM") }
+  let(:notification) { create(:notification, is_from_overseas_regulator: true, notifying_country: "country:AM") }
   let(:user) { create(:user, name: "User One") }
 
   describe ".call" do
@@ -35,14 +35,14 @@ RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :wi
           user:,
           notification:,
           is_from_overseas_regulator: true,
-          overseas_regulator_country:
+          notifying_country:
         )
       end
 
       let(:activity_entry) { notification.activities.where(type: AuditActivity::Investigation::ChangeOverseasRegulator.to_s).order(:created_at).last }
 
       context "when no changes have been made" do
-        let(:overseas_regulator_country) { "country:AM" }
+        let(:notifying_country) { "country:AM" }
 
         it "does not generate an activity entry" do
           result
@@ -56,12 +56,12 @@ RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :wi
       end
 
       context "when changes have been made" do
-        let(:overseas_regulator_country) { "country:US" }
+        let(:notifying_country) { "country:US" }
 
         it "updates the notification", :aggregate_failures do
           result
 
-          expect(notification.overseas_regulator_country).to eq("country:US")
+          expect(notification.notifying_country).to eq("country:US")
         end
 
         it "creates an activity entry" do
@@ -69,7 +69,7 @@ RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :wi
 
           expect(activity_entry.metadata).to eq({
             "updates" => {
-              "overseas_regulator_country" => ["country:AM", "country:US"]
+              "notifying_country" => ["country:AM", "country:US"]
             }
           })
         end

--- a/spec/services/change_notification_overseas_regulator_spec.rb
+++ b/spec/services/change_notification_overseas_regulator_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :with_stubbed_mailer, :with_test_queue_adapter do
-  let(:notification) { notif = create(:notification, is_from_overseas_regulator: true)
-  notif.notifying_country = "country:AM"
-  notif.save!
-  notif }
+  let(:notification) do
+    notif = create(:notification, is_from_overseas_regulator: true)
+    notif.notifying_country = "country:AM"
+    notif.save!
+    notif
+  end
   let(:user) { create(:user, name: "User One") }
 
   describe ".call" do

--- a/spec/services/change_notification_overseas_regulator_spec.rb
+++ b/spec/services/change_notification_overseas_regulator_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe ChangeNotificationOverseasRegulator, :with_stubbed_antivirus, :with_stubbed_mailer, :with_test_queue_adapter do
-  let(:notification) { create(:notification, is_from_overseas_regulator: true, notifying_country: "country:AM") }
+  let(:notification) { notif = create(:notification, is_from_overseas_regulator: true)
+  notif.notifying_country = "country:AM"
+  notif.save!
+  notif }
   let(:user) { create(:user, name: "User One") }
 
   describe ".call" do


### PR DESCRIPTION
Changed all references to overseas_regulator country in the code now change notifying_country instead. 
Made changes to field names for forms in order to reflect these changes, made changes to form to now use GOVUKDesignSystemFormBuilder instead of applicationformbuilder.
Made changes to activity partial so that it displays UK based countries in human form not the country code, this bug has been in the code for a long time.
Made spec changes