### PR TITLE
Fix/psd 3930 action view template error

### DIFF
--- a/app/views/products/duplicate_checks/show.html.erb
+++ b/app/views/products/duplicate_checks/show.html.erb
@@ -55,7 +55,7 @@
                       </span>
                     </summary>
                       <div class="govuk-details__text">
-                        <%= image_tag(@image.file_upload, alt: sanitize(@image.file_upload.filename), class: 'opss-details-img') %>
+                        <%= image_tag(@image.file_upload, alt: sanitize(@image.file_upload&.filename&.to_s || 'Image not available'), class: 'opss-details-img') if @image&.file_upload %>
                       </div>
                   </details>
                 <% end %>


### PR DESCRIPTION
## Description

Duplicate checks controller show view was encountering an error when the file object was nil added defensive code in the view and created spec file for coverage.