### PR TITLE
PSD-4705: prevent drafts from being accessed via URL

### DIFF
--- a/app/controllers/notifications/create_controller.rb
+++ b/app/controllers/notifications/create_controller.rb
@@ -1024,7 +1024,10 @@ module Notifications
     end
 
     def set_notification
-      @notification = Investigation::Notification.includes(:creator_user).where(pretty_id: params[:notification_pretty_id], creator_user: { id: current_user.id }).first!
+      @notification = Investigation::Notification.includes(:creator_user).find_by!(pretty_id: params[:notification_pretty_id])
+      unless policy(@notification).can_access_draft?
+        render "errors/forbidden", status: :forbidden
+      end
     end
 
     def disallow_changing_submitted_notification

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -10,7 +10,7 @@ class NotificationsController < ApplicationController
 
   # GET /notifications
   def index
-    # Find the most recent incomplete bulk products upload for the current user, if any
+    # Retrieve incomplete bulk products upload to allow users to continue their work
     @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil).order(updated_at: :desc).first
 
     @pagy, @answer  = pagy_searchkick(new_opensearch_for_investigations(20, paginate: true))
@@ -101,25 +101,16 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/:pretty_id
   def show
-    # Handle draft notifications
     if @notification.draft?
-      # If user doesn't have permission to access this draft, show forbidden error
-      unless policy(@notification).can_access_draft?
-        render "errors/forbidden", status: :forbidden
-        return
-      end
-
-      # If user has permission, redirect to the notification creation workflow
-      redirect_to notification_create_index_path(@notification)
+      handle_draft_notification
       return
     end
 
-    # For non-draft notifications, redirect to standard investigation path if user can't use notification task list
-    return redirect_to investigation_path(@notification) unless current_user.can_use_notification_task_list?
+    redirect_to investigation_path(@notification) and return unless current_user.can_use_notification_task_list?
 
     breadcrumb breadcrumb_case_label, breadcrumb_case_path
 
-    # Find the most recent incomplete bulk products upload for the current user and case, if any
+    # Retrieve incomplete bulk products upload to allow users to continue their work
     @incomplete_bulk_products_upload = BulkProductsUpload.where(user: current_user, submitted_at: nil, investigation: @notification).order(updated_at: :desc).first
   end
 
@@ -159,5 +150,14 @@ private
 
   def set_notification
     @notification = Investigation::Notification.includes(:creator_user, :creator_team, :owner_user, :owner_team, :comments).find_by!(pretty_id: params[:pretty_id])
+  end
+
+  def handle_draft_notification
+    unless policy(@notification).can_access_draft?
+      render "errors/forbidden", status: :forbidden
+      return
+    end
+
+    redirect_to notification_create_index_path(@notification)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -101,6 +101,20 @@ class NotificationsController < ApplicationController
 
   # GET /notifications/:pretty_id
   def show
+    # Handle draft notifications
+    if @notification.draft?
+      # If user doesn't have permission to access this draft, show forbidden error
+      unless policy(@notification).can_access_draft?
+        render "errors/forbidden", status: :forbidden
+        return
+      end
+
+      # If user has permission, redirect to the notification creation workflow
+      redirect_to notification_create_index_path(@notification)
+      return
+    end
+
+    # For non-draft notifications, redirect to standard investigation path if user can't use notification task list
     return redirect_to investigation_path(@notification) unless current_user.can_use_notification_task_list?
 
     breadcrumb breadcrumb_case_label, breadcrumb_case_path

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -87,4 +87,10 @@ class InvestigationPolicy < ApplicationPolicy
   def can_be_deleted?
     record.products.none?
   end
+
+  def can_access_draft?
+    return true unless record.is_a?(Investigation::Notification) && record.draft?
+
+    [record.creator_user, record.owner].include?(user)
+  end
 end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -1,13 +1,12 @@
 class InvestigationPolicy < ApplicationPolicy
-  # Ability to view the entire case including protected details
+  # Determines if the user has read-only access to the case
   def readonly?
     record.teams_with_read_only_access.include?(user.team)
   end
 
-  # Used for all updating of the case, including adding and removing related
-  # records, such as products, businesses and documents, with the exception of
-  # changing the notification owner, its status (eg 'open' or 'closed'), and whether
-  # or not it is 'restricted'.
+  # Determines if the user can update the case details and related records
+  # This includes adding/removing products, businesses, documents, etc.
+  # Does not include changing ownership, status, or restriction level
   def update?(user: @user)
     return false if record.is_closed? && !user.has_role?(:super_user)
 
@@ -18,14 +17,12 @@ class InvestigationPolicy < ApplicationPolicy
     record.draft? && (record.owner == user || user.has_role?(:super_user))
   end
 
-  # Ability to change the case owner, the status of the case (eg 'open' or 'closed'),
-  # and whether or not it is 'restricted'.
+  # Determines if the user can change case ownership, status, or restriction level
   def change_owner_or_status?(user: @user)
     record.owner.in_same_team_as?(user) || record.owner == user || user.has_role?(:super_user)
   end
 
-  # Ability to add and remove other teams as collaborators, and to set their
-  # permission levels.
+  # Determines if the user can manage team collaborations and permission levels
   def manage_collaborators?
     return false if record.is_closed?
     return false if record.owner.nil?
@@ -37,9 +34,8 @@ class InvestigationPolicy < ApplicationPolicy
     change_owner_or_status?(user:) && record.is_private? || user.has_role?(:super_user)
   end
 
-  # Ability to see most of the details of the case, with the exception of
-  # 'protected' details, such as personal contact details or correspondance
-  # with businesses.
+  # Determines if the user can view basic case details
+  # Protected details like personal contact info remain hidden
   def view_non_protected_details?(user: @user, private: @record.is_private)
     return true unless private
 
@@ -88,6 +84,8 @@ class InvestigationPolicy < ApplicationPolicy
     record.products.none?
   end
 
+  # Determines if the user can access a draft notification
+  # Only creators and owners can access draft notifications
   def can_access_draft?
     return true unless record.is_a?(Investigation::Notification) && record.draft?
 

--- a/spec/controllers/notifications/create_controller_spec.rb
+++ b/spec/controllers/notifications/create_controller_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe Notifications::CreateController, :with_stubbed_mailer, type: :controller do
+  let(:user) { create(:user, has_accepted_declaration: true, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let(:other_user) { create(:user, has_accepted_declaration: true, has_viewed_introduction: true, team: create(:team), roles: %w[notification_task_list_user]) }
+  let(:notification) { create(:notification, creator_user: user, owner_user: user, state: "draft") }
+
+  before do
+    sign_in(user)
+  end
+
+  describe "before_action :set_notification" do
+    context "when the notification is a draft" do
+      context "when the user is the creator" do
+        let(:notification) { create(:notification, creator_user: user, owner_user: user, state: "draft") }
+
+        before do
+          # Stub the find_by! method to return our notification
+          allow(Investigation::Notification).to receive_messages(includes: Investigation::Notification, find_by!: notification)
+
+          # Stub the policy to allow access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: true)
+          )
+
+          # Stub the draft? method to return true to avoid redirect in disallow_changing_submitted_notification
+          allow(notification).to receive(:draft?).and_return(true)
+        end
+
+        it "allows access to the index action" do
+          get :index, params: { notification_pretty_id: notification.pretty_id }
+          expect(response).to be_successful
+        end
+      end
+
+      context "when the user is the owner but not the creator" do
+        let(:notification) { create(:notification, creator_user: other_user, owner_user: user, state: "draft") }
+
+        before do
+          # Stub the find_by! method to return our notification
+          allow(Investigation::Notification).to receive_messages(includes: Investigation::Notification, find_by!: notification)
+
+          # Stub the policy to allow access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: true)
+          )
+
+          # Stub the draft? method to return true to avoid redirect in disallow_changing_submitted_notification
+          allow(notification).to receive(:draft?).and_return(true)
+        end
+
+        it "allows access to the index action" do
+          get :index, params: { notification_pretty_id: notification.pretty_id }
+          expect(response).to be_successful
+        end
+      end
+
+      context "when the user is neither the creator nor the owner" do
+        let(:notification) { create(:notification, creator_user: user, owner_user: user, state: "draft") }
+
+        before do
+          sign_in(other_user)
+
+          # Stub the find_by! method to return our notification
+          allow(Investigation::Notification).to receive_messages(includes: Investigation::Notification, find_by!: notification)
+
+          # Stub the policy to deny access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: false)
+          )
+
+          # Skip the disallow_changing_submitted_notification method to avoid double render
+          allow(controller).to receive(:disallow_changing_submitted_notification)
+        end
+
+        it "returns a forbidden status" do
+          get :index, params: { notification_pretty_id: notification.pretty_id }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "renders the forbidden error page" do
+          get :index, params: { notification_pretty_id: notification.pretty_id }
+          expect(response).to render_template("errors/forbidden")
+        end
+      end
+    end
+
+    context "when the notification is submitted" do
+      let(:notification) { create(:notification, creator_user: user, owner_user: user, state: "submitted") }
+
+      before do
+        # Stub the find_by! method to return our notification
+        allow(Investigation::Notification).to receive_messages(includes: Investigation::Notification, find_by!: notification)
+
+        # Stub the draft? method to return false to trigger redirect in disallow_changing_submitted_notification
+        allow(notification).to receive(:draft?).and_return(false)
+      end
+
+      it "redirects to the notification path" do
+        get :index, params: { notification_pretty_id: notification.pretty_id }
+        expect(response).to redirect_to(notification_path(notification))
+      end
+    end
+  end
+end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+RSpec.describe NotificationsController, :with_stubbed_mailer, type: :controller do
+  let(:user) { create(:user, has_accepted_declaration: true, has_viewed_introduction: true, roles: %w[notification_task_list_user]) }
+  let(:other_user) { create(:user, has_accepted_declaration: true, has_viewed_introduction: true, team: create(:team), roles: %w[notification_task_list_user]) }
+
+  before do
+    sign_in(user)
+  end
+
+  describe "GET #show" do
+    context "when the notification is a draft" do
+      let(:notification) { instance_double(Investigation::Notification, pretty_id: "1234", draft?: true) }
+
+      before do
+        allow(Investigation::Notification).to receive(:includes).and_return(Investigation::Notification)
+        allow(Investigation::Notification).to receive(:find_by!).with(pretty_id: notification.pretty_id).and_return(notification)
+      end
+
+      shared_examples "redirects to notification creation workflow" do
+        it "redirects to the notification creation workflow" do
+          # Stub the policy to allow access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: true)
+          )
+
+          get :show, params: { pretty_id: notification.pretty_id }
+          expect(response).to redirect_to(notification_create_index_path(notification))
+        end
+      end
+
+      context "when the user has access to the draft" do
+        # This covers both creator and owner cases
+        it_behaves_like "redirects to notification creation workflow"
+      end
+
+      context "when the user is neither the creator nor the owner" do
+        before do
+          sign_in(other_user)
+        end
+
+        it "returns a forbidden status" do
+          # Stub the policy to deny access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: false)
+          )
+
+          get :show, params: { pretty_id: notification.pretty_id }
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "renders the forbidden error page" do
+          # Stub the policy to deny access to draft
+          allow(controller).to receive(:policy).with(notification).and_return(
+            instance_double(InvestigationPolicy, can_access_draft?: false)
+          )
+
+          get :show, params: { pretty_id: notification.pretty_id }
+          expect(response).to render_template("errors/forbidden")
+        end
+      end
+    end
+
+    context "when the notification is submitted" do
+      # Use a regular double instead of instance_double to avoid method verification
+      let(:notification) { instance_double(Investigation::Notification, pretty_id: "1234", draft?: false) }
+      let(:relation_double) { instance_double(ActiveRecord::Relation, order: []) }
+
+      before do
+        allow(Investigation::Notification).to receive(:includes).and_return(Investigation::Notification)
+        allow(Investigation::Notification).to receive(:find_by!).with(pretty_id: notification.pretty_id).and_return(notification)
+        # Stub any methods that might be called on the notification
+        allow(notification).to receive_messages(
+          to_param: notification.pretty_id,
+          to_model: notification
+        )
+        allow(BulkProductsUpload).to receive(:where).and_return(relation_double)
+      end
+
+      it "renders the show template" do
+        allow(user).to receive(:can_use_notification_task_list?).and_return(true)
+
+        # Set up any additional stubs needed for the show action
+        allow(controller).to receive_messages(
+          breadcrumb_case_label: "Case",
+          breadcrumb_case_path: "/"
+        )
+
+        get :show, params: { pretty_id: notification.pretty_id }
+        expect(response).to be_successful
+      end
+
+      context "when the user cannot use notification task list" do
+        let(:non_task_list_user) { create(:user, has_accepted_declaration: true, has_viewed_introduction: true, roles: []) }
+
+        before do
+          sign_in(non_task_list_user)
+        end
+
+        it "redirects to the investigation path" do
+          # Ensure the current_user.can_use_notification_task_list? returns false
+          allow(non_task_list_user).to receive(:can_use_notification_task_list?).and_return(false)
+
+          get :show, params: { pretty_id: notification.pretty_id }
+          expect(response).to redirect_to(investigation_path(notification))
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/investigation_policy_can_access_draft_spec.rb
+++ b/spec/policies/investigation_policy_can_access_draft_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe InvestigationPolicy, :with_stubbed_mailer do
+  subject(:policy) { described_class.new(user, notification) }
+
+  let(:team) { create(:team) }
+  let(:user) { create(:user, team:) }
+  let(:creator_user) { create(:user, team:) }
+  let(:other_user) { create(:user, team: create(:team)) }
+
+  describe "#can_access_draft?" do
+    context "when the record is not a notification" do
+      let(:notification) { instance_double(Investigation::Allegation, is_a?: false) }
+
+      it "returns true" do
+        expect(policy.can_access_draft?).to be true
+      end
+    end
+
+    context "when the notification is not a draft" do
+      let(:notification) { instance_double(Investigation::Notification, is_a?: true, draft?: false) }
+
+      it "returns true" do
+        expect(policy.can_access_draft?).to be true
+      end
+    end
+
+    context "when the notification is a draft" do
+      context "when the user is the creator of the notification" do
+        let(:notification) { instance_double(Investigation::Notification, is_a?: true, draft?: true, creator_user: user, owner: nil) }
+
+        it "returns true" do
+          expect(policy.can_access_draft?).to be true
+        end
+      end
+
+      context "when the user is the owner of the notification" do
+        let(:notification) { instance_double(Investigation::Notification, is_a?: true, draft?: true, creator_user: creator_user, owner: user) }
+
+        it "returns true" do
+          expect(policy.can_access_draft?).to be true
+        end
+      end
+
+      context "when the user is neither the creator nor the owner" do
+        let(:notification) { instance_double(Investigation::Notification, is_a?: true, draft?: true, creator_user: creator_user, owner: creator_user) }
+        let(:user) { other_user }
+
+        it "returns false" do
+          expect(policy.can_access_draft?).to be false
+        end
+      end
+
+      context "when the user is a super user" do
+        let(:notification) { instance_double(Investigation::Notification, is_a?: true, draft?: true, creator_user: creator_user, owner: creator_user) }
+        let(:user) { create(:user, :super_user) }
+
+        it "returns false if they are not the creator or owner" do
+          expect(policy.can_access_draft?).to be false
+        end
+      end
+    end
+
+    context "when the notification transitions from draft to submitted" do
+      let(:notification) { create(:notification, creator_user:, state: "draft") }
+      let(:user) { creator_user }
+
+      it "allows access before and after submission" do
+        # Before submission (draft)
+        expect(policy.can_access_draft?).to be true
+
+        # After submission
+        notification.update!(state: "submitted")
+        expect(policy.can_access_draft?).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/investigation_policy_draft_access_spec.rb
+++ b/spec/policies/investigation_policy_draft_access_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe InvestigationPolicy, :with_stubbed_mailer do
+  describe "#can_access_draft?" do
+    let(:user) { create(:user) }
+    let(:policy) { described_class.new(user, notification) }
+
+    context "when the notification is not a draft" do
+      let(:notification) { instance_double(Investigation::Notification, draft?: false, is_a?: true) }
+
+      it "returns true" do
+        expect(policy.can_access_draft?).to be true
+      end
+    end
+
+    context "when the record is not a notification" do
+      let(:notification) { instance_double(Investigation, is_a?: false) }
+
+      it "returns true" do
+        expect(policy.can_access_draft?).to be true
+      end
+    end
+
+    context "when the notification is a draft" do
+      let(:notification) { instance_double(Investigation::Notification, draft?: true, is_a?: true, creator_user: creator_user, owner: owner) }
+      let(:creator_user) { nil }
+      let(:owner) { nil }
+
+      context "when the user is the creator" do
+        let(:creator_user) { user }
+
+        it "returns true" do
+          expect(policy.can_access_draft?).to be true
+        end
+      end
+
+      context "when the user is the owner" do
+        let(:owner) { user }
+
+        it "returns true" do
+          expect(policy.can_access_draft?).to be true
+        end
+      end
+
+      context "when the user is neither the creator nor the owner" do
+        let(:creator_user) { create(:user) }
+        let(:owner) { create(:user) }
+
+        it "returns false" do
+          expect(policy.can_access_draft?).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevents unauthorized access to draft notifications via direct URL

- Adds policy check to restrict draft notification access to creators and owners only
- Implements proper redirects and error handling for unauthorized access attempts
- Improves code readability with clean method extraction and better comments
- Adds comprehensive test coverage for all access scenarios