### PR TITLE
Refactored regex to handle leading double zero scenario

### DIFF
--- a/app/services/send_sms.rb
+++ b/app/services/send_sms.rb
@@ -41,6 +41,9 @@ private
 
   def normalize_uk_number(phone_number)
     cleaned_number = phone_number.gsub(/[\s-]+/, "")
+
+    cleaned_number = cleaned_number.sub(/\A00/, "+")
+
     return cleaned_number if cleaned_number.start_with?(UK_PREFIX)
 
     if cleaned_number.match?(UK_LEADING_ZERO)

--- a/spec/services/send_sms_spec.rb
+++ b/spec/services/send_sms_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe SendSMS, :with_stubbed_notify do
         "+447123 456 789" => "+447123456789",
         "07123 456789" => "+447123456789",
         "040-071234133" => "+4440071234133", # Hyphenated
-        "01234-567-980" => "+441234567980"
+        "01234-567-980" => "+441234567980",
+        "00 44 7922 574466" => "+447922574466"
       }
 
       test_cases.each do |input, expected|
@@ -99,6 +100,7 @@ RSpec.describe SendSMS, :with_stubbed_notify do
       valid_numbers = [
         "+447123456789",
         "+447890123456",
+        "+447922574466"
       ]
 
       valid_numbers.each do |number|


### PR DESCRIPTION
## Description

Sentry reporting an error: InvalidPhoneError: Not a UK mobile number (Notifications::Client::BadRequestError)

Expanded regex to cater for double leading zeros (when UK code is valid) as well.