### PR TITLE
fix/dbt-platform-compatibility

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,9 +114,13 @@ Rails.application.configure do
 
   # Connection setup (GOV PaaS)
   if ENV["VCAP_SERVICES"]
-    ENV["OPENSEARCH_URL"] = CF::App::Credentials.find_by_service_name("cosmetics-opensearch-1")["uri"]
-    ENV["DATABASE_URL"] = CF::App::Credentials.find_by_service_label("postgres")["uri"]
-    ENV["REDIS_URL"] = CF::App::Credentials.find_by_service_label("redis")["uri"]
+    opensearch_service = CF::App::Credentials.find_by_service_name("psd-opensearch-1")
+    postgres_service = CF::App::Credentials.find_by_service_label("postgres")
+    redis_service = CF::App::Credentials.find_by_service_label("redis")
+
+    ENV["OPENSEARCH_URL"] = opensearch_service["uri"] if opensearch_service
+    ENV["DATABASE_URL"] = postgres_service["uri"] if postgres_service
+    ENV["REDIS_URL"] = redis_service["uri"] if redis_service
   end
 
   # Connection setup (DBT Platform)


### PR DESCRIPTION
## Description
This PR fixes deployment issues with the platform compatibility changes:

1. Adds nil checks for service credentials to prevent NoMethodError when services are not found
2. Corrects the OpenSearch service name from "cosmetics-opensearch-1" to "psd-opensearch-1" to match what's defined in manifest.yml

This fixes the deployment error:

NoMethodError: undefined method `[]` for nil (NoMethodError)
ENV["OPENSEARCH_URL"] = CF::App::Credentials.find_by_service_name("cosmetics-opensearch-1")["uri"]

The code now safely handles cases where services aren't found, making it more robust and preventing deployment failures.
