### PR TITLE
fix/PSD-3971-GTM_bug_2 - Add GTM containers to PRISM layout

### DIFF
--- a/app/helpers/google_tag_manager_helper.rb
+++ b/app/helpers/google_tag_manager_helper.rb
@@ -1,0 +1,7 @@
+module GoogleTagManagerHelper
+  def gtm_containers
+    return [] unless Rails.env.production? && analytics_cookies_accepted?
+
+    %w[GTM-K2S954RK]
+  end
+end

--- a/app/views/shared/_ga_body.html.erb
+++ b/app/views/shared/_ga_body.html.erb
@@ -1,5 +1,9 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K2S954RK" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>
+<% gtm_containers.each do |container| %>
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=<%= container %>"
+            height="0" width="0" style="display:none;visibility:hidden">
+    </iframe>
+  </noscript>
+<% end %>
 <!-- End Google Tag Manager (noscript) -->

--- a/app/views/shared/_ga_head.html.erb
+++ b/app/views/shared/_ga_head.html.erb
@@ -5,10 +5,14 @@
   });
 <% end %>
 
-<%= javascript_tag nonce: true do %>
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-K2S954RK');
+<!-- Google Tag Manager -->
+<% gtm_containers.each do |container| %>
+  <script nonce="<%= request.content_security_policy_nonce %>">
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= container %>');
+  </script>
 <% end %>
+<!-- End Google Tag Manager -->

--- a/prism/app/controllers/prism/application_controller.rb
+++ b/prism/app/controllers/prism/application_controller.rb
@@ -1,6 +1,8 @@
 module Prism
   class ApplicationController < ActionController::Base
     include Pagy::Backend
+    include CookiesConcern
+    helper ::GoogleTagManagerHelper
 
     protect_from_forgery with: :exception
 

--- a/spec/system/prism/google_tag_manager_spec.rb
+++ b/spec/system/prism/google_tag_manager_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Google Tag Manager in PRISM", type: :system do
+  include Prism::Engine.routes.url_helpers
+
+  let(:user) { create(:user) }
+  let(:risk_assessment) { create(:prism_risk_assessment, created_by_user_id: user.id) }
+  let(:gtm_containers) { %w[GTM-K2S954RK] }
+
+  def set_cookie_preferences(accept_analytics: true)
+    page.driver.browser.set_cookie("accept_analytics_cookies=#{accept_analytics}")
+    page.driver.browser.set_cookie("cookie_preferences_set=true")
+  end
+
+  shared_examples "has no GTM containers" do
+    it "does not include GTM script tags" do
+      gtm_containers.each do |container|
+        expect(page).not_to have_selector("script", visible: false, text: /#{container}/)
+      end
+    end
+
+    it "does not include GTM noscript iframes" do
+      gtm_containers.each do |container|
+        expect(page).not_to have_selector("noscript iframe[src*='#{container}']", visible: false)
+      end
+    end
+  end
+
+  before do
+    sign_in(user)
+    driven_by(:rack_test)
+  end
+
+  context "when in production" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+    end
+
+    context "when analytics cookies are accepted" do
+      before do
+        set_cookie_preferences(accept_analytics: true)
+        visit risk_assessment_tasks_path(risk_assessment)
+      end
+
+      it "includes GTM script tags" do
+        gtm_containers.each do |container|
+          expect(page).to have_selector("script", visible: false, text: /#{container}/)
+        end
+      end
+
+      it "includes GTM noscript iframes" do
+        gtm_containers.each do |container|
+          expect(page).to have_selector("noscript iframe[src*='#{container}']", visible: false)
+        end
+      end
+    end
+
+    context "when analytics cookies are not accepted" do
+      before do
+        set_cookie_preferences(accept_analytics: false)
+        visit risk_assessment_tasks_path(risk_assessment)
+      end
+
+      include_examples "has no GTM containers"
+    end
+  end
+
+  context "when not in production" do
+    before do
+      visit risk_assessment_tasks_path(risk_assessment)
+    end
+
+    include_examples "has no GTM containers"
+  end
+end


### PR DESCRIPTION
# Add GTM containers to PRISM layout

## Problem
PRISM risk assessment pages were not being tagged with Google Tag Manager (GTM), leading to inconsistent analytics tracking across the application. This was particularly noticeable when users were editing risk assessments.

## Solution
- Added GTM partials to the PRISM layout file with proper conditional rendering:
  - Only loads in production environment
  - Only loads when analytics cookies are accepted
- Extended `CookiesConcern` to the PRISM layout to handle cookie checks
- Included `GoogleTagManagerHelper` in PRISM application controller
- Ensured consistent loading of GTM container (`GTM-K2S954RK`) across all PRISM pages
- Implemented DRY approach with a helper method to manage GTM container configuration

## Testing
Added comprehensive system tests that verify:
- GTM container is included when:
  - In production environment AND
  - Analytics cookies are accepted
- GTM container is NOT included when:
  - Not in production environment OR
  - Analytics cookies are not accepted

## QA Steps
1. **Environment Setup**:
   - Access staging environment
   - Sign in to the application

2. **Analytics Cookies Not Accepted**:
   - Reject analytics cookies or clear existing cookie preferences
   - Visit PRISM risk assessment pages
   - Verify GTM container is not present (check page source)
   - Verify no GTM-related network requests in browser dev tools

3. **Analytics Cookies Accepted**:
   - Accept analytics cookies
   - Visit PRISM risk assessment pages
   - Verify GTM container (`GTM-K2S954RK`) is present
   - Check GTM script tag in `<head>`
   - Check GTM noscript iframe in `<body>`
   - Verify dataLayer includes user ID when logged in
   - Check network tab for successful GTM requests

4. **Non-Production Testing**:
   - Verify GTM is not loaded in development/test environments
   - Confirm this behavior is consistent across all PRISM pages

5. **Cross-browser Testing**:
   - Verify functionality in Chrome, Firefox, and Safari
   - Ensure GTM loads correctly across all supported browsers