### PR TITLE
added retired_at exclusion from search query; refactored spec and add…

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -103,23 +103,27 @@ module Notifications
         }[params[:sort_by]] || { created_at: :desc }
 
         products = if @page_name == "your_products"
-                     Product.includes(investigations: %i[owner_user owner_team])
+                     Product.not_retired
+                            .includes(investigations: %i[owner_user owner_team])
                             .where(users: { id: current_user.id })
                             .order(sort_by)
                    elsif @page_name == "team_products"
                      team = current_user.team
-                     Product.includes(investigations: %i[owner_user owner_team])
+                     Product.not_retired
+                            .includes(investigations: %i[owner_user owner_team])
                             .where(users: { id: team.users.map(&:id) }, teams: { id: team.id })
                             .order(sort_by)
                    elsif @search_query
                      @search_query.strip!
-                     Product.where("products.name ILIKE ?", "%#{@search_query}%")
-                            .or(Product.where("products.description ILIKE ?", "%#{@search_query}%"))
-                            .or(Product.where("CONCAT('psd-', products.id) = LOWER(?)", @search_query))
-                            .or(Product.where(id: @search_query))
+                     Product.not_retired
+                            .where("products.name ILIKE ?", "%#{@search_query}%")
+                            .or(Product.not_retired.where("products.description ILIKE ?", "%#{@search_query}%"))
+                            .or(Product.not_retired.where("CONCAT('psd-', products.id) = LOWER(?)", @search_query))
+                            .or(Product.not_retired.where(id: @search_query))
                             .order(sort_by)
                    else
-                     Product.all.order(sort_by)
+                     Product.not_retired
+                     .all.order(sort_by)
                    end
 
         @records_count = products.size

--- a/spec/features/search_for_or_add_spec.rb
+++ b/spec/features/search_for_or_add_spec.rb
@@ -1,18 +1,16 @@
 require "rails_helper"
 
-RSpec.feature "Add notification with search", :with_opensearch, :with_product_form_helper, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Search for or add a product", :with_opensearch, :with_product_form_helper, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
-  let(:existing_product) { create(:product) }
-  let(:new_product_attributes) do
-    attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing", "unsure").sample)
-  end
-  let(:image_file) { Rails.root.join "test/fixtures/files/testImage.png" }
-  let(:text_file) { Rails.root.join "test/fixtures/files/attachment_filename.txt" }
+  let(:product_one) { create(:product) }
+  let(:product_two) { create(:product) }
+  let(:retired_product) { create(:product) }
 
   before do
     sign_in(user)
-
-    existing_product
+    product_one
+    product_two
+    retired_product
   end
 
   scenario "Creating a notification with the normal flow search for and add a product" do
@@ -35,7 +33,50 @@ RSpec.feature "Add notification with search", :with_opensearch, :with_product_fo
     click_button "Continue"
   end
 
-  scenario "Creating a notification with the normal flow search for and add multiple products" do
+  scenario "Creating a notification add existing product and a product that does not exist" do
+    visit "/notifications/create"
+
+    set_retired(retired_product)
+
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
+    expect(page).to have_content("Create a product safety notification")
+    expect(page).to have_selector(:id, "task-list-0-0-status", text: "Not yet started")
+
+    click_link "Search for or add a product"
+    click_button "Select", match: :first
+
+    within_fieldset "Do you need to add another product?" do
+      choose "Yes"
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_content("Choose the product for your notification")
+    expect(page).to have_content("Search by product name, description or PSD reference")
+    expect(page).to have_content("Product details")
+
+    find_field("q-field").fill_in(with: "ABC123")
+    first('button.govuk-button[type="submit"][formnovalidate="formnovalidate"]').click
+
+    expect(page).to have_content("There are no product records")
+
+    visit "/notifications/your-notifications"
+
+    expect(page).to have_content("Draft notifications")
+
+    click_link "Make changes"
+
+    expect(page).to have_content("Create a product safety notification")
+
+    product = :first
+    if product.present?
+      expect(page).to have_content(product.name)
+    end
+  end
+
+  scenario "Creating a notification add existing product with one retired product" do
+    set_retired(retired_product)
+
     visit "/notifications/create"
 
     expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
@@ -52,17 +93,31 @@ RSpec.feature "Add notification with search", :with_opensearch, :with_product_fo
     click_button "Continue"
 
     expect(page).to have_content("Choose the product for your notification")
-
     expect(page).to have_content("Search by product name, description or PSD reference")
-
     expect(page).to have_content("Product details")
 
-    find_field("q-field").fill_in(with: "ABC123")
+    find_field("q-field").fill_in(with: retired_product.id)
+    first('button.govuk-button[type="submit"][formnovalidate="formnovalidate"]').click
 
-    find('button.govuk-button[type="submit"][formnovalidate="formnovalidate"]').click
+    expect(page).to have_content("There are no product records for \"#{retired_product.id}\"")
 
-    expect(page).to have_content("There are no product records")
+    visit "/notifications/your-notifications"
 
-    # TODO: figure out how to go back to the previous screen "Search for or add a product"
+    have_content("Draft notifications")
+
+    click_link "Make changes"
+
+    expect(page).to have_content("Create a product safety notification")
+
+    expect(page).not_to have_content(retired_product.name)
+  end
+
+private
+
+  def set_retired(product)
+    if product.present?
+      product.retired_at = Time.zone.now
+      product.save!
+    end
   end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-3529

## Description

Fixed issue where retired products were being displayed in the product search results.

Incorrect results (showing two retired products):
![image](https://github.com/user-attachments/assets/9415a1bf-2c80-410e-a044-9b163eb3a56e)

Fix applied:
![image](https://github.com/user-attachments/assets/fcf64a8f-f4a7-4bb4-afa3-f729185cc4c9)

All products screen appears to already exclude retired products (checked view):
![image](https://github.com/user-attachments/assets/bb105bc1-e8ec-4b63-947c-f377cf9a5e29)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
