### PR TITLE
PSD-4023  send_email_reminders_to_submit_drafts based on the days elapsed

### DIFF
--- a/app/jobs/send_reminder_email_draft_notifications_job.rb
+++ b/app/jobs/send_reminder_email_draft_notifications_job.rb
@@ -23,6 +23,7 @@ private
       send_mails(drafts, days_old, remaining_days, last_reminder, last_line)
     end
   rescue StandardError => e
+    Sentry.capture_exception(e)
     Rails.logger.error "Failed to send reminder emails for drafts days old due to: #{e.message}"
   end
 
@@ -45,7 +46,7 @@ private
         pretty_id: draft.pretty_id,
         last_reminder: last_reminder,
         last_line: last_line
-      )
+      ).deliver_later
     end
   end
 
@@ -59,9 +60,9 @@ private
 
   def reminder_last_line(last_reminder)
     if last_reminder
-      "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'."
+      I18n.t(".final_reminder", scope: "mail.send_email_reminder_to_submit_draft")
     else
-      "If the status of this notification remains in 'Draft', another reminder email will be sent in the next coming days."
+      I18n.t(".another_email", scope: "mail.send_email_reminder_to_submit_draft")
     end
   end
 end

--- a/app/jobs/send_reminder_email_draft_notifications_job.rb
+++ b/app/jobs/send_reminder_email_draft_notifications_job.rb
@@ -1,0 +1,67 @@
+class SendReminderEmailDraftNotificationsJob < ApplicationJob
+  DRAFT_NOTIFICATION_RULES = [
+    { days_old: 75, remaining_days: 15, last_reminder: false },
+    { days_old: 80, remaining_days: 10, last_reminder: false },
+    { days_old: 87, remaining_days: 3, last_reminder: true }
+  ].freeze
+
+  def perform
+    return unless Flipper.enabled?(:submit_notification_reminder)
+
+    send_reminder_emails
+  end
+
+private
+
+  def send_reminder_emails
+    DRAFT_NOTIFICATION_RULES.each do |rule|
+      days_old = rule[:days_old]
+      remaining_days = rule[:remaining_days]
+      last_reminder = rule[:last_reminder]
+      last_line = reminder_last_line(last_reminder)
+      drafts = fetch_drafts(days_old)
+      send_mails(drafts, days_old, remaining_days, last_reminder, last_line)
+    end
+  rescue StandardError => e
+    Rails.logger.error "Failed to send reminder emails for drafts days old due to: #{e.message}"
+  end
+
+  def fetch_drafts(days_old)
+    Investigation::Notification
+    .where(state: "draft")
+    .where(updated_at: days_old.days.ago.beginning_of_day..days_old.days.ago.end_of_day)
+  end
+
+  def send_mails(drafts, days_old, remaining_days, last_reminder, last_line)
+    drafts.each do |draft|
+      next unless (user = find_user(draft))
+
+      draft_title = get_draft_title(draft)
+      NotifyMailer.send_email_reminder(
+        user: user,
+        remaining_days: remaining_days,
+        days: days_old,
+        title: draft_title,
+        pretty_id: draft.pretty_id,
+        last_reminder: last_reminder,
+        last_line: last_line
+      )
+    end
+  end
+
+  def find_user(draft)
+    User.find_by(id: draft.creator_user.id) unless draft.creator_user.nil?
+  end
+
+  def get_draft_title(draft)
+    draft.user_title? ? draft.user_title : "Untitled Draft Notification - Last updated #{draft&.updated_at&.to_formatted_s(:govuk)}"
+  end
+
+  def reminder_last_line(last_reminder)
+    if last_reminder
+      "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'."
+    else
+      "If the status of this notification remains in 'Draft', another reminder email will be sent in the next coming days."
+    end
+  end
+end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -20,7 +20,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
       notification_export: "f6c9a4ad-2050-4f76-bbad-d73bd9747d18",
       business_export: "68df2257-07f5-4768-b50a-74ffa3cb7fd3",
       unsafe_file: "3ba1da4f-a6e4-4d29-a03c-8996fe711c26",
-      unsafe_attachment: "6960b99c-7c60-4e28-a7ea-d29a0d0f3d0e"
+      unsafe_attachment: "6960b99c-7c60-4e28-a7ea-d29a0d0f3d0e",
+      draft_notification_reminder: "4defeadb-cb64-49dc-8e36-89e52e5ea3b1"
     }.freeze
 
   def reset_password_instructions(user, token)
@@ -288,6 +289,23 @@ class NotifyMailer < GovukNotifyRails::Mailer
       name: user.name,
       record_type:,
       id:
+    )
+
+    mail(to: user.email)
+  end
+
+  def send_email_reminder(user:, remaining_days:, days:, title:, pretty_id:, last_reminder:, last_line:)
+    set_template(TEMPLATES[:draft_notification_reminder])
+    set_reference("Draft Notification submission reminder")
+
+    set_personalisation(
+      name: user.name,
+      remaining_days:,
+      days:,
+      title:,
+      investigation_url: investigation_url(pretty_id:),
+      last_reminder:,
+      last_line:
     )
 
     mail(to: user.email)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
       permission:
         edit: "edit full notification"
         readonly: "view full notification"
+    send_email_reminder_to_submit_draft:
+      final_reminder: "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'."
+      another_email: "If the status of this notification remains in 'Draft', another reminder email will be sent in the next coming days."   
 
   why_reporting_form:
     no_checkboxes_selected: "Choose at least one option"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -34,3 +34,6 @@
     soft_delete_draft_notifications_job:
       cron: "30 1 * * *"
       class: "SoftDeleteDraftNotificationsJob"
+    send_draft_notification_reminder_job:
+      cron: "0 5 * * *"
+      class: "SendReminderEmailDraftNotificationsJob" 

--- a/spec/jobs/send_reminder_email_draft_notifications_job_spec.rb
+++ b/spec/jobs/send_reminder_email_draft_notifications_job_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe SendReminderEmailDraftNotificationsJob, :with_stubbed_antivirus, :with_stubbed_mailer, type: :job do
+  let(:user) { create(:user) }
+  let(:draft) { create_notification(state: "draft", updated_at: 75.days.ago, pretty_id: "2024-0002") }
+  let(:mailer) { instance_double(ActionMailer::MessageDelivery) }
+
+  before do
+    allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(true)
+    allow(NotifyMailer).to receive(:send_email_reminder).and_return(mailer)
+    allow(mailer).to receive(:deliver_later)
+  end
+
+  describe "#perform" do
+    context "when the Flipper feature is enabled" do
+      it "calls send_reminder_emails" do
+        job = described_class.new
+        allow(job).to receive(:send_reminder_emails)
+        job.perform
+        expect(job).to have_received(:send_reminder_emails)
+      end
+    end
+
+    context "when the Flipper feature is disabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(false)
+      end
+
+      it "does not call send_reminder_emails" do
+        job = described_class.new
+        allow(job).to receive(:send_reminder_emails)
+        job.perform
+        expect(job).not_to have_received(:send_reminder_emails)
+      end
+    end
+  end
+
+  describe "#send_reminder_emails" do
+    before do
+      draft # Trigger creation of the draft
+    end
+
+    it "fetches drafts and sends emails" do
+      allow(NotifyMailer).to receive(:send_email_reminder)
+      described_class.new.send(:send_reminder_emails)
+      expect(NotifyMailer).to have_received(:send_email_reminder)
+    end
+
+    it "logs an error if an exception occurs" do
+      job = described_class.new
+      allow(job).to receive(:fetch_drafts).and_raise(StandardError, "Test error")
+      allow(Rails.logger).to receive(:error)
+      expect {
+        job.send(:send_reminder_emails)
+      }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(/Failed to send reminder emails for drafts days old due to: Test error/)
+    end
+  end
+
+  describe "#fetch_drafts" do
+    it "fetches drafts matching the criteria" do
+      draft
+      drafts = described_class.new.send(:fetch_drafts, 75)
+      expect(drafts).to include(draft)
+    end
+  end
+
+  describe "#send_mails" do
+    context "when the draft has a valid user" do
+      before do
+        draft # Trigger creation of the draft
+      end
+
+      it "sends the final reminder email with the correct details" do
+        allow(NotifyMailer).to receive(:send_email_reminder).and_return(mailer)
+        described_class.new.send(:send_mails, [draft], 87, 3, true, "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.")
+        expect(NotifyMailer).to have_received(:send_email_reminder).with(
+          user: user, remaining_days: 3, last_reminder: true, last_line: "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.",
+          days: 87, title: draft.user_title, pretty_id: draft.pretty_id
+        )
+      end
+    end
+  end
+
+  describe "#reminder_last_line" do
+    it "returns the final reminder text if last_reminder is true" do
+      line = described_class.new.send(:reminder_last_line, true)
+      expect(line).to eq("This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.")
+    end
+
+    it "returns the regular reminder text if last_reminder is false" do
+      line = described_class.new.send(:reminder_last_line, false)
+      expect(line).to eq("If the status of this notification remains in 'Draft', another reminder email will be sent in the next coming days.")
+    end
+  end
+
+  def create_notification(state:, updated_at:, pretty_id:)
+    notification = build(:notification, state:, updated_at:, pretty_id:)
+    notification.build_creator_user_collaboration(collaborator: user)
+    notification.save!(validate: false)
+    notification
+  end
+end

--- a/spec/jobs/send_reminder_email_draft_notifications_job_spec.rb
+++ b/spec/jobs/send_reminder_email_draft_notifications_job_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe SendReminderEmailDraftNotificationsJob, :with_stubbed_antivirus, 
 
       it "sends the final reminder email with the correct details" do
         allow(NotifyMailer).to receive(:send_email_reminder).and_return(mailer)
-        described_class.new.send(:send_mails, [draft], 87, 3, true, "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.")
+        described_class.new.send(:send_mails, [draft], 87, 3, true, I18n.t(".final_reminder", scope: "mail.send_email_reminder_to_submit_draft"))
         expect(NotifyMailer).to have_received(:send_email_reminder).with(
-          user: user, remaining_days: 3, last_reminder: true, last_line: "This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.",
+          user: user, remaining_days: 3, last_reminder: true, last_line: I18n.t(".final_reminder", scope: "mail.send_email_reminder_to_submit_draft"),
           days: 87, title: draft.user_title, pretty_id: draft.pretty_id
         )
       end
@@ -85,12 +85,12 @@ RSpec.describe SendReminderEmailDraftNotificationsJob, :with_stubbed_antivirus, 
   describe "#reminder_last_line" do
     it "returns the final reminder text if last_reminder is true" do
       line = described_class.new.send(:reminder_last_line, true)
-      expect(line).to eq("This will be the final reminder before the notification will be automatically deleted in 3 days, if the status remains on 'Draft'.")
+      expect(line).to eq(I18n.t(".final_reminder", scope: "mail.send_email_reminder_to_submit_draft"))
     end
 
     it "returns the regular reminder text if last_reminder is false" do
       line = described_class.new.send(:reminder_last_line, false)
-      expect(line).to eq("If the status of this notification remains in 'Draft', another reminder email will be sent in the next coming days.")
+      expect(line).to eq(I18n.t(".another_email", scope: "mail.send_email_reminder_to_submit_draft"))
     end
   end
 


### PR DESCRIPTION
a new job to run and check the elapsed days on drafts to send emails to the users to remind them to submit the Notification