### PR TITLE
fix/PSD-2754-bulk_upload_notification_status_to_be_draft

### DIFF
--- a/app/services/create_bulk_products_upload.rb
+++ b/app/services/create_bulk_products_upload.rb
@@ -9,7 +9,7 @@ class CreateBulkProductsUpload
 
     ActiveRecord::Base.transaction do
       notification = Investigation::Notification.new(reported_reason: "non_compliant", hazard_description:)
-      CreateNotification.call!(notification:, user:, bulk: true, silent: true)
+      CreateNotification.call!(state: "draft", notification:, user:, bulk: true, silent: true)
       context.bulk_products_upload = BulkProductsUpload.create!(investigation: notification, user:)
     end
   end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -44,7 +44,16 @@ private
   end
 
   def its_product_bulk_upload
-    user.can_bulk_upload_products?
+    check_caller("create_bulk_products_upload")
+  end
+
+  def check_caller(class_pattern, method_name = "call")
+    regex = /#{class_pattern}.*in `#{method_name}'/
+    if caller.any? { |call| call.match?(regex) }
+      true
+    else
+      false
+    end
   end
 
   def generate_pretty_id

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -13,7 +13,7 @@ class CreateNotification
     notification.creator_team = team
     notification.notifying_country = team.country
 
-    get_notification_state
+    notification.state = "submitted" unless from_task_list || bulk
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.
@@ -38,23 +38,6 @@ class CreateNotification
   end
 
 private
-
-  def get_notification_state
-    notification.state = "submitted" unless from_task_list || its_product_bulk_upload
-  end
-
-  def its_product_bulk_upload
-    check_caller("create_bulk_products_upload")
-  end
-
-  def check_caller(class_pattern, method_name = "call")
-    regex = /#{class_pattern}.*in `#{method_name}'/
-    if caller.any? { |call| call.match?(regex) }
-      true
-    else
-      false
-    end
-  end
 
   def generate_pretty_id
     "#{date.strftime('%y%m')}-#{latest_case_number_this_month.next}"

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -43,6 +43,10 @@ private
     notification.state = "submitted" unless from_task_list || its_product_bulk_upload
   end
 
+  def its_product_bulk_upload
+    user.can_bulk_upload_products?
+  end
+
   def generate_pretty_id
     "#{date.strftime('%y%m')}-#{latest_case_number_this_month.next}"
   end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -12,7 +12,8 @@ class CreateNotification
     notification.creator_user = user
     notification.creator_team = team
     notification.notifying_country = team.country
-    notification.state = "submitted" unless from_task_list
+
+    get_notification_state
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.
@@ -37,6 +38,10 @@ class CreateNotification
   end
 
 private
+
+  def get_notification_state
+    notification.state = "submitted" unless from_task_list || its_product_bulk_upload
+  end
 
   def generate_pretty_id
     "#{date.strftime('%y%m')}-#{latest_case_number_this_month.next}"

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -35,6 +35,37 @@ RSpec.feature "Bulk upload products", :with_opensearch, :with_stubbed_antivirus,
     expect(page).to have_content("You can’t upload a mix of multiple non-compliant and unsafe products")
   end
 
+  scenario "Draft notification when adding non-compliant products" do
+    visit "/products/bulk-upload/triage"
+
+    expect(page).to have_content("How would you describe the products in terms of their compliance and safety?")
+
+    choose "Products are non-compliant"
+    click_button "Continue"
+
+    expect(page).to have_error_summary("Enter why the products are non-compliant")
+
+    fill_in "Why are the products non-compliant?", with: "Testing"
+    click_button "Continue"
+
+    expect(page).to have_content("Create a notification for multiple products")
+
+    fill_in "Notification name", with: "Test notification"
+    click_button "Continue"
+
+    expect(page).to have_error_summary("Select yes if you want to add a reference number")
+
+    choose "No"
+
+    visit "/cases/your-cases"
+    expect(page).to have_content("Your notifications")
+
+    within "section.govuk-grid-column-three-quarters#page-content" do
+      # expect(page).to have_content("Test notification")
+      byebug
+    end
+  end
+
   scenario "Adding non-compliant products" do
     visit "/products/bulk-upload/triage"
 

--- a/spec/services/create_notification_spec.rb
+++ b/spec/services/create_notification_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe CreateNotification, :with_test_queue_adapter do
     context "with required parameters" do
       let(:result) { described_class.call(notification:, user:, product:) }
 
+      it "has draft notification state" do
+        expect(notification.state).to eq("draft")
+      end
+
       it "returns success" do
         expect(result).to be_success
       end


### PR DESCRIPTION
[PSD-2874](https://regulatorydelivery.atlassian.net/browse/PSD-2874)

## Description
Ensured notification is in submitted state until its actually submitted at the end of the journey.

## Screen-shots or screen-capture of UI changes

![image](https://github.com/user-attachments/assets/45f66be9-5398-4822-9944-c71436aa1211)

![image](https://github.com/user-attachments/assets/c1fd7327-66b1-4400-8100-762949fa0beb)


[PSD-2874]: https://regulatorydelivery.atlassian.net/browse/PSD-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ