### PR TITLE
feat/psd-4832-hard_delete_old_draft_notifications

### DIFF
--- a/app/jobs/hard_delete_draft_notifications_job.rb
+++ b/app/jobs/hard_delete_draft_notifications_job.rb
@@ -1,0 +1,7 @@
+class HardDeleteDraftNotificationsJob < ApplicationJob
+  def perform
+    return unless Flipper.enabled?(:submit_notification_reminder)
+
+    Investigation::Notification.hard_delete_old_drafts!
+  end
+end

--- a/app/jobs/soft_delete_draft_notifications_job.rb
+++ b/app/jobs/soft_delete_draft_notifications_job.rb
@@ -1,7 +1,0 @@
-class SoftDeleteDraftNotificationsJob < ApplicationJob
-  def perform
-    return unless Flipper.enabled?(:submit_notification_reminder)
-
-    Investigation::Notification.soft_delete_old_drafts!
-  end
-end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -66,24 +66,18 @@ class Investigation < ApplicationRecord
       AuditActivity::Investigation::AddCase
     end
 
-    def self.soft_delete_old_drafts!
-      Rails.logger.info "Starting to soft delete old draft notifications"
+    def self.hard_delete_old_drafts!
+      Rails.logger.info "Starting to hard delete old draft notifications"
       processed_count = 0
 
       old_drafts.find_each do |notification|
-        notification.mark_as_deleted!
-        notification.update!(deleted_by: "System")
-        AuditActivity::Investigation::AutomaticallyClosedCase.create!(
-          investigation: notification,
-          metadata: AuditActivity::Investigation::AutomaticallyClosedCase.build_metadata(notification)
-        )
-        notification.reindex
+        notification.destroy!
         processed_count += 1
       rescue StandardError => e
-        Rails.logger.error "Failed to soft delete notification #{notification.id}: #{e.message}"
+        Rails.logger.error "Failed to hard delete notification #{notification.id}: #{e.message}"
       end
 
-      Rails.logger.info "Completed soft deleting old draft notifications. Processed: #{processed_count}"
+      Rails.logger.info "Completed hard deleting old draft notifications. Processed: #{processed_count}"
     end
 
     def virus_free_images

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -31,9 +31,9 @@
     generate_rollups_job:
       cron: "45 23 * * *"
       class: "GenerateRollupsJob"
-    soft_delete_draft_notifications_job:
+    hard_delete_draft_notifications_job:
       cron: "30 1 * * *"
-      class: "SoftDeleteDraftNotificationsJob"
+      class: "HardDeleteDraftNotificationsJob"
     send_draft_notification_reminder_job:
       cron: "0 5 * * *"
-      class: "SendReminderEmailDraftNotificationsJob" 
+      class: "SendReminderEmailDraftNotificationsJob"

--- a/spec/jobs/hard_delete_draft_notifications_job_spec.rb
+++ b/spec/jobs/hard_delete_draft_notifications_job_spec.rb
@@ -1,30 +1,30 @@
 require "rails_helper"
 
-RSpec.describe SoftDeleteDraftNotificationsJob, type: :job do
+RSpec.describe HardDeleteDraftNotificationsJob, type: :job do
   describe "#perform" do
     subject(:job) { described_class.new }
 
     context "when the feature flag is disabled" do
       before do
         allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(false)
-        allow(Investigation::Notification).to receive(:soft_delete_old_drafts!)
+        allow(Investigation::Notification).to receive(:hard_delete_old_drafts!)
       end
 
-      it "does not call soft_delete_old_drafts!" do
+      it "does not call hard_delete_old_drafts!" do
         job.perform
-        expect(Investigation::Notification).not_to have_received(:soft_delete_old_drafts!)
+        expect(Investigation::Notification).not_to have_received(:hard_delete_old_drafts!)
       end
     end
 
     context "when the feature flag is enabled" do
       before do
         allow(Flipper).to receive(:enabled?).with(:submit_notification_reminder).and_return(true)
-        allow(Investigation::Notification).to receive(:soft_delete_old_drafts!)
+        allow(Investigation::Notification).to receive(:hard_delete_old_drafts!)
       end
 
-      it "calls soft_delete_old_drafts! on Investigation::Notification" do
+      it "calls hard_delete_old_drafts! on Investigation::Notification" do
         job.perform
-        expect(Investigation::Notification).to have_received(:soft_delete_old_drafts!)
+        expect(Investigation::Notification).to have_received(:hard_delete_old_drafts!)
       end
     end
   end

--- a/spec/models/investigation/notification_spec.rb
+++ b/spec/models/investigation/notification_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Investigation::Notification, :with_stubbed_antivirus, :with_stubb
     end
   end
 
-  describe ".soft_delete_old_drafts!" do
+  describe ".hard_delete_old_drafts!" do
     let(:user) { create(:user, :activated, :opss_user) }
     let(:old_draft) { create_notification(state: "draft", updated_at: 91.days.ago, pretty_id: "2024-0001") }
     let(:recent_draft) { create_notification(state: "draft", updated_at: 89.days.ago, pretty_id: "2024-0002") }
@@ -54,94 +54,29 @@ RSpec.describe Investigation::Notification, :with_stubbed_antivirus, :with_stubb
 
     before do
       allow(CreateNotification).to receive(:call).and_return(OpenStruct.new(success?: true))
-      allow(old_draft).to receive(:reindex)
       old_draft
+      recent_draft
+      old_submitted
     end
 
-    shared_examples "soft deletes old draft notifications" do
-      it "sets deleted_at" do
-        described_class.soft_delete_old_drafts!
-        expect(old_draft.reload.deleted_at).to be_present
-      end
+    it "permanently deletes old draft notifications" do
+      expect {
+        described_class.hard_delete_old_drafts!
+      }.to change(described_class, :count).by(-1)
 
-      it "sets deleted_by to 'System'" do
-        described_class.soft_delete_old_drafts!
-        expect(old_draft.reload.deleted_by).to eq("System")
-      end
+      expect { old_draft.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    shared_examples "preserves notifications" do |notification_type|
-      it "does not delete #{notification_type}" do
-        described_class.soft_delete_old_drafts!
-        notification = send(notification_type)
-        expect(notification.reload.deleted_at).to be_nil
-      end
+    it "preserves recent draft notifications" do
+      expect {
+        described_class.hard_delete_old_drafts!
+      }.not_to(change { recent_draft.reload.deleted_at })
     end
 
-    shared_examples "creates audit activity" do
-      it "creates an audit activity" do
-        expect { described_class.soft_delete_old_drafts! }
-          .to change(AuditActivity::Investigation::AutomaticallyClosedCase, :count).by(1)
-      end
-
-      it "links the audit activity to the notification" do
-        described_class.soft_delete_old_drafts!
-        activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
-        expect(activity.investigation).to eq(old_draft)
-      end
-
-      it "includes the notification ID in the audit activity metadata" do
-        described_class.soft_delete_old_drafts!
-        activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
-        expect(activity.metadata["notification_id"]).to eq(old_draft.id)
-      end
-
-      it "includes the closed_at timestamp in the audit activity metadata" do
-        freeze_time do
-          described_class.soft_delete_old_drafts!
-          activity = AuditActivity::Investigation::AutomaticallyClosedCase.last
-          expect(Time.zone.parse(activity.metadata["closed_at"].to_s)).to eq(Time.current)
-        end
-      end
-    end
-
-    include_examples "soft deletes old draft notifications"
-    include_examples "preserves notifications", :recent_draft
-    include_examples "preserves notifications", :old_submitted
-    include_examples "creates audit activity"
-
-    it "calls reindex on the notification" do
-      relation = instance_double(ActiveRecord::Relation)
-      allow(described_class).to receive(:old_drafts).and_return(relation)
-      allow(relation).to receive(:find_each).and_yield(old_draft)
-      allow(old_draft).to receive(:reindex)
-      described_class.soft_delete_old_drafts!
-      expect(old_draft).to have_received(:reindex).once
-    end
-
-    it "logs the number of processed notifications" do
-      allow(Rails.logger).to receive(:info)
-      described_class.soft_delete_old_drafts!
-      expect(Rails.logger).to have_received(:info).with("Starting to soft delete old draft notifications")
-      expect(Rails.logger).to have_received(:info).with("Completed soft deleting old draft notifications. Processed: 1")
-    end
-
-    context "when an error occurs" do
-      let(:error_message) { "Test error" }
-      let(:relation) { instance_double(ActiveRecord::Relation) }
-
-      before do
-        allow(Rails.logger).to receive(:error)
-        allow(Rails.logger).to receive(:info)
-        allow(described_class).to receive(:old_drafts).and_return(relation)
-        allow(relation).to receive(:find_each).and_yield(old_draft)
-        allow(old_draft).to receive(:mark_as_deleted!).and_raise(StandardError.new(error_message))
-      end
-
-      it "logs the error and continues processing" do
-        described_class.soft_delete_old_drafts!
-        expect(Rails.logger).to have_received(:error).with("Failed to soft delete notification #{old_draft.id}: #{error_message}")
-      end
+    it "preserves old submitted notifications" do
+      expect {
+        described_class.hard_delete_old_drafts!
+      }.not_to(change { old_submitted.reload.deleted_at })
     end
   end
 


### PR DESCRIPTION
## PSD-4832: Hard delete draft notifications older than 90 days

### What does this PR do?
Implements permanent (hard) deletion of draft notifications that haven't been touched for 90+ days, helping to keep the database clean and efficient. The new functionality:

- Adds a `hard_delete_old_drafts!` method to the `Investigation::Notification` model
- Creates a new `HardDeleteDraftNotificationsJob` scheduled to run daily at 2:30 AM
- Includes comprehensive test coverage

### Why?
While soft deletion (marking as deleted) was already in place, this change permanently removes old drafts from the database to reduce database size and improve performance.