### PR TITLE
bug/psd-5581-fixes-for-psd-5034

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -2,7 +2,7 @@
 <%
   category_hint = if @taxonomy_export_file_details.present?
     link = link_to "Download a full list of main and sub-categories", @taxonomy_export_file_details[:path], class: "govuk-link", rel: "noreferrer noopener", target: "_blank"
-    "#{link}. Updated #{@taxonomy_export_file_details[:updated_at].strftime("%d %B %Y")}.<br>Please ensure you are viewing the latest version of the full category list.<br><br>Once you select the main category, you will be able to select a related sub-category.".html_safe
+    "Updated #{@taxonomy_export_file_details[:updated_at].strftime("%d %B %Y")}. #{link}.<br>Please ensure you are viewing the latest version of the full category list.<br><br>Once you select the main category, you will be able to select a related sub-category.".html_safe
   else
     "Select a category from the drop down"
   end

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -352,7 +352,7 @@ RSpec.feature "Adding a product", :with_flipper, :with_product_form_helper, :wit
 
       it "links to the file" do
         expect(page).to have_link("Download a full list of main and sub-categories", href: Rails.application.routes.url_helpers.rails_storage_proxy_path(product_taxonomy_import.export_file, only_path: true))
-        expect(page).to have_selector("#product-category-hint", text: "Download a full list of main and sub-categories. Updated #{Time.zone.now.strftime('%d %B %Y')}.Please ensure you are viewing the latest version of the full category list.Once you select the main category, you will be able to select a related sub-category.")
+        expect(page).to have_selector("#product-category-hint", text: "Updated #{Time.zone.now.strftime('%d %B %Y')}. Download a full list of main and sub-categories.Please ensure you are viewing the latest version of the full category list.Once you select the main category, you will be able to select a related sub-category.")
       end
     end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5581

## Description

Changes the order of the hint text for main category when adding a new product.

## Screen-shots or screen-capture of UI changes

### Before

<img width="641" alt="Screenshot 2025-04-30 at 15 33 08" src="https://github.com/user-attachments/assets/a749c6d8-e3fd-4e2f-8b5a-aeb24e2e4521" />

### After

<img width="637" alt="Screenshot 2025-04-30 at 15 33 32" src="https://github.com/user-attachments/assets/baa8b6b3-a44c-4090-9f3a-5bb6eafbc31b" />

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
