### PR TITLE
Feat/psd 3908 add change test reports

### DIFF
--- a/app/controllers/notifications/test_reports_controller.rb
+++ b/app/controllers/notifications/test_reports_controller.rb
@@ -1,0 +1,175 @@
+module Notifications
+  class TestReportsController < ApplicationController
+    include BreadcrumbHelper
+
+    before_action :set_notification
+    before_action :validate_step
+    before_action :set_notification_product
+    before_action :set_test_result, only: %i[show_with_notification_product_test update_with_notification_product_test]
+    before_action :set_test_result_list, only: %i[show_with_notification_product update_with_notification_product]
+
+    breadcrumb "cases.label", :your_cases_investigations
+
+    def index; end
+
+    def show_with_notification_product
+      # byebug
+      if params[:add_a_test_report_form].present?
+        @add_another_test_report = AddTestReportsForm.new(add_another_test_report: params[:add_a_test_report_form][:add_another_test_report])
+        @add_another_test_report.valid?
+      else
+        @add_another_test_report = AddTestReportsForm.new
+      end
+
+      if @existing_test_results.present?
+        render :add_test_reports and return
+      end
+
+      @set_test_result_funding_on_case_form = SetTestResultFundingOnCaseForm.new
+      render :add_test_reports_opss_funding
+    end
+
+    def update_with_notification_product
+      # byebug
+      @add_another_test_report = if params[:add_test_reports_form].present?
+                                   AddTestReportsForm.new(add_test_report_params)
+                                 else
+                                   AddTestReportsForm.new
+                                 end
+
+      if params[:final].present?
+        if @add_another_test_report.valid?
+          if @add_another_test_report.add_another_test_report == "true"
+            @set_test_result_funding_on_case_form = SetTestResultFundingOnCaseForm.new
+            render :add_test_reports_opss_funding and return
+          else
+            return redirect_to notification_path(@notification), flash: { success: "Notification updated successfully." }
+          end
+        else
+          render :add_test_reports and return
+        end
+      end
+      @set_test_result_funding_on_case_form = SetTestResultFundingOnCaseForm.new(opss_funding_params)
+
+      if @set_test_result_funding_on_case_form.valid?
+        @test_result = @notification.test_results.create!(investigation_product: @investigation_product)
+        redirect_to with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: opss_funding_params[:opss_funded])
+      else
+        render :add_test_reports_opss_funding
+      end
+    end
+
+    def show_with_notification_product_test
+      if @test_result.tso_certificate_issue_date.present? || (params[:opss_funded] == "false")
+        @test_result_form = TestResultForm.from(@test_result)
+        render :add_test_reports_details
+      else
+        @set_test_result_certificate_on_case_form = SetTestResultCertificateOnCaseForm.new
+        render :add_test_reports_funding_details
+      end
+    end
+
+    def update_with_notification_product_test
+      if @test_result.tso_certificate_issue_date.present? || params[:opss_funded] == "false"
+        @test_result_form = TestResultForm.new(test_details_params)
+        @test_result_form.cache_file!(current_user)
+        if @test_result_form.valid?
+          UpdateTestResult.call!(
+            investigation: @notification,
+            investigation_product_id: @investigation_product.id,
+            test_result: @test_result,
+            legislation: @test_result_form.legislation,
+            standards_product_was_tested_against: @test_result_form.standards_product_was_tested_against,
+            result: @test_result_form.result,
+            failure_details: @test_result_form.failure_details,
+            details: @test_result_form.details,
+            document: @test_result_form.document,
+            date: @test_result_form.date,
+            changes: @test_result_form.changes,
+            user: current_user,
+            silent: true
+          )
+          redirect_to with_product_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id), flash: { success: "Test report added/updated successfully." }
+        else
+          render :add_test_reports_details
+        end
+      else
+        @set_test_result_certificate_on_case_form = SetTestResultCertificateOnCaseForm.new(opss_funding_details_params)
+
+        if @set_test_result_certificate_on_case_form.valid?
+          UpdateTestResult.call!(
+            investigation: @notification,
+            investigation_product_id: @investigation_product.id,
+            test_result: @test_result,
+            tso_certificate_reference_number: @set_test_result_certificate_on_case_form.tso_certificate_reference_number,
+            tso_certificate_issue_date: @set_test_result_certificate_on_case_form.tso_certificate_issue_date,
+            changes: {},
+            user: current_user,
+            silent: true
+          )
+          redirect_to with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: params[:opss_funded])
+        else
+          render :add_test_reports_funding_details
+        end
+      end
+    end
+
+  private
+
+    def set_notification
+      @notification = Investigation::Notification.includes(:owner_user, :owner_team, :creator_user, :creator_team).where(pretty_id: params[:notification_pretty_id]).first
+
+      if @notification.nil?
+        redirect_to "/404"
+      else
+        @notification
+      end
+    end
+
+    def validate_step
+      # Ensure objects exist
+      unless @notification && current_user
+        redirect_to "/404" and return
+      end
+
+      user_team = current_user.team
+
+      # Check if the current user or their team is authorized to edit the notification
+      authorized_to_edit =
+        [@notification.creator_user, @notification.owner_user].include?(current_user) ||
+        [@notification.owner_team, @notification.creator_team].include?(user_team) ||
+        @notification.non_owner_teams_with_edit_access.include?(user_team)
+
+      # Redirect if not authorized
+      redirect_to "/403" unless authorized_to_edit
+    end
+
+    def set_notification_product
+      @investigation_product = @notification.investigation_products.find(params[:investigation_product_id])
+    end
+
+    def opss_funding_params
+      params.require(:set_test_result_funding_on_case_form).permit(:opss_funded)
+    end
+
+    def set_test_result
+      @test_result = @test_result = @investigation_product.test_results.find(params[:test_report_id])
+    end
+
+    def opss_funding_details_params
+      params.require(:set_test_result_certificate_on_case_form).permit(:tso_certificate_reference_number, tso_certificate_issue_date: %i[day month year])
+    end
+
+    def test_details_params
+      params.require(:test_result_form).permit(:legislation, :standards_product_was_tested_against, :result, :failure_details, :details, :existing_document_file_id, :document, date: %i[day month year])
+    end
+
+    def add_test_report_params
+      params.require(:add_test_reports_form).permit(:add_another_test_report)
+    end
+
+    def set_test_result_list
+      @existing_test_results = @notification.test_results.where(investigation_product_id: @investigation_product.id).includes(investigation_product: :product)
+    end
+  end
+end

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -178,8 +178,8 @@
               value: { text: formatted_test_results(investigation_product.test_results).html_safe.presence || "Not provided" },
               actions: show_edit_link? ? [
                 {
-                  text: "Change",
-                  href: investigation_supporting_information_index_path(@notification, anchor: "test-results"),
+                  text: "Add",
+                  href: with_product_notification_test_reports_path(@notification.pretty_id,investigation_product_id: investigation_product.id),
                   visually_hidden_text: "test reports"
                 }
               ] : []

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -178,7 +178,7 @@
               value: { text: formatted_test_results(investigation_product.test_results).html_safe.presence || "Not provided" },
               actions: show_edit_link? ? [
                 {
-                  text: "Add",
+                  text: "Edit",
                   href: with_product_notification_test_reports_path(@notification.pretty_id,investigation_product_id: investigation_product.id),
                   visually_hidden_text: "test reports"
                 }

--- a/app/views/notifications/test_reports/add_test_reports.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports.html.erb
@@ -1,0 +1,26 @@
+
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_test_reports.title"), errors: false) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+      <%= t("notifications.create.index.sections.evidence.tasks.add_test_reports.title") %>
+    </h1>
+    <p class="govuk-body">You have added <%= pluralize(@existing_test_results&.count, "test report") %>.
+    <%=
+      govuk_summary_list do |summary_list|
+        @existing_test_results.each do |test_result|
+          summary_list.with_row do |row|
+            row.with_key(text: "#{sanitize(test_result.document.blob&.filename.to_s) || 'No document'}<br>#{sanitize(test_result.investigation_product.product.decorate.name_with_brand)}".html_safe)
+            row.with_action(text: "Change", href: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: test_result.investigation_product.id, test_report_id: test_result.id, opss_funded: false), visually_hidden_text: "test report")
+          end
+        end
+      end
+    %>
+    <%= form_with model: @add_another_test_report, url: request.fullpath, method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :add_another_test_report, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, inline: true, legend: { text: "Do you need to add another test report?", size: "m" } %>
+      <%= f.govuk_submit "Save and continue", name: "final", value: "true" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/test_reports/add_test_reports.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports.html.erb
@@ -12,7 +12,7 @@
         @existing_test_results.each do |test_result|
           summary_list.with_row do |row|
             row.with_key(text: "#{sanitize(test_result.document.blob&.filename.to_s) || 'No document'}<br>#{sanitize(test_result.investigation_product.product.decorate.name_with_brand)}".html_safe)
-            row.with_action(text: "Change", href: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: test_result.investigation_product.id, test_report_id: test_result.id, opss_funded: false), visually_hidden_text: "test report")
+            row.with_action(text: "Change", href: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: test_result.investigation_product.id, test_report_id: test_result.id, edit_test_report: true), visually_hidden_text: "test report")
           end
         end
       end

--- a/app/views/notifications/test_reports/add_test_reports_details.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports_details.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @test_result_form, url: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: params[:opss_funded]), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @test_result_form, url: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: params[:opss_funded], edit_test_report: params[:edit_test_report]), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>

--- a/app/views/notifications/test_reports/add_test_reports_details.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports_details.html.erb
@@ -1,0 +1,81 @@
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_test_reports.report_details.title"), errors: @test_result_form.errors.any?) %>
+<% date_error = @test_result_form.errors.include?(:date) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @test_result_form, url: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: params[:opss_funded]), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+        <%= t("notifications.create.index.sections.evidence.tasks.add_test_reports.report_details.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= sanitize(@investigation_product.decorate.product.name_with_brand) %></li>
+        </ul>
+      <% end %>
+      <% if @test_result.date.present? %>
+        <%= govuk_inset_text do %>
+          This test report is marked as <strong><%= sanitize(@test_result.tso_certificate_issue_date.blank? ? "not" : "") %> being funded under the <abbr>OPSS</abbr> sampling protocol</strong>.
+        <% end %>
+      <% end %>
+      <%= f.govuk_collection_select :legislation, legislation_options, :id, :name, label: { text: "Under which legislation?", size: "m" }, hint: { text: "Select the relevant legislation from the list." } %>
+      <%= f.govuk_text_field :standards_product_was_tested_against, label: { text: "Which standard was the product tested against?", size: "m" }, hint: { text: "For example, EN71. Use a comma to separate multiple standards." } %>
+      <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
+      <div class="govuk-form-group<%= date_error ? ' govuk-form-group--error' : '' %>">
+        <fieldset class="govuk-fieldset" aria-describedby="test-result-form-date-hint<%= date_error ? ' test-result-form-date-error' : '' %>">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Date of test</legend>
+          <div class="govuk-hint" id="test-result-form-date-hint">For example, 12 5 2023</div>
+          <% if date_error %>
+          <p class="govuk-error-message" id="test-result-form-date-field-error">
+            <span class="govuk-visually-hidden">Error: </span><%= sanitize(@test_result_form.errors.full_messages_for(:date).first) %>
+          </p>
+          <% end %>
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="test_result_form_date_day">Day</label>
+                <input id="test_result_form_date_day" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_error ? ' govuk-input--error' : '' %>" name="test_result_form[date][day]" type="text" inputmode="numeric" value="<%= sanitize(@test_result_form.date&.day.to_s || @test_result.date&.day.to_s) %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="test_result_form_date_month">Month</label>
+                <input id="test_result_form_date_month" class="govuk-input govuk-date-input__input govuk-input--width-2<%= date_error ? ' govuk-input--error' : '' %>" name="test_result_form[date][month]" type="text" inputmode="numeric" value="<%= sanitize(@test_result_form.date&.month.to_s || @test_result.date&.month.to_s) %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="test_result_form_date_year">Year</label>
+                <input id="test_result_form_date_year" class="govuk-input govuk-date-input__input govuk-input--width-4<%= date_error ? ' govuk-input--error' : '' %>" name="test_result_form[date][year]" type="text" inputmode="numeric" value="<%= sanitize(@test_result_form.date&.year.to_s || @test_result.date&.year.to_s) %>">
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= f.govuk_radio_buttons_fieldset :result, legend: { text: "What was the result?", size: "m" } do %>
+        <%= f.govuk_radio_button :result, "passed", label: { text: "Pass" }, link_errors: true %>
+        <%= f.govuk_radio_button :result, "failed", label: { text: "Fail" } do %>
+          <%= f.govuk_text_area :failure_details, label: { text: "How the product failed" }, hint: { text: "Describe how the product was tested and how it failed to meet the requirements." }, max_chars: 32_767 %>
+        <% end %>
+        <%= f.govuk_radio_button :result, "other", label: { text: "Other" } %>
+      <% end %>
+      <%= f.govuk_text_area :details, label: { text: "Further details", size: "m" }, max_chars: 32_767 %>
+      <%= f.hidden_field :existing_document_file_id %>
+      <% if @test_result_form.document.present? %>
+        <p id="current-attachment-details">
+          Currently selected file:
+          <%= link_to sanitize(@test_result_form.document.filename.to_s), @test_result_form.document, class: "govuk-link", target: "_blank", rel: "noreferrer noopener" %>
+        </p>
+        <%= f.hidden_field :document, value: @test_result_form.document.id %>
+        <%= govuk_details(summary_text: "Replace this file") do %>
+          <%= f.govuk_file_field :document, label: { text: "Test report attachment", size: "m" }, hint: { text: "If you have multiple files, compress them in a zip file." } %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_file_field :document, label: { text: "Test report attachment", size: "m" }, hint: { text: "If you have multiple files, compress them in a zip file." } %>
+      <% end %>
+      <%= f.govuk_submit @test_result.date.present? ? "Update test report" : "Add test report" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/test_reports/add_test_reports_funding_details.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports_funding_details.html.erb
@@ -1,0 +1,55 @@
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_test_reports.opss_funding_details.title"), errors: @set_test_result_certificate_on_case_form.errors.any?) %>
+<% tso_certificate_issue_date_error = @set_test_result_certificate_on_case_form.errors.include?(:tso_certificate_issue_date) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @set_test_result_certificate_on_case_form, url: with_product_testid_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id, test_report_id: @test_result.id, opss_funded: params[:opss_funded]), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+        <%= t("notifications.create.index.sections.evidence.tasks.add_test_reports.opss_funding_details.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= sanitize(@investigation_product.decorate.product.name_with_brand) %></li>
+        </ul>
+      <% end %>
+      <p class="govuk-body">These details will help the <abbr>OPSS</abbr> match funding to individual tests.</p>
+      <%= f.govuk_text_field :tso_certificate_reference_number, label: { text: "What is the trading standards officer sample reference number?", size: "m" }, hint: { text: "The reference number, for a specific product, that was provided to the test lab for product testing." }, width: "one-third" %>
+      <%# Manually add the date fields since we use virtual models for forms that don't support the default Rails date format %>
+      <div class="govuk-form-group<%= tso_certificate_issue_date_error ? ' govuk-form-group--error' : '' %>">
+        <fieldset class="govuk-fieldset" aria-describedby="set-test-result-certificate-on-case-form-tso-certificate-issue-date-hint<%= tso_certificate_issue_date_error ? ' set-test-result-certificate-on-case-form-tso-certificate-issue-date-error' : '' %>">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What date was the test certificate issued?</legend>
+          <div class="govuk-hint" id="set-test-result-certificate-on-case-form-tso-certificate-issue-date-hint">For example, 12 5 2023</div>
+          <% if tso_certificate_issue_date_error %>
+          <p class="govuk-error-message" id="set-test-result-certificate-on-case-form-tso-certificate-issue-date-field-error">
+            <span class="govuk-visually-hidden">Error: </span><%= @set_test_result_certificate_on_case_form.errors.full_messages_for(:tso_certificate_issue_date).first %>
+          </p>
+          <% end %>
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="set_test_result_certificate_on_case_form_tso_certificate_issue_date_day">Day</label>
+                <input id="set_test_result_certificate_on_case_form_tso_certificate_issue_date_day" class="govuk-input govuk-date-input__input govuk-input--width-2<%= tso_certificate_issue_date_error ? ' govuk-input--error' : '' %>" name="set_test_result_certificate_on_case_form[tso_certificate_issue_date][day]" type="text" inputmode="numeric" value="<%= sanitize(@set_test_result_certificate_on_case_form.tso_certificate_issue_date&.day || @test_result.tso_certificate_issue_date&.day.to_s) %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="set_test_result_certificate_on_case_form_tso_certificate_issue_date_month">Month</label>
+                <input id="set_test_result_certificate_on_case_form_tso_certificate_issue_date_month" class="govuk-input govuk-date-input__input govuk-input--width-2<%= tso_certificate_issue_date_error ? ' govuk-input--error' : '' %>" name="set_test_result_certificate_on_case_form[tso_certificate_issue_date][month]" type="text" inputmode="numeric" value="<%= sanitize(@set_test_result_certificate_on_case_form.tso_certificate_issue_date&.month || @test_result.tso_certificate_issue_date&.month.to_s) %>">
+              </div>
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-date-input__label" for="set_test_result_certificate_on_case_form_tso_certificate_issue_date_year">Year</label>
+                <input id="set_test_result_certificate_on_case_form_tso_certificate_issue_date_year" class="govuk-input govuk-date-input__input govuk-input--width-4<%= tso_certificate_issue_date_error ? ' govuk-input--error' : '' %>" name="set_test_result_certificate_on_case_form[tso_certificate_issue_date][year]" type="text" inputmode="numeric" value="<%= sanitize(@set_test_result_certificate_on_case_form.tso_certificate_issue_date&.year || @test_result.tso_certificate_issue_date&.year.to_s) %>">
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notifications/test_reports/add_test_reports_opss_funding.html.erb
+++ b/app/views/notifications/test_reports/add_test_reports_opss_funding.html.erb
@@ -1,0 +1,22 @@
+<%= page_title(t("notifications.create.index.sections.evidence.tasks.add_test_reports.opss_funding.title"), errors: @set_test_result_funding_on_case_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @set_test_result_funding_on_case_form, url: with_product_notification_test_reports_path(@notification, investigation_product_id: @investigation_product.id), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t("notifications.create.index.sections.evidence.title") %></span>
+        <%= t("notifications.create.index.sections.evidence.tasks.add_test_reports.opss_funding.title") %>
+      </h1>
+      <%= govuk_inset_text do %>
+        <p class="govuk-body">For</p>
+        <ul class="govuk-list">
+          <li class="govuk-body-l"><%= sanitize(@investigation_product.decorate.product.name_with_brand) %></li>
+        </ul>
+      <% end %>
+      <p>This is only relevant if you are a Local Authority user. If you are not a Local Authority user, select 'No'.</p>
+      <%= f.govuk_collection_radio_buttons :opss_funded, [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")], :id, :name, legend: nil, bold_labels: false %>
+      <%= f.govuk_submit "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,20 @@ Rails.application.routes.draw do
             # # `:investigation_product_id/:entity_id` routes.
           end
         end
+
+        resources :test_reports, controller: "notifications/test_reports", only: %i[index], path: "test-reports" do
+          collection do
+            # Routes without test_report_id
+            get ":investigation_product_id", to: "test_reports#show_with_notification_product", as: "with_product"
+            patch ":investigation_product_id", to: "test_reports#update_with_notification_product"
+            put ":investigation_product_id", to: "test_reports#update_with_notification_product"
+
+            # Existing routes that use test_report_id
+            get ":investigation_product_id/:test_report_id", to: "test_reports#show_with_notification_product_test", as: "with_product_testid"
+            patch ":investigation_product_id/:test_report_id", to: "test_reports#update_with_notification_product_test"
+            put ":investigation_product_id:test_report_id", to: "test_reports#update_with_notification_product_test"
+          end
+        end
       end
     end
 

--- a/spec/features/add_and_remove_a_testreport_edit_notification_spec.rb
+++ b/spec/features/add_and_remove_a_testreport_edit_notification_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.feature "Add or remove test report during Edit Notification journey", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+  let!(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let!(:product_one) { create(:product_washing_machine, name: "MyBrand Washing Machine") }
+  let!(:product_two) { create(:product_iphone, name: "iPhone 23") }
+  let!(:notification) { create(:notification, :with_business, products: [product_one, product_two], creator: user, reported_reason: "unsafe_and_non_compliant", hazard_type: "Burns", hazard_description: "FIRE", non_compliant_reason: "danger") }
+  let(:file) { Rails.root.join "test/fixtures/files/test_result.txt" }
+  let(:date) { Date.parse("1 Jan 2023") }
+
+  before do
+    sign_in(user)
+  end
+
+  scenario "Edit Test report during the edit Notification journey follows right flow" do
+    visit "/notifications/your-notifications"
+    click_link "Update notification"
+    expect(page).to have_content(notification.user_title)
+
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    expect(page).to have_breadcrumb("Notifications")
+    expect(page).to have_content("Was the test funded under the OPSS sampling protocol for Local Authorities?")
+    choose "Yes"
+    click_button "Save and continue"
+
+    expect(page).to have_breadcrumb("Notifications")
+    expect(page).to  have_content("Add the test certificate details")
+
+    fill_in "What is the trading standards officer sample reference number?", with: "TSO123"
+
+    fill_in "Day", with: date.day
+    fill_in "Month", with: date.month
+    fill_in "Year", with: date.year
+    click_button "Save and continue"
+
+    expect(page).to have_breadcrumb("Notifications")
+    expect(page).to  have_content("Add test report")
+
+    fill_in "Further details", with: "Test result includes certificate of conformity"
+    fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date:, test_result: "Pass", file:, standards: "EN71, EN73")
+    expect_confirmation_banner("Test report uploaded successfully.")
+
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+
+    click_button "Save and continue"
+    expect(page).to have_current_path("/notifications/#{notification.pretty_id}", ignore_query: true)
+  end
+
+  scenario "Add test report journey , when the test was not funded by OPSS" do
+    visit "/notifications/your-notifications"
+    click_link "Update notification"
+    expect(page).to have_content(notification.user_title)
+
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+
+    expect(page).to  have_content("Was the test funded under the OPSS sampling protocol for Local Authorities?")
+    choose "No"
+    click_button "Save and continue"
+
+    expect(page).not_to have_content("Add the test certificate details")
+
+    expect(page).to  have_content("Add test report")
+
+    fill_in "Further details", with: "Test result includes certificate of conformity"
+    fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date:, test_result: "Pass", file:, standards: "EN71, EN73")
+    expect_confirmation_banner("Test report uploaded successfully.")
+
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+
+    click_button "Save and continue"
+    expect(page).to have_current_path("/notifications/#{notification.pretty_id}", ignore_query: true)
+  end
+
+  scenario "Add test report journey , when there are tests already associated to the Product" do
+    visit "/notifications/your-notifications"
+    click_link "Update notification"
+    expect(page).to have_content(notification.user_title)
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    expect(page).to  have_content("Was the test funded under the OPSS sampling protocol for Local Authorities?")
+    choose "No"
+    click_button "Save and continue"
+    fill_in "Further details", with: "Test result includes certificate of conformity"
+    fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date:, test_result: "Pass", file:, standards: "EN71, EN73")
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+    click_button "Save and continue"
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    expect(page).to  have_content("Add test reports")
+    expect(page).to  have_content("You have added 1 test report.")
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+
+    click_button "Save and continue"
+    expect(page).to have_current_path("/notifications/#{notification.pretty_id}", ignore_query: true)
+  end
+
+  scenario "Add test report journey , Edit an already existing Test report" do
+    visit "/notifications/your-notifications"
+    click_link "Update notification"
+    expect(page).to have_content(notification.user_title)
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    expect(page).to  have_content("Was the test funded under the OPSS sampling protocol for Local Authorities?")
+    choose "No"
+    click_button "Save and continue"
+    fill_in "Further details", with: "Test result includes certificate of conformity"
+    fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date:, test_result: "Pass", file:, standards: "EN71, EN73")
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+    click_button "Save and continue"
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    expect(page).to  have_content("Add test reports")
+    expect(page).to  have_content("You have added 1 test report.")
+
+    click_link "Change"
+    fill_in "Further details", with: "Updated Test result includes certificate of conformity"
+    click_button "Update test report"
+    expect_confirmation_banner("Test report updated successfully.")
+    within_fieldset "Do you need to add another test report?" do
+      choose "No"
+    end
+    click_button "Save and continue"
+    expect(page).to have_current_path("/notifications/#{notification.pretty_id}", ignore_query: true)
+  end
+
+  scenario "Expect validation errors when mandatory fields are not entered" do
+    visit "/notifications/your-notifications"
+    click_link "Update notification"
+    click_link "Edit test reports (#{product_one.decorate.name_with_brand})"
+    choose "Yes"
+    click_button "Save and continue"
+
+    expect(page).to have_content("Add the test certificate details")
+    click_button "Save and continue"
+    expect_certificate_date_error
+
+    fill_in "Day", with: date.day
+    fill_in "Month", with: date.month
+    fill_in "Year", with: date.year
+    click_button "Save and continue"
+    expect(page).to have_content("Add test report")
+    click_button "Add test report"
+    expect_full_error_list
+  end
+
+  def fill_in_test_result_submit_form(legislation:, date:, test_result:, file:, standards:)
+    select legislation, from: "Under which legislation?"
+    fill_in "Day",   with: date.day if date
+    fill_in "Month", with: date.month if date
+    fill_in "Year",  with: date.year  if date
+    fill_in "Which standard was the product tested against?", with: standards
+    within_fieldset "What was the result?" do
+      choose test_result
+    end
+    attach_file "test_result_form[document]", file
+
+    click_button "Add test report"
+  end
+
+  def expect_certificate_date_error
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Enter the date the test certificate was issued"
+  end
+
+  def expect_full_error_list
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
+    expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
+    expect(errors_list[2].text).to eq "Enter date of the test"
+    expect(errors_list[3].text).to eq "Select result of the test"
+    expect(errors_list[4].text).to eq "Provide the test results file"
+  end
+end


### PR DESCRIPTION
PSD 2.0 flow for adding Test reports in Edit Submitted Notification flow,
I have added new controller and independent views , in order to make them more edit friendly , for example in future if we want make some things non editable for only edit journey
created Rspec feature file for the entire flow
