### PR TITLE
feat/PSD-4024-Soft-delete-drafts-after-90-days

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -763,6 +763,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x64-mingw-ucrt
   x86_64-darwin-20
   x86_64-darwin-21

--- a/app/jobs/soft_delete_draft_notifications_job.rb
+++ b/app/jobs/soft_delete_draft_notifications_job.rb
@@ -1,0 +1,7 @@
+class SoftDeleteDraftNotificationsJob < ApplicationJob
+  def perform
+    return unless Flipper.enabled?(:submit_notification_reminder)
+
+    Investigation::Notification.soft_delete_old_drafts!
+  end
+end

--- a/app/models/audit_activity/investigation/automatically_closed_case.rb
+++ b/app/models/audit_activity/investigation/automatically_closed_case.rb
@@ -1,0 +1,13 @@
+class AuditActivity::Investigation::AutomaticallyClosedCase < AuditActivity::Investigation::Base
+  def self.build_metadata(notification)
+    {
+      notification_id: notification.id,
+      title: notification.user_title,
+      closed_at: Time.current
+    }
+  end
+
+  def title(_user = nil)
+    "Draft notification automatically closed"
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -31,3 +31,6 @@
     generate_rollups_job:
       cron: "45 23 * * *"
       class: "GenerateRollupsJob"
+    soft_delete_draft_notifications_job:
+      cron: "30 1 * * *"
+      class: "SoftDeleteDraftNotificationsJob"

--- a/spec/jobs/soft_delete_draft_notifications_job_spec.rb
+++ b/spec/jobs/soft_delete_draft_notifications_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SoftDeleteDraftNotificationsJob, type: :job do
+  describe "#perform" do
+    subject(:job) { described_class.new }
+
+    context "when the feature flag is disabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(false)
+        allow(Investigation::Notification).to receive(:soft_delete_old_drafts!)
+      end
+
+      it "does not call soft_delete_old_drafts!" do
+        job.perform
+        expect(Investigation::Notification).not_to have_received(:soft_delete_old_drafts!)
+      end
+    end
+
+    context "when the feature flag is enabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(true)
+        allow(Investigation::Notification).to receive(:soft_delete_old_drafts!)
+      end
+
+      it "calls soft_delete_old_drafts! on Investigation::Notification" do
+        job.perform
+        expect(Investigation::Notification).to have_received(:soft_delete_old_drafts!)
+      end
+    end
+  end
+end

--- a/spec/models/investigation/notification_spec.rb
+++ b/spec/models/investigation/notification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Investigation::Notification do
+RSpec.describe Investigation::Notification, :with_stubbed_mailer do
   subject(:notification) { build(:notification) }
 
   describe "#case_type" do
@@ -36,6 +36,112 @@ RSpec.describe Investigation::Notification do
       subject(:notification) { build(:notification, user_title: nil) }
 
       it { is_expected.not_to be_valid_api_dataset }
+    end
+  end
+
+  describe ".soft_delete_old_drafts!" do
+    let(:user) { create(:user, :activated, :opss_user) }
+    let(:old_draft) { create_notification(state: "draft", updated_at: 91.days.ago, pretty_id: "2024-0001") }
+    let(:recent_draft) { create_notification(state: "draft", updated_at: 89.days.ago, pretty_id: "2024-0002") }
+    let(:old_submitted) { create_notification(state: "submitted", updated_at: 91.days.ago, pretty_id: "2024-0003") }
+
+    def create_notification(state:, updated_at:, pretty_id:)
+      notification = build(:notification, state:, updated_at:, pretty_id:)
+      notification.build_owner_collaborations_from(user)
+      notification.save!(validate: false)
+      notification
+    end
+
+    before do
+      allow(CreateNotification).to receive(:call).and_return(OpenStruct.new(success?: true))
+      allow(old_draft).to receive(:reindex)
+      old_draft
+    end
+
+    shared_examples "soft deletes old draft notifications" do
+      it "sets deleted_at" do
+        described_class.soft_delete_old_drafts!
+        expect(old_draft.reload.deleted_at).to be_present
+      end
+
+      it "sets deleted_by to 'System'" do
+        described_class.soft_delete_old_drafts!
+        expect(old_draft.reload.deleted_by).to eq("System")
+      end
+    end
+
+    shared_examples "preserves notifications" do |notification_type|
+      it "does not delete #{notification_type}" do
+        described_class.soft_delete_old_drafts!
+        notification = send(notification_type)
+        expect(notification.reload.deleted_at).to be_nil
+      end
+    end
+
+    shared_examples "creates audit activity" do
+      it "creates an audit activity" do
+        expect { described_class.soft_delete_old_drafts! }
+          .to change(AuditActivity::Investigation::AutomaticallyClosedCase, :count).by(1)
+      end
+
+      it "links the audit activity to the notification" do
+        described_class.soft_delete_old_drafts!
+        activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
+        expect(activity.investigation).to eq(old_draft)
+      end
+
+      it "includes the notification ID in the audit activity metadata" do
+        described_class.soft_delete_old_drafts!
+        activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
+        expect(activity.metadata["notification_id"]).to eq(old_draft.id)
+      end
+
+      it "includes the closed_at timestamp in the audit activity metadata" do
+        freeze_time do
+          described_class.soft_delete_old_drafts!
+          activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
+          expect(Time.zone.parse(activity.metadata["closed_at"].to_s)).to eq(Time.current)
+        end
+      end
+    end
+
+    include_examples "soft deletes old draft notifications"
+    include_examples "preserves notifications", :recent_draft
+    include_examples "preserves notifications", :old_submitted
+    include_examples "creates audit activity"
+
+    it "calls reindex on the notification" do
+      relation = instance_double(ActiveRecord::Relation)
+      allow(described_class).to receive(:old_drafts).and_return(relation)
+      allow(relation).to receive(:find_each).and_yield(old_draft)
+      allow(old_draft).to receive(:reindex)
+      described_class.soft_delete_old_drafts!
+      expect(old_draft).to have_received(:reindex).once
+    end
+
+    it "logs the number of processed notifications" do
+      allow(Rails.logger).to receive(:info)
+      described_class.soft_delete_old_drafts!
+      expect(Rails.logger).to have_received(:info).with("Starting to soft delete old draft notifications")
+      expect(Rails.logger).to have_received(:info).with("Completed soft deleting old draft notifications. Processed: 1")
+    end
+
+    context "when an error occurs" do
+      let(:error_message) { "Test error" }
+      let(:relation) { instance_double(ActiveRecord::Relation) }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+        allow(described_class).to receive(:old_drafts).and_return(relation)
+        allow(relation).to receive(:find_each).and_yield(old_draft)
+        allow(old_draft).to receive(:mark_as_deleted!).and_raise(StandardError.new(error_message))
+      end
+
+      it "logs the error and continues processing" do
+        described_class.soft_delete_old_drafts!
+        expect(Rails.logger).to have_received(:error).with("Failed to soft delete notification #{old_draft.id}: #{error_message}")
+      end
     end
   end
 end


### PR DESCRIPTION
# Implement Soft Delete for Draft Notifications After 90 Days

## Description
This PR implements automatic soft deletion of draft notifications that have not been updated in the last 90 days. This helps maintain data quality by removing stale draft notifications while preserving them in the database.

## Changes
- Added `SoftDeleteDraftNotificationsJob` to handle periodic cleanup of old draft notifications
- Implemented `soft_delete_old_drafts!` method in `Investigation::Notification` model
- Created `AutomaticallyClosedCase` audit activity to track soft deletions
- Added feature flag `submit_notification_reminder` to control the functionality
- Added comprehensive test coverage for the new functionality

## Implementation Details
- Notifications are considered stale if:
  - They are in `draft` state
  - Haven't been updated in the last 90 days
- Soft deletion:
  - Sets `deleted_at` timestamp
  - Sets `deleted_by` to "System"
  - Creates an audit activity record
- Feature can be toggled using the `submit_notification_reminder` feature flag

## Testing
- Added model specs for `Investigation::Notification#soft_delete_old_drafts!`
- Added job specs for `SoftDeleteDraftNotificationsJob`
- Tested with various notification states and ages
- Verified audit trail creation
- Confirmed proper handling of the feature flag