### PR TITLE
bug/psd-5582-fixes-for-psd-4854

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -36,6 +36,8 @@ class ProductForm
   before_validation { nilify_blanks(:barcode, :brand) }
 
   validates :category, :subcategory, presence: true, unless: -> { Flipper.enabled?(:new_taxonomy) }
+  validate :valid_category
+  validate :valid_subcategory
   validates :authenticity, inclusion: { in: Product.authenticities.keys }
   validates :has_markings, inclusion: { in: Product.has_markings.keys }
   validates :name, presence: true
@@ -44,8 +46,6 @@ class ProductForm
   validates :barcode, allow_nil: true, length: { minimum: 5, maximum: 15 }, if: -> { barcode =~ /\A\d+\z/ }
   validates :country_of_origin, presence: true
   validates :description, length: { maximum: 10_000 }
-  validate :valid_category
-  validate :valid_subcategory
   validate :acceptable_image
 
   validate :markings_validity, if: -> { has_markings == "markings_yes" }

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -107,13 +107,13 @@ RSpec.feature "Adding a product", :with_flipper, :with_product_form_helper, :wit
       # Expected validation errors
       expect(page).to have_error_messages
       errors_list = page.find(".govuk-error-summary__list").all("li")
-      expect(errors_list[0].text).to eq "You must state whether the product is a counterfeit"
-      expect(errors_list[1].text).to eq "Select yes if the product has UKCA, UKNI or CE marking"
-      expect(errors_list[2].text).to eq "Name cannot be blank"
-      expect(errors_list[3].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
-      expect(errors_list[4].text).to eq "Enter a valid barcode number"
-      expect(errors_list[5].text).to eq "Country of origin cannot be blank"
-      expect(errors_list[6].text).to eq "Select the main category"
+      expect(errors_list[0].text).to eq "Select the main category"
+      expect(errors_list[1].text).to eq "You must state whether the product is a counterfeit"
+      expect(errors_list[2].text).to eq "Select yes if the product has UKCA, UKNI or CE marking"
+      expect(errors_list[3].text).to eq "Name cannot be blank"
+      expect(errors_list[4].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
+      expect(errors_list[5].text).to eq "Enter a valid barcode number"
+      expect(errors_list[6].text).to eq "Country of origin cannot be blank"
 
       select attributes[:category], from: "Main category"
       select attributes[:subcategory], from: "Sub-category"


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5582

## Description

Fixes the ordering of error message on the add product page to match the order of the form elements.

## Screen-shots or screen-capture of UI changes

### Before

<img width="1512" alt="Screenshot 2025-04-30 at 15 37 17" src="https://github.com/user-attachments/assets/bbfb7d4b-3fea-4f0b-80dc-9e57439c3030" />

### After

<img width="1512" alt="Screenshot 2025-04-30 at 15 37 33" src="https://github.com/user-attachments/assets/05ea9b20-3f2a-4dce-96ab-aeb5dc243407" />

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
