### PR TITLE
fix/psd-5101-update_av_code

### DIFF
--- a/spec/support/antivirus.rb
+++ b/spec/support/antivirus.rb
@@ -1,7 +1,7 @@
 RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
   before do
-    antivirus_url = Rails.application.config.antivirus_url
-    stubbed_response = JSON.generate(safe: true)
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+    stubbed_response = JSON.generate(infected: false)
     stub_request(
       :any, /#{Regexp.quote(antivirus_url)}/
     ).to_return(
@@ -14,8 +14,8 @@ end
 
 RSpec.shared_context "with stubbed failing Antivirus API", shared_context: :metadata do
   before do
-    antivirus_url = Rails.application.config.antivirus_url
-    stubbed_response = JSON.generate(safe: false)
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+    stubbed_response = JSON.generate(infected: true)
     stub_request(
       :any, /#{Regexp.quote(antivirus_url)}/
     ).to_return(


### PR DESCRIPTION
# Update to ClamAV REST Integration

## What

Updated our antivirus scanning to use the recommended `/v2/scan-chunked` endpoint from the dit-clamav-rest service.

## Changes

* Modified `AntiVirusAnalyzer` to use the correct endpoint, headers, and content format
* Updated response handling to parse JSON response properly
* Fixed and expanded tests to verify correct behavior

## Why

Improves virus scanning efficiency, especially for larger files, by using the recommended API endpoint.

## Related PR

This implements the same changes that were made in the SCPN repository (PR #3580).