### PR TITLE
Post QA bug fixing

### DIFF
--- a/prism/app/models/prism/form/serious_risk.rb
+++ b/prism/app/models/prism/form/serious_risk.rb
@@ -4,9 +4,10 @@ module Prism
       include ActiveModel::Model
       include ActiveModel::Attributes
 
-      attribute :poses_a_serious_risk, :boolean
+      attribute :product_id, :string
+      attribute :risk_type, :string
 
-      validates :poses_a_serious_risk, inclusion: [true, false]
+      validates :risk_type, presence: true, inclusion: { in: %w[serious_risk normal_risk] }
     end
   end
 end

--- a/prism/app/views/prism/triage/serious_risk.html.erb
+++ b/prism/app/views/prism/triage/serious_risk.html.erb
@@ -4,9 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @prism_risk_assessment, url: serious_risk_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :patch do |f| %>
+      <% if @form&.product_id.present? %>
+        <%= f.hidden_field :product_id, value: @form.product_id %>
+      <% end %>
       <%= f.govuk_error_summary %>
-      <%=
-        f.govuk_collection_radio_buttons :risk_type,
+      <%= f.govuk_collection_radio_buttons :risk_type,
         [
           OpenStruct.new(id: "serious_risk", name: "Yes"),
           OpenStruct.new(id: "normal_risk", name: "No")

--- a/prism/app/views/prism/triage/serious_risk_rebuttable.html.erb
+++ b/prism/app/views/prism/triage/serious_risk_rebuttable.html.erb
@@ -4,6 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @prism_risk_assessment, url: serious_risk_rebuttable_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :patch do |f| %>
+    <%= f.hidden_field :product_id, value: params[:product_id] %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset(:less_than_serious_risk, legend: { text: "Are there any factors to indicate the product risk to be less than serious?", size: "l" }, hint: { text: "Even where the product or hazard is of a type where a serious risk can generally be assumed to exist, you should take account of any evidence to indicate the risk might be less than serious in the particular circumstances. Where such evidence exists, you will be asked to summarise it and will then be returned to the standard risk assessment process." }) do %>
         <%= f.govuk_radio_button :less_than_serious_risk, true, label: { text: "Yes" }, link_errors: true do %>

--- a/spec/features/prism/triage_spec.rb
+++ b/spec/features/prism/triage_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "PRISM triage", type: :feature do
   let(:user) { create(:user, :activated) }
   let(:prism_risk_assessment) { create(:prism_risk_assessment, :serious_risk, :with_product, created_by_user_id: user.id) }
+  let(:product) { create(:product) }
 
   before do
     sign_in user
@@ -16,7 +17,7 @@ RSpec.feature "PRISM triage", type: :feature do
   end
 
   scenario "selecting that a product poses a serious risk" do
-    visit prism.serious_risk_path
+    visit prism.serious_risk_path(product_id: product.id)
 
     expect(page).to have_text("Is the product or hazard of a type where a serious risk can generally be deemed to exist?")
 
@@ -31,7 +32,7 @@ RSpec.feature "PRISM triage", type: :feature do
   end
 
   scenario "selecting that a product does not pose a serious risk" do
-    visit prism.serious_risk_path
+    visit prism.serious_risk_path(product_id: product.id)
 
     expect(page).to have_text("Is the product or hazard of a type where a serious risk can generally be deemed to exist?")
 


### PR DESCRIPTION
## Description
Issue With PRISM risks assessment controller - associated products would not be preserved between screens/views. Resolved by using the Serious Risk form to preserve value during validation and user flow.