### PR TITLE
PSD-4457 - data change , rake task to update notifications

### DIFF
--- a/lib/tasks/update_submitted_at_investigations.rake
+++ b/lib/tasks/update_submitted_at_investigations.rake
@@ -1,0 +1,8 @@
+namespace :investigations do
+  desc "Update submitted_at with created_at for investigations where submitted_at is nil"
+  task update_submitted_date: :environment do
+    Investigation.unscoped.where(submitted_at: nil).find_each(batch_size: 500) do |investigation|
+      investigation.update_columns(submitted_at: investigation.created_at)
+    end
+  end
+end

--- a/spec/lib/update_submitted_at_investigations_spec.rb
+++ b/spec/lib/update_submitted_at_investigations_spec.rb
@@ -1,0 +1,29 @@
+# rubocop:disable RSpec/DescribeClass
+require "rails_helper"
+require "rake"
+Rails.application.load_tasks
+
+RSpec.describe "investigations:update_submitted_date", :with_stubbed_antivirus, :with_stubbed_mailer do
+  let(:user) { create(:user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let!(:investigation_with_nil_submitted_at) { create(:notification, submitted_at: nil, created_at: 1.day.ago) }
+  let!(:investigation_with_submitted_at) { create(:notification, submitted_at: Time.zone.now, created_at: 2.days.ago) }
+
+  before do
+    # Clear the task before each test to ensure it can be re-invoked
+    Rake.application["investigations:update_submitted_date"].reenable
+  end
+
+  it "updates submitted_at with created_at for investigations where submitted_at is nil" do
+    # Run the task
+    Rake::Task["investigations:update_submitted_date"].invoke
+
+    # Reload the objects to get the updated values
+    investigation_with_nil_submitted_at.reload
+    investigation_with_submitted_at.reload
+
+    # Expectations
+    expect(investigation_with_nil_submitted_at.submitted_at).to eq(investigation_with_nil_submitted_at.created_at)
+    expect(investigation_with_submitted_at.submitted_at).not_to eq(investigation_with_submitted_at.created_at)
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
Rake task to update the Submitted_at with created_at date for all notifications , and the epic track status change will cater for all new Notifications created.

To run the task : rails investigations:update_submitted_date