### PR TITLE
fix/psd-3719-alert-for-image-opening-in-new-window

### DIFF
--- a/app/views/notifications/add_supporting_images/add_supporting_images.html.erb
+++ b/app/views/notifications/add_supporting_images/add_supporting_images.html.erb
@@ -20,14 +20,15 @@
       <%= f.hidden_field :file_upload, value: "" %>
       <%= f.govuk_file_field :file_upload, label: nil, hint: { text: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF. Maximum file size: 100MB." } %>
       <%= f.govuk_submit "Upload image", secondary: true %>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
       <% if @notification.image_uploads.present? %>
+        <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-2 govuk-!-text-align-right">View link will open image in a new browser tab</p>
         <%=
           govuk_summary_list do |summary_list|
             @notification.image_uploads.each do |image_upload|
               summary_list.with_row do |row|
                 row.with_key(text: sanitize(image_upload.file_upload.filename.to_s))
-                row.with_action(text: "View", href: url_for(image_upload.file_upload), visually_hidden_text: "supporting image", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
+                row.with_action(text: "View", href: url_for(image_upload.file_upload), visually_hidden_text: "supporting image (opens in new tab)", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
                 row.with_action(text: "Remove", href: remove_upload_notification_add_supporting_images_path(@notification, image_upload), visually_hidden_text: "supporting image")
               end
             end

--- a/app/views/notifications/create/add_supporting_images.html.erb
+++ b/app/views/notifications/create/add_supporting_images.html.erb
@@ -20,14 +20,15 @@
       <%= f.hidden_field :file_upload, value: "" %>
       <%= f.govuk_file_field :file_upload, label: nil, hint: { text: "Acceptable file formats: GIF, JPEG, PNG, WEBP or HEIC/HEIF. Maximum file size: 100MB." } %>
       <%= f.govuk_submit "Upload image", secondary: true %>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
       <% if @notification.image_uploads.present? %>
+        <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-2 govuk-!-text-align-right">View link will open image in a new browser tab</p>
         <%=
           govuk_summary_list do |summary_list|
             @notification.image_uploads.each do |image_upload|
               summary_list.with_row do |row|
                 row.with_key(text: sanitize(image_upload.file_upload.filename.to_s))
-                row.with_action(text: "View", href: url_for(image_upload.file_upload), visually_hidden_text: "supporting image", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
+                row.with_action(text: "View", href: url_for(image_upload.file_upload), visually_hidden_text: "supporting image (opens in new tab)", html_attributes: { target: "_blank", rel: "noreferrer noopener" })
                 row.with_action(text: "Remove", href: remove_upload_notification_create_index_path(@notification, step: "add_supporting_images", upload_id: image_upload.id), visually_hidden_text: "supporting image")
               end
             end

--- a/spec/requests/notifications/add_supporting_images_spec.rb
+++ b/spec/requests/notifications/add_supporting_images_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe "Supporting Images Management", :with_stubbed_antivirus, :with_st
       get notification_add_supporting_images_path(notification_pretty_id: notification.pretty_id)
       expect(response).to render_template("notifications/add_supporting_images/add_supporting_images")
     end
+
+    it "displays information alert when images are present" do
+      upload_test_image
+      get notification_add_supporting_images_path(notification_pretty_id: notification.pretty_id)
+
+      expect(response.body).to include("View link will open image in a new browser tab")
+    end
   end
 
   describe "POST /notifications/:pretty_id/add-supporting-images" do


### PR DESCRIPTION
# PR Description

## PSD-3719: Add alert when an image opens in a new window

This PR adds an informational message indicating that the 'View' link will open images in a new browser tab. This change addresses accessibility requirements (WCAG 3.2.2 Level A) by alerting users before opening content in a new window.

Changes include:
- Added an informational text above the image list in both supporting image pages
- Added "opens in new tab" to the visually hidden text for screen readers
- Styled the informational text to be right-aligned and properly spaced according to GOV.UK design guidelines
- Added relevant tests

This addresses the bug report SI_33 where assistive technology users were not being informed when an image would open in a new window.