### PR TITLE
fix/psd-4840-fix_2fa_flipper_for_staging

### DIFF
--- a/spec/features/two_factor_authentication_flipper_spec.rb
+++ b/spec/features/two_factor_authentication_flipper_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "Two Factor Authentication Flipper", type: :feature do
   # Prevent configuration changes from leaking between tests
   after do
     Rails.application.config.instance_variable_set(:@secondary_authentication_enabled, nil)
+    # Clean up environment variables
+    ENV.delete("VCAP_APPLICATION")
   end
 
   # Reusable environment setup to avoid duplication
@@ -24,7 +26,14 @@ RSpec.describe "Two Factor Authentication Flipper", type: :feature do
     end
   end
 
-  describe "in staging environment" do
+  # Reusable context for CloudFoundry staging space
+  shared_context "when in CloudFoundry staging space" do
+    before do
+      ENV["VCAP_APPLICATION"] = '{"application_name":"psd-web","application_uris":["staging-product-safety-database.london.cloudapps.digital"],"name":"psd-web"}'
+    end
+  end
+
+  describe "in staging Rails environment" do
     include_context "when in staging environment"
 
     context "when the two_factor_authentication flipper is enabled" do
@@ -65,9 +74,73 @@ RSpec.describe "Two Factor Authentication Flipper", type: :feature do
     end
   end
 
+  describe "in production Rails environment but CloudFoundry staging space" do
+    before do
+      # Simulate production Rails environment
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+
+      # Simulate CloudFoundry staging space directly
+      ENV["VCAP_APPLICATION"] = '{"application_name":"psd-web","application_uris":["staging-product-safety-database.london.cloudapps.digital"],"name":"psd-web"}'
+    end
+
+    context "when setting up application config" do
+      # Helper to set up application config like in application.rb
+      def configure_for_cf_staging
+        # Detect if we're in the staging CloudFoundry space
+        staging_space = ENV["VCAP_APPLICATION"].to_s.include?("staging")
+
+        # Reset configuration
+        Rails.application.config.instance_variable_set(:@secondary_authentication_enabled, nil)
+
+        # Initial value
+        Rails.application.config.secondary_authentication_enabled = true
+
+        # Only apply Flipper override if in staging space
+        if Rails.env.staging? || (Rails.env.production? && staging_space)
+          class << Rails.application.config
+            def secondary_authentication_enabled
+              return true unless defined?(Flipper)
+
+              Flipper.enabled?(:two_factor_authentication)
+            end
+          end
+        else
+          Rails.application.config.secondary_authentication_enabled =
+            ENV.fetch("TWO_FACTOR_AUTHENTICATION_ENABLED", "true") == "true"
+        end
+      end
+
+      context "when the two_factor_authentication flipper is enabled" do
+        before do
+          configure_for_cf_staging
+          allow(Flipper).to receive(:enabled?).with(:two_factor_authentication).and_return(true)
+        end
+
+        it "enables secondary authentication" do
+          expect(Rails.application.config.secondary_authentication_enabled).to be true
+        end
+      end
+
+      context "when the two_factor_authentication flipper is disabled" do
+        before do
+          configure_for_cf_staging
+          allow(Flipper).to receive(:enabled?).with(:two_factor_authentication).and_return(false)
+        end
+
+        it "disables secondary authentication" do
+          expect(Rails.application.config.secondary_authentication_enabled).to be false
+        end
+      end
+    end
+  end
+
   describe "in non-staging environments" do
     before do
+      # Mock the Rails environment as production
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+
+      # Ensure we're not in CloudFoundry staging space
+      ENV["VCAP_APPLICATION"] = '{"application_name":"psd-web","application_uris":["product-safety-database.london.cloudapps.digital"],"name":"psd-web"}'
     end
 
     context "when TWO_FACTOR_AUTHENTICATION_ENABLED is true" do


### PR DESCRIPTION
## Changes:
- Detect CloudFoundry staging space via VCAP_APPLICATION env var
- Enable Flipper-based 2FA when either:
  - Rails.env is 'staging', OR
  - Rails.env is 'production' but we're in the staging space
- Ensure both Rails.configuration and Rails.application.config return the same values