### PR TITLE
fix/run_bundle_install_after_nokogiri_downgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,13 +382,13 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.1-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.1-x64-mingw-ucrt)
+    nokogiri (1.17.2-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-linux-gnu)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
@@ -814,7 +814,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (= 1.18.1)
+  nokogiri (= 1.17.2)
   opensearch-ruby
   pagy (~> 9.3.3)
   paper_trail


### PR DESCRIPTION
# Update Gemfile.lock for Nokogiri downgrade

## Problem
After merging the Nokogiri downgrade PR, `bundle install` wasn't run, leaving `Gemfile.lock` out of sync with `Gemfile`.

## Changes
- Run `bundle install` to update `Gemfile.lock` to reflect Nokogiri 1.17.2

## Related PR
Follows up on #3319 (Nokogiri downgrade PR)