### PR TITLE
CSP file ensuring the app scripts & styles are handled

### DIFF
--- a/app/views/shared/_ga_head.html.erb
+++ b/app/views/shared/_ga_head.html.erb
@@ -1,14 +1,14 @@
-<script>
-    window.dataLayer = window.dataLayer || [];
-    dataLayer.push({
-      'userId': <%= Digest::SHA256.hexdigest(current_user&.id.to_s) if current_user %>
-    });
- </script>
+<%= javascript_tag nonce: true do %>
+  window.dataLayer = window.dataLayer || [];
+  dataLayer.push({
+    'userId': '<%= current_user&.id.to_s if current_user %>'
+  });
+<% end %>
 
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-K2S954RK');</script>
-<!-- End Google Tag Manager -->
+<%= javascript_tag nonce: true do %>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-K2S954RK');
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,9 +2,12 @@
 
 # Trusted sources
 trusted_script_sources = [:self, "https://www.googletagmanager.com"]
-trusted_style_sources  = [:self, "https://fonts.googleapis.com"]
+trusted_style_sources = [:self, "https://fonts.googleapis.com"]
 trusted_font_sources = [:self, "https://fonts.gstatic.com", "*.gov.uk"]
 trusted_img_sources = %i[self data]
+trusted_connect_sources = [:self,
+                           "https://*.google-analytics.com",
+                           "https://stats.g.doubleclick.net"]
 
 # Configuration
 Rails.application.config.content_security_policy do |policy|
@@ -30,6 +33,9 @@ Rails.application.config.content_security_policy do |policy|
   # Additional resource directives
   policy.font_src(*trusted_font_sources)
   policy.img_src(*trusted_img_sources)
+
+  # Connect-src directive for Google Analytics
+  policy.connect_src(*trusted_connect_sources)
 end
 
 # CSP nonce configuration


### PR DESCRIPTION
## Description

Fixed shared partial that loads the GTM related scripts with a `javascript_tag` helper to ensure `nonce` is handled and resolve the CSP violations currently in Staging.
Resolved GA container script and source related issues.
