### PR TITLE
PSD-3709: Fix location validation handling and error display

### DIFF
--- a/app/controllers/businesses/locations_controller.rb
+++ b/app/controllers/businesses/locations_controller.rb
@@ -17,11 +17,11 @@ module Businesses
     def edit; end
 
     def create
-      @location = @business.locations.create!(location_params.merge({ added_by_user: current_user }))
+      @location = @business.locations.build(location_params.merge({ added_by_user: current_user }))
       if @location.save
         redirect_to business_url(@business, anchor: "locations"), flash: { success: "Location was successfully created." }
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/spec/controllers/businesses/locations_controller_spec.rb
+++ b/spec/controllers/businesses/locations_controller_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Businesses::LocationsController, type: :controller do
+  let(:user) { create(:user, :activated) }
+  let(:business) { create(:business) }
+
+  before do
+    sign_in(user)
+    request.host = "example.org"
+  end
+
+  describe "POST #create" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          business_id: business.id,
+          location: {
+            name: "Head Office",
+            country: "country:GB",
+            address_line_1: "123 Test St",
+            city: "London",
+            postal_code: "SW1A 1AA"
+          }
+        }
+      end
+
+      it "creates a new location" do
+        expect {
+          post :create, params: valid_params
+        }.to change(Location, :count).by(1)
+      end
+
+      it "redirects to the business page" do
+        post :create, params: valid_params
+        expect(response).to redirect_to(business_url(business, anchor: "locations", only_path: true))
+      end
+
+      it "sets a success flash message" do
+        post :create, params: valid_params
+        expect(flash[:success]).to eq("Location was successfully created.")
+      end
+
+      it "assigns the current user as added_by_user" do
+        post :create, params: valid_params
+        expect(Location.last.added_by_user).to eq(user)
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) do
+        {
+          business_id: business.id,
+          location: {
+            name: "", # Required field
+            country: "", # Required field
+            address_line_1: "123 Test St",
+            city: "London",
+            postal_code: "SW1A 1AA"
+          }
+        }
+      end
+
+      it "does not create a new location" do
+        expect {
+          post :create, params: invalid_params
+        }.not_to change(Location, :count)
+      end
+
+      it "returns unprocessable_entity status" do
+        post :create, params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the new template" do
+        post :create, params: invalid_params
+        expect(response).to render_template(:new)
+      end
+
+      it "sets validation errors on the location" do
+        post :create, params: invalid_params
+        expect(assigns(:location).errors[:name]).to include("Name cannot be blank")
+        expect(assigns(:location).errors[:country]).to include("Country cannot be blank")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Fix location validation handling and error display

## Description
This PR fixes the validation handling when creating a new location for a business. Previously, when required fields (name and country) were missing, the application would raise an exception instead of displaying validation errors to the user.

## Changes
- Changed `create!` to `build` in locations controller to handle validation errors gracefully
- Added proper HTTP status code (422 Unprocessable Entity) for validation errors
- Added comprehensive controller specs to ensure proper validation handling

## Testing
Added controller specs that verify:
- Valid locations can be created successfully
- Invalid locations show proper validation errors
- Correct HTTP status codes are returned
- User is redirected appropriately after successful creation
- Flash messages are set correctly
- Current user is properly assigned as `added_by_user`