### PR TITLE
[PSD-2092] - product recall module enhancements

### DIFF
--- a/app/views/products/recalls/product-details.html.erb
+++ b/app/views/products/recalls/product-details.html.erb
@@ -123,7 +123,8 @@
         small: true
       %>
       <div class="govuk-button-group">
-        <%= form.govuk_submit("Continue") %>
+        <%= form.govuk_submit("Save and continue") %>
+        <%= link_to "Back", product_recall_path(product_id: @product.id, id: "select-images"), class: "govuk-link" %>
       </div>
     <% end %>
   </div>

--- a/app/views/products/recalls/select-images.html.erb
+++ b/app/views/products/recalls/select-images.html.erb
@@ -5,7 +5,12 @@
       <h1 class="govuk-heading-l">
          Select the images to include
       </h1>
-      <% if @product.virus_free_images.any? ||  @product.get_notification_images.any? %>
+      <%
+	      has_notification_images =  @product.get_notification_images.any?
+	      has_product_images = @product.virus_free_images.any?
+	      has_valid_images = ( has_product_images || has_notification_images)
+      %>
+      <% if has_valid_images %>
         <div class="govuk-hint" id="image-ids-hint">
           <div>Acceptable file formats to create a product recall PDF: JPEG &amp; PNG</div>
           <div>Any other file types you have uploaded will not be displayed here.</div>
@@ -13,7 +18,7 @@
       <% end %>
       <%= form.hidden_field :step, value: @form.step %>
       <div class="govuk-form-group image-select">
-        <% if @product.virus_free_images.any? %>
+        <% if has_product_images %>
           <%= form.govuk_check_boxes_fieldset(:product_image_ids, legend: { text: "Product record images", size: "m" }) do %>
             <% @product.virus_free_images.each do |image| %>
               <% if image.file_upload.content_type == "image/jpeg" || image.file_upload.content_type == "image/png" %>
@@ -31,7 +36,7 @@
         <% end %>
       </div>
       <div class="govuk-form-group image-select">
-      <% if @product.get_notification_images.any? %>
+      <% if has_notification_images %>
         <%= form.govuk_check_boxes_fieldset(:notification_image_ids, legend: { text: "Supporting images for all linked notifications", size: "m" }) do %>
           <% @product.get_notification_images.each do |image| %>
             <% if image.file_upload.content_type == "image/jpeg" || image.file_upload.content_type == "image/png" %>
@@ -51,11 +56,13 @@
 
       <div class="govuk-button-group">
         <%= form.govuk_submit("Save and continue") %>
-        <a href="<%= product_recall_path(product_id: @product.id, id: "product-details") %>" class="govuk-link">Skip</a>
-      </div>
-      <div>
         <%= link_to "Back", product_recall_path(product_id: @product.id, id: :start), class: "govuk-link" %>
       </div>
+      <% if has_valid_images %>
+        <div>
+          <a href="<%= product_recall_path(product_id: @product.id, id: "product-details") %>" class="govuk-link">Skip</a>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/spec/features/product_recall_spec.rb
+++ b/spec/features/product_recall_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Product Recall Spec", :with_product_form_helper, :with_stubbed_an
       choose("Medicines and Healthcare products Regulatory Agency (MHRA)")
     end
 
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(find("textarea#markdown_template_product_safety_report").value).to have_text("Medicines and Healthcare products Regulatory Agency (MHRA)")
     expect(find("textarea#markdown_template_product_recall").value).to have_text("Medicines and Healthcare products Regulatory Agency (MHRA)")
@@ -139,7 +139,7 @@ RSpec.feature "Product Recall Spec", :with_product_form_helper, :with_stubbed_an
       choose("Medicines and Healthcare products Regulatory Agency (MHRA)")
     end
 
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(find("textarea#markdown_template_product_safety_report").value).to have_text("Medicines and Healthcare products Regulatory Agency (MHRA)")
     expect(find("textarea#markdown_template_product_recall").value).to have_text("Medicines and Healthcare products Regulatory Agency (MHRA)")


### PR DESCRIPTION
changes made to keep the wording of the button save to "Save and continue" , also minimised unnecessary calling of the methods


