### PR TITLE
omit drafts from showing up on the products page

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -119,4 +119,9 @@ class Product < ApplicationRecord
   def get_notification_images
     investigations.flat_map(&:image_uploads)
   end
+
+  def get_investigations_count_for_display
+    investigations.where(type: ["Investigation::Allegation", "Investigation::Project", "Investigation::Enquiry"])
+                  .or(investigations.where(type: "Investigation::Notification", state: "submitted")).count
+  end
 end

--- a/app/views/products/_cases.html.erb
+++ b/app/views/products/_cases.html.erb
@@ -1,13 +1,15 @@
+<% count = @product.get_investigations_count_for_display %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body opss-secondary-text">
-      This product record has been added to <%= pluralize @product.investigations.size, 'notification' %>.
+      This product record has been added to <%= pluralize count, 'notification' %>.
     </p>
   </div>
 </div>
-<% if @product.investigations.any? %>
-  <% rows = @product.investigations.uniq.map do |investigation| %>
-    <% [investigation.case_title_key(@current_user), *investigation.case_summary_values] %>
+<% if count > 0 %>
+  <% rows = @product.investigations.uniq.each_with_object([]) do |investigation, array| %>
+    <% next if investigation.is_a?(Investigation::Notification) && investigation.state == 'draft' %>
+    <% array << [investigation.case_title_key(@current_user), *investigation.case_summary_values] %>
   <% end %>
   <%= govuk_table(head: ["Notification name", "Notification number", "Notification owner", "Status"], rows:) %>
 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -71,7 +71,7 @@
         accordion.with_section(heading_text: "Images (#{@product.virus_free_images.size})") do
           render("images", product: @product)
         end
-        accordion.with_section(heading_text: "Notifications (#{@product.unique_investigation_products.size})") do
+        accordion.with_section(heading_text: "Notifications (#{@product.get_investigations_count_for_display})") do
           render("cases", product: @product)
         end
       end

--- a/spec/features/product_summary_spec.rb
+++ b/spec/features/product_summary_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Product Summary", :with_opensearch, :with_stubbed_mailer, type: :feature do
+  let(:user) { create :user, :opss_user, :activated, has_viewed_introduction: true, roles: %w[notification_task_list_user] }
+  let!(:iphone) { create(:product_iphone, brand: "Apple", created_at: 1.day.ago, authenticity: "counterfeit") }
+  let!(:investigation) { create(:notification, products: [iphone], hazard_type: "Cuts") }
+  let!(:second_investigation) { create(:notification, products: [iphone], hazard_type: "Cuts") }
+
+  before do
+    sign_in(user)
+  end
+
+  context "when viewing the product summary page" do
+    scenario "with two notifications" do
+      visit products_path
+      expect(page).to have_content "There are currently 1 product."
+
+      visit "/products/#{iphone.id}"
+      expect(page).to have_text("This product record has been added to 2 notifications")
+
+      expect(page).to have_link(investigation.title, href: "/cases/#{investigation.pretty_id}")
+      expect(page).to have_link(investigation.title, href: "/cases/#{second_investigation.pretty_id}")
+    end
+
+    scenario "does not show draft notifications" do
+      create_a_draft_notification
+      visit "/notifications/your-notifications"
+
+      expect(page).to have_content("Draft notifications")
+      expect(page).to have_content("Fake name")
+      expect(page).to have_content(iphone.name)
+      visit "/products/#{iphone.id}"
+      expect(page).to have_text("This product record has been added to 2 notifications")
+    end
+  end
+
+  def create_a_draft_notification
+    visit "/notifications/create"
+
+    expect(page).to have_current_path(/\/notifications\/\d{4}-\d{4}\/create/)
+    click_link "Search for or add a product"
+
+    click_button "Select", match: :first
+
+    within_fieldset "Do you need to add another product?" do
+      choose "No"
+    end
+
+    click_button "Continue"
+
+    click_link "Add notification details"
+
+    add_notification_details
+  end
+
+  def add_notification_details
+    fill_in "Notification title", with: "Fake name"
+    fill_in "Notification summary", with: "This is a fake summary"
+    within_fieldset("Why are you creating the notification?") do
+      choose "A product is unsafe or non-compliant"
+    end
+    click_button "Save and continue"
+  end
+end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -98,14 +98,14 @@ RSpec.feature "Products listing", :with_stubbed_mailer, type: :feature do
       end
     end
 
-    context "when over 10k cases exist" do
+    context "when over 10k products exist" do
       before do
         not_retired_products_double = instance_double(ActiveRecord::Relation)
         allow(Product).to receive(:not_retired).and_return(not_retired_products_double)
         allow(not_retired_products_double).to receive(:count).and_return(10_001)
       end
 
-      it "shows total number of cases" do
+      it "shows total number of products" do
         visit products_path
         expect(page).to have_content "There are currently 10001 products."
       end


### PR DESCRIPTION
omit drafts from showing up on the products page