### PR TITLE
fix/restore_nokogiri_to_1.17.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "net-smtp"
 
 gem "loaf", "~> 0.10"
 gem "matrix", "~> 0.4"
-gem "nokogiri", "1.18.1"
+gem "nokogiri", "1.17.2"
 gem "pagy", "~> 9.3.3"
 gem "paper_trail"
 gem "pg", "~> 1.5"


### PR DESCRIPTION
# Fix Nokogiri GLIBC compatibility issue in deployment

## Problem
The application was failing to deploy due to Nokogiri 1.18.1 requiring GLIBC 2.28, which is not available in our deployment environment.

## Solution
Downgrade Nokogiri to version 1.17.2 which has compatible GLIBC requirements with our deployment environment.

## Alternative Solutions Considered
- Using `force_ruby_platform: true` was considered but would impact performance
- Global bundler configuration changes were evaluated but deemed too broad

## Testing
- Verified application deploys successfully
- All existing tests pass with the downgraded version