### PR TITLE
fix/PSD-3673-actions_heading_and_table_repetition

### DIFF
--- a/app/views/notifications/your_notifications.html.erb
+++ b/app/views/notifications/your_notifications.html.erb
@@ -36,7 +36,7 @@
                 row.with_cell(text: "Notification title", html_attributes: { scope: "col" })
                 row.with_cell(text: "Last updated", html_attributes: { scope: "col" })
                 row.with_cell(text: "Status", html_attributes: { scope: "col" })
-                row.with_cell(text: "<span class=\"govuk-visually-hidden\">Actions</span>".html_safe, html_attributes: { scope: "col" })
+                row.with_cell(text: "Change or Delete", html_attributes: { scope: "col" })
               end
             end
 
@@ -48,27 +48,40 @@
                   updated_value = notification.updated_at.to_formatted_s(:govuk)
                   status_value = "Draft"
 
+                  product_with_header = content_tag(:span, "Product name: ", class: "govuk-visually-hidden") +
+                                        sanitize(notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).presence&.join("<br>") || "Not provided", tags: %w(br)).html_safe
+
+                  title_with_header = content_tag(:span, "Notification title: ", class: "govuk-visually-hidden") +
+                                      sanitize(title_value)
+
+                  updated_with_header = content_tag(:span, "Last updated: ", class: "govuk-visually-hidden") +
+                                        updated_value
+
+                  status_with_header = content_tag(:span, "Status: ", class: "govuk-visually-hidden") +
+                                       content_tag(:span, status_value, class: "govuk-tag govuk-tag--grey")
+
+                  make_changes_link = content_tag(:a, "Make changes", href: notification_create_index_path(notification), class: "govuk-link")
+                  hr_tag = content_tag(:hr, nil, class: "govuk-section-break govuk-section-break--m govuk-section-break--visible")
+                  delete_link = content_tag(:a, "Delete", href: delete_notification_path(notification), class: "govuk-link")
+
+                  actions_with_header = content_tag(:span, "Change or Delete: ", class: "govuk-visually-hidden") +
+                                        make_changes_link + hr_tag + delete_link
+
                   row.with_cell(
                     header: true,
-                    text: sanitize(notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).presence&.join("<br>") || "Not provided", tags: %w(br)).html_safe
+                    text: product_with_header
                   )
-                  row.with_cell(text: sanitize(title_value))
-                  row.with_cell(text: updated_value)
-                  row.with_cell(text: govuk_tag(text: status_value, colour: "grey").html_safe)
                   row.with_cell(
-                    text: sanitize(
-                      "<span id=\"desc-#{notification.id}\" class=\"govuk-visually-hidden\">
-                        Product name(s): #{product_value}.
-                        Notification title: #{title_value}.
-                        Last updated: #{updated_value}.
-                        Status: #{status_value}.
-                      </span>
-                      <a href=\"#{notification_create_index_path(notification)}\" class=\"govuk-link\" aria-describedby=\"desc-#{notification.id}\">Make changes</a>
-                      <hr class=\"govuk-section-break govuk-section-break--m govuk-section-break--visible\">
-                      <a href=\"#{delete_notification_path(notification)}\" class=\"govuk-link\" aria-describedby=\"desc-#{notification.id}\">Delete</a>",
-                      tags: %w(a hr span),
-                      attributes: %w(href class id aria-describedby)
-                    ).html_safe
+                    text: title_with_header
+                  )
+                  row.with_cell(
+                    text: updated_with_header
+                  )
+                  row.with_cell(
+                    text: status_with_header
+                  )
+                  row.with_cell(
+                    text: actions_with_header
                   )
                 end
               end
@@ -89,7 +102,7 @@
                 row.with_cell(text: "Notification title", html_attributes: { scope: "col" })
                 row.with_cell(text: "Last updated", html_attributes: { scope: "col" })
                 row.with_cell(text: "Status", html_attributes: { scope: "col" })
-                row.with_cell(text: "<span class=\"govuk-visually-hidden\">Actions</span>".html_safe, html_attributes: { scope: "col" })
+                row.with_cell(text: "Update", html_attributes: { scope: "col" })
               end
             end
 
@@ -101,25 +114,44 @@
                   updated_value = notification.updated_at.to_formatted_s(:govuk)
                   status_value = "Submitted #{notification.submitted_at? ? notification.submitted_at.to_formatted_s(:govuk) : "Date not provided"}"
 
+                  product_with_header = content_tag(:span, "Product name: ", class: "govuk-visually-hidden") +
+                                        sanitize(notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).join("<br>"), tags: %w(br)).html_safe
+
+                  title_with_header = content_tag(:span, "Notification title: ", class: "govuk-visually-hidden") +
+                                      sanitize(title_value)
+
+                  updated_with_header = content_tag(:span, "Last updated: ", class: "govuk-visually-hidden") +
+                                        updated_value
+
+                  submitted_tag = content_tag(:span, "Submitted", class: "govuk-tag govuk-tag--green")
+                  submitted_date = notification.submitted_at? ? notification.submitted_at.to_formatted_s(:govuk) : "Date not provided"
+                  status_with_header = content_tag(:span, "Status: ", class: "govuk-visually-hidden") +
+                                       content_tag(:div) do
+                                         safe_join([
+                                           submitted_tag,
+                                           content_tag(:div, submitted_date, class: "govuk-!-margin-top-2")
+                                         ])
+                                       end
+
+                  update_link = content_tag(:a, "Update notification", href: notification_path(notification), class: "govuk-link")
+
+                  actions_with_header = content_tag(:span, "Update: ", class: "govuk-visually-hidden") + update_link
+
                   row.with_cell(
                     header: true,
-                    text: sanitize(notification.investigation_products.decorate.map(&:product).map(&:name_with_brand).join("<br>"), tags: %w(br)).html_safe
+                    text: product_with_header
                   )
-                  row.with_cell(text: sanitize(title_value))
-                  row.with_cell(text: updated_value)
-                  row.with_cell(text: "#{govuk_tag(text: 'Submitted', colour: 'green').html_safe}<br><br>#{notification.submitted_at? ? notification.submitted_at.to_formatted_s(:govuk) : "Date not provided"}".html_safe)
                   row.with_cell(
-                    text: sanitize(
-                      "<span id=\"desc-submitted-#{notification.id}\" class=\"govuk-visually-hidden\">
-                        Product name(s): #{product_value}.
-                        Notification title: #{title_value}.
-                        Last updated: #{updated_value}.
-                        Status: #{status_value}.
-                      </span>
-                      <a href=\"#{notification_path(notification)}\" class=\"govuk-link\" aria-describedby=\"desc-submitted-#{notification.id}\">Update notification</a>",
-                      tags: %w(a span),
-                      attributes: %w(href class id aria-describedby)
-                    ).html_safe
+                    text: title_with_header
+                  )
+                  row.with_cell(
+                    text: updated_with_header
+                  )
+                  row.with_cell(
+                    text: status_with_header
+                  )
+                  row.with_cell(
+                    text: actions_with_header
                   )
                 end
               end


### PR DESCRIPTION
- Action headings updated visually from nothing to "Change or Delete" for draft notifications and "Update" for submitted notifications
- Screen readers now correctly announce each value with its heading