### PR TITLE
fix/restore_nokogiri_to_previous

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "net-smtp"
 
 gem "loaf", "~> 0.10"
 gem "matrix", "~> 0.4"
-gem "nokogiri"
+gem "nokogiri", "1.17.2"
 gem "pagy", "~> 9.3.3"
 gem "paper_trail"
 gem "pg", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,13 +382,13 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.1-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.1-x64-mingw-ucrt)
+    nokogiri (1.17.2-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-linux-gnu)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
@@ -813,7 +813,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri
+  nokogiri (= 1.17.2)
   opensearch-ruby
   pagy (~> 9.3.3)
   paper_trail


### PR DESCRIPTION
## Description
After a recent dependabot update the nokogiri gem broke deployments. This restores the gem to version 1.17.2