### PR TITLE
fix/psd-4852-omit-draft-notifications-from-business-record-page

### DIFF
--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -34,6 +34,16 @@ class Business < ApplicationRecord
   redacted_export_with :id, :added_by_user_id, :company_number, :created_at,
                        :legal_name, :trading_name, :updated_at
 
+  def submitted_investigation_businesses
+    investigation_businesses.reject do |ib|
+      ib.investigation.is_a?(Investigation::Notification) && ib.investigation.state == "draft"
+    end
+  end
+
+  def submitted_notifications_count
+    submitted_investigation_businesses.count
+  end
+
   def supporting_information
     corrective_actions + risk_assessments
   end

--- a/app/views/businesses/show.html.erb
+++ b/app/views/businesses/show.html.erb
@@ -17,7 +17,7 @@
     tabs.with_tab(label: "Contacts (#{@business.contacts.count})") do
       render("businesses/tabs/contacts")
     end
-    tabs.with_tab(label: "Notifications (#{@business.investigations.count})") do
+    tabs.with_tab(label: "Notifications (#{@business.submitted_notifications_count})") do
       render("businesses/tabs/notifications")
     end
     tabs.with_tab(label: "Products (#{@business.investigation_products.count})") do

--- a/app/views/businesses/tabs/_notifications.html.erb
+++ b/app/views/businesses/tabs/_notifications.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Notifications</h2>
 <div style="text-align: left">
-  <% if @business.investigation_businesses.any? %>
-    <% @business.investigation_businesses.each do |investigation_business| %>
+  <% if @business.submitted_investigation_businesses.any? %>
+    <% @business.submitted_investigation_businesses.each do |investigation_business| %>
       <%=
         govuk_summary_list do |summary_list|
           investigation = investigation_business.investigation.decorate


### PR DESCRIPTION
## Description
This PR updates the business record page to only show submitted notifications and exclude draft notifications. It addresses the issue where draft notifications were being displayed on the business record page, causing confusion for users.

### Changes:
- Added a `submitted_investigation_businesses` method to the Business model to filter out draft notifications
- Added a `submitted_notifications_count` method to get the correct count for the tabs
- Updated the business record page to only display submitted notifications
- Updated the tab header to show the correct count of submitted notifications
- Added tests to verify these changes