### PR TITLE
Implemented Flipper flag feature hint text display in Your notificati…

### DIFF
--- a/app/views/notifications/your_notifications.html.erb
+++ b/app/views/notifications/your_notifications.html.erb
@@ -12,8 +12,23 @@
 
       <% if @draft_notifications.any? %>
         <%=
-          govuk_table do |table|
-            table.with_caption(size: "m", text: "Draft notifications")
+          govuk_table do |table|       
+          if Flipper.enabled?(:submit_notification_reminder)
+            table.with_caption(size: "m") do
+                  safe_join([
+                    "Draft notifications",
+                    content_tag(:p, "If a notification remains in a draft status for 90 days it
+                    will be automatically deleted. Please submit or delete a draft in the time frame
+                    provided to help improve data quality and reporting. The 90 day period is reset
+                    if an update is applied to the draft.", class: "govuk-hint")
+                  ])
+                end
+          else
+            table.with_caption(
+              size: "m", 
+              text: "Draft notifications"
+            )          
+          end
 
             table.with_head do |head|
               head.with_row do |row|


### PR DESCRIPTION
## Description

 Added hint text to users notification list to remind users to submit or delete draft notifications in the Your notifications screen.

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [x] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [x] Works keyboard only
- [x] Tested with one screen reader
- [x] Zoom page to 400% - content still visible
- [x] Disable CSS - does content make sense and appear in a logical order?
