### PR TITLE
chore/psd-redis-config-for-dbt-migration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,6 +121,10 @@ Rails.application.configure do
     ENV["OPENSEARCH_URL"] = opensearch_service["uri"] if opensearch_service
     ENV["DATABASE_URL"] = postgres_service["uri"] if postgres_service
     ENV["REDIS_URL"] = redis_service["uri"] if redis_service
+
+    # Set Redis URLs for session and queue services to support DBT platform migration
+    ENV["SESSION_URL"] ||= CF::App::Credentials.find_by_service_name("psd-session-6")["uri"] if CF::App::Credentials.find_by_service_name("psd-session-6")
+    ENV["QUEUE_URL"] ||= CF::App::Credentials.find_by_service_name("psd-queue-6")["uri"] if CF::App::Credentials.find_by_service_name("psd-queue-6")
   end
 
   # Connection setup (DBT Platform)

--- a/config/redis_session.yml
+++ b/config/redis_session.yml
@@ -9,4 +9,5 @@ test:
   <<: *default
 
 production:
-  <<: *default
+  url: <%= ENV['SESSION_URL'] %>
+  db: 1

--- a/config/redis_store.yml
+++ b/config/redis_store.yml
@@ -9,4 +9,5 @@ test:
   <<: *default
 
 production:
-  <<: *default
+  url: <%= ENV['QUEUE_URL'] %>
+  db: 0


### PR DESCRIPTION
# Redis Configuration Refactoring for DBT Platform Migration

## Summary
This PR refactors the Redis configuration to support the migration from GOV.UK PaaS to the DBT platform.

## Changes
- Added environment variable setup in production.rb to set `SESSION_URL` and `QUEUE_URL` based on GOV.UK PaaS Redis services
- Updated Redis configuration files to use these environment variables directly
- This ensures compatibility with both platforms during the migration process

## Benefits
- **Simplified Configuration**: Redis configuration files now use consistent environment variables
- **Centralized Platform Logic**: All platform-specific configuration happens in production.rb
- **Easier Migration**: No code changes will be needed when switching platforms
- **Cleaner Code**: Separation of concerns between platform detection and configuration usage

## Testing
- Tested with existing specs to ensure functionality is maintained
- Verified that the configuration works with the current GOV.UK PaaS setup

## Notes
This approach centralizes platform detection in production.rb and keeps the configuration files simple and consistent. When the application runs on GOV.UK PaaS, it will set `SESSION_URL` and `QUEUE_URL` based on the existing services, and the configuration files will use these variables. When the application runs on the DBT platform, these variables will be set directly by the platform, and the configuration files will use them without any changes.