### PR TITLE
fix/psd-5101-av-code-update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "jsbundling-rails"
 gem "mini_magick"
 gem "opensearch-ruby"
 gem "phonelib", "~> 0.10.6"
+gem "rest-client", "~> 2.1"
 
 # ActionMailer dependencies
 gem "net-imap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,7 @@ GEM
       devise (>= 4.3.0)
     diff-lcs (1.6.1)
     docile (1.4.1)
+    domain_name (0.6.20240107)
     dotenv (3.1.7)
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
@@ -311,6 +312,9 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -373,6 +377,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.2)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0402)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -393,6 +401,7 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
@@ -538,6 +547,11 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     reverse_markdown (3.0.0)
       nokogiri
     rexml (3.4.1)
@@ -860,6 +874,7 @@ DEPENDENCIES
   redcarpet (~> 3.6)
   redis-rails (~> 5.0)
   report_portal!
+  rest-client (~> 2.1)
   rollups
   roo (~> 2.10)
   rspec

--- a/spec/support/antivirus.rb
+++ b/spec/support/antivirus.rb
@@ -1,28 +1,32 @@
 RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
   before do
     antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
-    stubbed_response = JSON.generate(infected: false)
-    stub_request(
-      :any, /#{Regexp.quote(antivirus_url)}/
-    ).to_return(
-      body: stubbed_response,
-      status: 200,
-      headers: { "Content-Type" => "application/json" }
-    )
+
+    # For clamav-rest API, the opposite of "safe: true" is "malware: false"
+    stubbed_response = '{"malware": false, "reason": null, "time": 0.001}'
+
+    stub_request(:post, /#{Regexp.quote(antivirus_url)}/)
+      .to_return(
+        body: stubbed_response,
+        status: 200,
+        headers: { "Content-Type" => "application/json" }
+      )
   end
 end
 
 RSpec.shared_context "with stubbed failing Antivirus API", shared_context: :metadata do
   before do
     antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
-    stubbed_response = JSON.generate(infected: true)
-    stub_request(
-      :any, /#{Regexp.quote(antivirus_url)}/
-    ).to_return(
-      body: stubbed_response,
-      status: 200,
-      headers: { "Content-Type" => "application/json" }
-    )
+
+    # For clamav-rest API, this would be "malware: true"
+    stubbed_response = '{"malware": true, "reason": "Test-Virus-Found", "time": 0.001}'
+
+    stub_request(:post, /#{Regexp.quote(antivirus_url)}/)
+      .to_return(
+        body: stubbed_response,
+        status: 200,
+        headers: { "Content-Type" => "application/json" }
+      )
   end
 end
 


### PR DESCRIPTION
# PSD-5101: Update antivirus analyzer to match SCPN implementation

## Summary
This PR fixes issues with the antivirus scanning functionality by updating the implementation to match the proven approach used in the SCPN application.

## Changes
- Replace Net::HTTP implementation with RestClient in AntiVirusAnalyzer
- Update API request format to match the expected format of the antivirus service
- Enhance error handling and logging for better diagnostics
- Add `rest-client` gem dependency
- Add diagnostic rake tasks for testing antivirus functionality

## Testing
This change has been tested locally by:
1. Running the AntiVirusAnalyzer on existing blobs
2. Verifying that the proper API requests are made to the antivirus service
3. Confirming correct handling of API responses

## Deployment Notes
Since this adds a new gem dependency, it will require a full deployment with bundle install.

## Related PRs
References [SCPN PR #3580](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/3580) which implemented a similar fix.