### PR TITLE
Implemented fix and updated spec

### DIFF
--- a/app/services/create_bulk_products_upload.rb
+++ b/app/services/create_bulk_products_upload.rb
@@ -9,7 +9,7 @@ class CreateBulkProductsUpload
 
     ActiveRecord::Base.transaction do
       notification = Investigation::Notification.new(reported_reason: "non_compliant", hazard_description:)
-      CreateNotification.call!(notification:, user:, bulk: true, silent: true)
+      CreateNotification.call!(state: "draft", notification:, user:, bulk: true, silent: true)
       context.bulk_products_upload = BulkProductsUpload.create!(investigation: notification, user:)
     end
   end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -43,6 +43,10 @@ private
     notification.state = "submitted" unless from_task_list || its_product_bulk_upload
   end
 
+  def its_product_bulk_upload
+    user.can_bulk_upload_products?
+  end
+
   def generate_pretty_id
     "#{date.strftime('%y%m')}-#{latest_case_number_this_month.next}"
   end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -12,7 +12,8 @@ class CreateNotification
     notification.creator_user = user
     notification.creator_team = team
     notification.notifying_country = team.country
-    notification.state = "submitted" unless from_task_list
+
+    get_notification_state
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.
@@ -37,6 +38,10 @@ class CreateNotification
   end
 
 private
+
+  def get_notification_state
+    notification.state = "submitted" unless from_task_list || its_product_bulk_upload
+  end
 
   def generate_pretty_id
     "#{date.strftime('%y%m')}-#{latest_case_number_this_month.next}"

--- a/spec/services/create_notification_spec.rb
+++ b/spec/services/create_notification_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe CreateNotification, :with_test_queue_adapter do
     context "with required parameters" do
       let(:result) { described_class.call(notification:, user:, product:) }
 
+      it "has draft notification state" do
+        expect(notification.state).to eq("draft")
+      end
+
       it "returns success" do
         expect(result).to be_success
       end


### PR DESCRIPTION
[PSD-2874](https://regulatorydelivery.atlassian.net/browse/PSD-2874)

## Description
Ensured notification is in submitted state until its actually submitted at the end of the journey.

## Screen-shots or screen-capture of UI changes

![image](https://github.com/user-attachments/assets/45f66be9-5398-4822-9944-c71436aa1211)

![image](https://github.com/user-attachments/assets/c1fd7327-66b1-4400-8100-762949fa0beb)


[PSD-2874]: https://regulatorydelivery.atlassian.net/browse/PSD-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ