### PR TITLE
chore/psd-5202-create_copilot_secrets_update_yml

### DIFF
--- a/.github/workflows/copilot-secrets-update.yml
+++ b/.github/workflows/copilot-secrets-update.yml
@@ -1,0 +1,151 @@
+name: Update AWS Copilot Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to update secrets for (staging, uat, prod)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - uat
+          - prod
+
+jobs:
+  update-secrets:
+    name: Update Copilot Secrets for ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          # Use the appropriate role based on environment
+          role-to-assume: ${{ github.event.inputs.environment == 'prod' && 'arn:aws:iam::971422706584:role/GithubActionsRole' || 'arn:aws:iam::816069161783:role/GithubActionsRole' }}
+          role-duration-seconds: 900
+
+      - name: Install AWS Copilot CLI
+        run: |
+          curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x copilot
+          sudo mv ./copilot /usr/local/bin/copilot
+          copilot --version
+
+      # Update secrets for the selected environment using copilot secret init
+      - name: Update Secrets for ${{ github.event.inputs.environment }}
+        env:
+          APP_NAME: psd
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
+        run: |
+          echo "Updating secrets for $ENVIRONMENT environment..."
+
+          # Core application secrets
+          echo "Updating core application secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SECRET_KEY_BASE --value $(openssl rand -hex 64)
+
+          # Database and session secrets
+          echo "Updating database and session secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name DATABASE_URL --value "${{ secrets[format('{0}_DATABASE_URL', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name REDIS_URL --value "${{ secrets[format('{0}_REDIS_URL', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SESSION_URL --value "${{ secrets[format('{0}_SESSION_URL', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name QUEUE_URL --value "${{ secrets[format('{0}_QUEUE_URL', github.event.inputs.environment)] }}"
+
+          # Search service secrets
+          echo "Updating search service secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name OPENSEARCH_URL --value "${{ secrets[format('{0}_OPENSEARCH_URL', github.event.inputs.environment)] }}"
+
+          # Notification secrets
+          echo "Updating notification secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name NOTIFY_API_KEY --value "${{ secrets[format('{0}_NOTIFY_API_KEY', github.event.inputs.environment)] }}"
+
+          # Authentication and security secrets
+          echo "Updating authentication and security secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name KEYCLOAK_AUTH_URL --value "${{ secrets[format('{0}_KEYCLOAK_AUTH_URL', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name KEYCLOAK_CLIENT_ID --value "${{ secrets[format('{0}_KEYCLOAK_CLIENT_ID', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name KEYCLOAK_CLIENT_SECRET --value "${{ secrets[format('{0}_KEYCLOAK_CLIENT_SECRET', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name KEYCLOAK_REDIRECT_URI --value "${{ secrets[format('{0}_KEYCLOAK_REDIRECT_URI', github.event.inputs.environment)] }}"
+
+          # S3 bucket secrets
+          echo "Updating S3 bucket secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name AWS_S3_BUCKET --value "${{ secrets[format('{0}_AWS_S3_BUCKET', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name AWS_ACCESS_KEY_ID --value "${{ secrets[format('{0}_AWS_ACCESS_KEY_ID', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name AWS_SECRET_ACCESS_KEY --value "${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name AWS_REGION --value "${{ secrets[format('{0}_AWS_REGION', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name AWS_ACCOUNT_ID --value "${{ secrets[format('{0}_AWS_ACCOUNT_ID', github.event.inputs.environment)] }}"
+
+          # Antivirus secrets
+          echo "Updating antivirus secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name ANTIVIRUS_URL --value "${{ secrets[format('{0}_ANTIVIRUS_URL', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name ANTIVIRUS_USERNAME --value "${{ secrets[format('{0}_ANTIVIRUS_USERNAME', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name ANTIVIRUS_PASSWORD --value "${{ secrets[format('{0}_ANTIVIRUS_PASSWORD', github.event.inputs.environment)] }}"
+
+          # Admin access secrets
+          echo "Updating admin access secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name HEALTH_CHECK_USERNAME --value "${{ secrets[format('{0}_HEALTH_CHECK_USERNAME', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name HEALTH_CHECK_PASSWORD --value "${{ secrets[format('{0}_HEALTH_CHECK_PASSWORD', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name PGHERO_USERNAME --value "${{ secrets[format('{0}_PGHERO_USERNAME', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name PGHERO_PASSWORD --value "${{ secrets[format('{0}_PGHERO_PASSWORD', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SIDEKIQ_USERNAME --value "${{ secrets[format('{0}_SIDEKIQ_USERNAME', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SIDEKIQ_PASSWORD --value "${{ secrets[format('{0}_SIDEKIQ_PASSWORD', github.event.inputs.environment)] }}"
+
+          # Monitoring and reporting secrets
+          echo "Updating monitoring and reporting secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SCOUT_KEY --value "${{ secrets[format('{0}_SCOUT_KEY', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SENTRY_DSN --value "${{ secrets[format('{0}_SENTRY_DSN', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SENTRY_CSP_REPORT_URI --value "${{ secrets[format('{0}_SENTRY_CSP_REPORT_URI', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name SENTRY_CURRENT_ENV --value "${{ secrets[format('{0}_SENTRY_CURRENT_ENV', github.event.inputs.environment)] }}"
+
+          # Host configuration secrets
+          echo "Updating host configuration secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name PSD_HOST --value "${{ secrets[format('{0}_PSD_HOST', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name PSD_HOST_REPORT --value "${{ secrets[format('{0}_PSD_HOST_REPORT', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name PSD_HOST_SUPPORT --value "${{ secrets[format('{0}_PSD_HOST_SUPPORT', github.event.inputs.environment)] }}"
+
+          # Redacted Export configuration
+          echo "Updating redacted export configuration..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name REDACTED_EXPORT_BUCKET --value "${{ secrets[format('{0}_REDACTED_EXPORT_BUCKET', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name REDACTED_EXPORT_ROLE_ARN --value "${{ secrets[format('{0}_REDACTED_EXPORT_ROLE_ARN', github.event.inputs.environment)] }}"
+
+          # Feature flag secrets
+          echo "Updating feature flag secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name TWO_FACTOR_AUTHENTICATION_ENABLED --value "${{ secrets[format('{0}_TWO_FACTOR_AUTHENTICATION_ENABLED', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name EMAIL_WHITELIST_ENABLED --value "${{ secrets[format('{0}_EMAIL_WHITELIST_ENABLED', github.event.inputs.environment)] }}"
+
+          # Performance configuration secrets
+          echo "Updating performance configuration secrets..."
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name RAILS_MAX_THREADS --value "${{ secrets[format('{0}_RAILS_MAX_THREADS', github.event.inputs.environment)] }}"
+          copilot secret init --app $APP_NAME --env $ENVIRONMENT --name STATEMENT_TIMEOUT --value "${{ secrets[format('{0}_STATEMENT_TIMEOUT', github.event.inputs.environment)] }}"
+
+      - name: Verify Secrets
+        env:
+          APP_NAME: psd
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
+        run: |
+          # List secrets to verify they were added correctly
+          echo "Listing secrets for $ENVIRONMENT environment:"
+          copilot secret list --app $APP_NAME --env $ENVIRONMENT
+
+          echo "Secrets updated successfully for $ENVIRONMENT environment."
+
+      - name: Notify success via Slack
+        if: success()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST --data-urlencode "payload={\"channel\": \"#alerts\", \"username\": \"secretsbot\", \"text\": \"Successfully updated secrets for ${{ github.event.inputs.environment }}!\", \"icon_emoji\": \":lock:\"}" $SLACK_WEBHOOK
+
+      - name: Notify failure via Slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST --data-urlencode "payload={\"channel\": \"#alerts\", \"username\": \"secretsbot\", \"text\": \"Failed to update secrets for ${{ github.event.inputs.environment }}!\n\nSee ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\", \"icon_emoji\": \":rotating_light:\"}" $SLACK_WEBHOOK


### PR DESCRIPTION
# Create copilot-secrets-update.yml file for staging, UAT and prod

## Ticket: PSD-5202

## Description
This PR adds a new GitHub workflow file `copilot-secrets-update.yml` that automates the process of updating AWS Copilot secrets for the PSD application across staging, UAT, and production environments.

The workflow:
- Can be manually triggered with environment selection
- Updates all application secrets in the selected environment
- Configures appropriate AWS credentials and IAM roles
- Includes all necessary environment variables from the current Gov PaaS deployment
- Provides notification via Slack on completion or failure

## Changes
- Created `.github/workflows/copilot-secrets-update.yml` with a comprehensive list of environment variables

## Testing
The workflow has been set up with appropriate conditionals for each environment. Will require manual testing once merged by triggering the workflow for each environment.

## Checklist
- [x] Added new workflow file for secret management
- [x] Included all necessary application environment variables
- [x] Configured appropriate IAM roles for different environments
- [x] Added Slack notifications for workflow results