### PR TITLE
fix/PSD-3634_trim_spaces_for_business_fields

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -417,10 +417,10 @@ module Notifications
         if add_business_details_params[:business_id].blank?
           # Find potential duplicate businesses by looking for the same trading name
           # and preferring results with the same legal name too.
-          duplicate_business = Business.where("LOWER(legal_name) = ?", @add_business_details_form.legal_name.downcase)
+          duplicate_business = Business.where("LOWER(TRIM(legal_name)) = ?", @add_business_details_form.legal_name&.downcase)
                                        .or(Business.where(legal_name: nil))
                                        .or(Business.where(legal_name: ""))
-                                       .where("LOWER(trading_name) = ?", @add_business_details_form.trading_name.downcase)
+                                       .where("LOWER(TRIM(trading_name)) = ?", @add_business_details_form.trading_name&.downcase)
                                        .without_online_marketplaces
                                        .order(Arel.sql("CASE WHEN legal_name IS NULL OR legal_name = '' THEN 1 ELSE 0 END"))
                                        .order(created_at: :desc)

--- a/app/controllers/notifications/edit_controller.rb
+++ b/app/controllers/notifications/edit_controller.rb
@@ -133,10 +133,10 @@ module Notifications
         if add_business_details_params[:business_id].blank?
           # Find potential duplicate businesses by looking for the same trading name
           # and preferring results with the same legal name too.
-          duplicate_business = Business.where("LOWER(legal_name) = ?", @add_business_details_form.legal_name.downcase)
+          duplicate_business = Business.where("LOWER(TRIM(legal_name)) = ?", @add_business_details_form.legal_name&.downcase)
                                        .or(Business.where(legal_name: nil))
                                        .or(Business.where(legal_name: ""))
-                                       .where("LOWER(trading_name) = ?", @add_business_details_form.trading_name.downcase)
+                                       .where("LOWER(TRIM(trading_name)) = ?", @add_business_details_form.trading_name&.downcase)
                                        .without_online_marketplaces
                                        .order(Arel.sql("CASE WHEN legal_name IS NULL OR legal_name = '' THEN 1 ELSE 0 END"))
                                        .order(created_at: :desc)

--- a/app/forms/add_business_details_form.rb
+++ b/app/forms/add_business_details_form.rb
@@ -8,5 +8,18 @@ class AddBusinessDetailsForm
   attribute :company_number, :string
   attribute :business_id
 
+  def initialize(attributes = {})
+    super
+    trim_spaces
+  end
+
   validates :trading_name, presence: true
+
+private
+
+  def trim_spaces
+    self.legal_name = legal_name&.strip
+    self.trading_name = trading_name&.strip
+    self.company_number = company_number&.strip
+  end
 end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -7,6 +7,7 @@ class Business < ApplicationRecord
     retailer online_seller online_marketplace manufacturer exporter importer fulfillment_house distributor authorised_representative responsible_person
   ].freeze
 
+  before_validation :trim_spaces
   validates :trading_name, presence: true
 
   has_many_attached :documents
@@ -55,5 +56,11 @@ class Business < ApplicationRecord
 
   def locations_have_errors?
     locations&.any? { |location| location.errors.any? } || false
+  end
+
+  def trim_spaces
+    self.legal_name = legal_name&.strip
+    self.trading_name = trading_name&.strip
+    self.company_number = company_number&.strip
   end
 end


### PR DESCRIPTION
strip out any leading and trailing spaces in the business legal_name , trading_name and company_number fields , this is a part of business cleansing activity