### PR TITLE
feat/psd-4892-disable-editing-product-category

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -138,11 +138,18 @@ private
   end
 
   def product_params_for_update
-    params.require(:product).permit(
-      :category, :subcategory, :product_code,
-      :webpage, :description, :country_of_origin, :barcode,
-      :when_placed_on_market, :has_markings, markings: []
-    )
+    if Flipper.enabled?(:new_taxonomy)
+      params.require(:product).permit(
+        :product_code, :webpage, :description, :country_of_origin, :barcode,
+        :when_placed_on_market, :has_markings, markings: []
+      )
+    else
+      params.require(:product).permit(
+        :category, :subcategory, :product_code,
+        :webpage, :description, :country_of_origin, :barcode,
+        :when_placed_on_market, :has_markings, markings: []
+      )
+    end
   end
 
   def query_params

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -126,6 +126,7 @@ private
 
   def valid_category
     return unless Flipper.enabled?(:new_taxonomy)
+    return unless id.nil? # don't validate for editing since fields are disabled and not saved
     return if ProductCategory.pluck(:name).include?(category)
 
     errors.add(:category, :inclusion)
@@ -133,6 +134,7 @@ private
 
   def valid_subcategory
     return unless Flipper.enabled?(:new_taxonomy)
+    return unless id.nil? # don't validate for editing since fields are disabled and not saved
     return if category.blank?
     return if ProductSubcategory.joins(:product_category).where(product_category: { name: category }).pluck(:name).include?(subcategory)
 

--- a/app/javascript/products/product_category_conditional_select.js
+++ b/app/javascript/products/product_category_conditional_select.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const parentElement = document.querySelector('#product-category-field, #product-category-field-error, #product-recall-form-product-type-field, #product-recall-form-product-type-field-error')
   const childElement = document.querySelector('#product-subcategory-field, #product-subcategory-field-error, #product-recall-form-subcategory-field, #product-recall-form-subcategory-field-error')
 
-  if (parentElement && childElement) {
+  if (parentElement && childElement && !parentElement.disabled && !childElement.disabled) {
     // Get a list of all product subcategories and their parent product categories
     // from the API - this happens once per page load of a relevant page
     const productSubcategoriesApi = await fetch('/api/v1/products/product_subcategories')

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -10,10 +10,17 @@
 <% subcategory_items = [OpenStruct.new(value: "", text: "")] + @product_subcategories.map { |x| OpenStruct.new(value: x, text: x) } %>
 
 <% if Flipper.enabled?(:new_taxonomy) %>
-  <%= form.govuk_collection_select :category, category_items, :value, :text, label: { text: "Main category", size: "m" }, hint: { text: category_hint }, disabled: local_assigns[:is_not_allowed], "aria-controls": "product-category-conditional" %>
-  <div class="opss-select__conditional govuk-radios__conditional" id="product-category-conditional">
-    <%= form.govuk_collection_select :subcategory, subcategory_items, :value, :text, label: { text: "Sub-category", size: "m" }, hint: { text: "Filtered by your main category selection" }, disabled: local_assigns[:is_not_allowed] %>
-  </div>
+  <% if local_assigns[:is_not_allowed] %>
+    <%= form.govuk_text_field :category, label: { text: "Main category", size: "m" }, disabled: true %>
+    <div class="govuk-radios__conditional">
+      <%= form.govuk_text_field :subcategory, label: { text: "Sub-category", size: "m" }, disabled: true %>
+    </div>
+  <% else %>
+    <%= form.govuk_collection_select :category, category_items, :value, :text, label: { text: "Main category", size: "m" }, hint: { text: category_hint }, "aria-controls": "product-category-conditional" %>
+    <div class="opss-select__conditional govuk-radios__conditional" id="product-category-conditional">
+      <%= form.govuk_collection_select :subcategory, subcategory_items, :value, :text, label: { text: "Sub-category", size: "m" }, hint: { text: "Filtered by your main category selection" } %>
+    </div>
+  <% end %>
 <% else %>
   <%= form.govuk_collection_select :category, category_items, :value, :text, label: { text: "Product category", size: "m" }, hint: { text: category_hint }, disabled: local_assigns[:is_not_allowed] %>
   <%= form.govuk_text_field :subcategory, label: { text: "Product subcategory", size: "m" }, hint: { text: "For example, 'Face mask' or 'Washing machine'" } %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -15,17 +15,19 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% not_allowed = if @product.owning_team == nil
-                          false
-                        elsif @product.owning_team == current_user.team
-                          false
-                        elsif current_user.is_superuser?
-                          false
-                        else
-                          true
-                        end
+      <% not_allowed = if Flipper.enabled?(:new_taxonomy)
+                         true # disallow editing category/subcategory for new flow
+                       elsif @product.owning_team == nil
+                         false
+                       elsif @product.owning_team == current_user.team
+                         false
+                       elsif current_user.is_superuser?
+                         false
+                       else
+                         true
+                       end
       %>
-      <%= render "form", form: form, product_form: @product_form, countries: @countries, search: false, disable_permanent_fields: true,  disable_image_upload: true, is_not_allowed: not_allowed %>
+      <%= render "form", form: form, product_form: @product_form, countries: @countries, search: false, disable_permanent_fields: true, disable_image_upload: true, is_not_allowed: not_allowed %>
     </div>
   </div>
 <% end %>

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Editing a product", :with_opensearch, :with_product_form_helper, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Editing a product", :with_flipper, :with_opensearch, :with_product_form_helper, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:product_code)      { Faker::Barcode.issn }
   let(:webpage)           { Faker::Internet.url }
   let(:user)              { create(:user, :activated, has_viewed_introduction: true) }
@@ -235,6 +235,20 @@ RSpec.feature "Editing a product", :with_opensearch, :with_product_form_helper, 
     it "informs the user" do
       visit edit_product_path(product)
       expect(page).to have_content("The original record was recorded as 'unsure'")
+    end
+  end
+
+  context "when using the new taxonomy" do
+    before do
+      create(:product_subcategory, name: product.subcategory, product_category: create(:product_category, name: product.category))
+      enable_feature(:new_taxonomy)
+      sign_in user
+    end
+
+    it "disallows editing the category and sub-category" do
+      visit edit_product_path(product)
+      expect(page).to have_field("Main category", with: product.category, disabled: true)
+      expect(page).to have_field("Sub-category", with: product.subcategory, disabled: true)
     end
   end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-4892

## Description

Disables editing the product category and sub-category for the new taxonomy post product creation.

## Screen-shots or screen-capture of UI changes

![Screenshot 2025-04-28 at 14 29 39](https://github.com/user-attachments/assets/3e7a3fa2-3ad8-4915-8cbb-fce85fb2949b)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
