### PR TITLE
fix/PSD-2754-bulk_upload_notification_to_be_draft_status

### DIFF
--- a/app/services/create_bulk_products_upload.rb
+++ b/app/services/create_bulk_products_upload.rb
@@ -8,7 +8,7 @@ class CreateBulkProductsUpload
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
     ActiveRecord::Base.transaction do
-      notification = Investigation::Notification.new(reported_reason: "non_compliant", hazard_description:)
+      notification = Investigation::Notification.new(reported_reason: "non_compliant", hazard_description:, state: "draft")
       CreateNotification.call!(notification:, user:, bulk: true, silent: true)
       context.bulk_products_upload = BulkProductsUpload.create!(investigation: notification, user:)
     end

--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -12,7 +12,7 @@ class CreateNotification
     notification.creator_user = user
     notification.creator_team = team
     notification.notifying_country = team.country
-    notification.state = "submitted" unless from_task_list
+    notification.state = "submitted" unless from_task_list || bulk
 
     ActiveRecord::Base.transaction do
       # This ensures no other pretty_id generation is happening concurrently.


### PR DESCRIPTION
bulk product upload creates a notification in draft status