### PR TITLE
fix/psd-5603-remove_non_json_prefix_from_asim_logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ require "action_cable/engine"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 require_relative "../lib/formatters/asim_formatter"
+require_relative "../lib/formatters/json_formatter"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -51,7 +52,9 @@ module ProductSafetyDatabase
     if ENV["ENABLE_ASIM_LOGGER"] == "true"
       config.lograge.enabled = true
       config.lograge.formatter = Formatters::AsimFormatter.new
-      config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stdout))
+      logger = Logger.new($stdout)
+      logger.formatter = Formatters::JsonFormatter.new
+      config.logger = ActiveSupport::TaggedLogging.new(logger)
       config.log_tags = JsonTaggedLogger::LogTagsConfig.generate(
         :request_id,
         :remote_ip,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,9 +59,15 @@ Rails.application.configure do
   }
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  if ENV["ENABLE_ASIM_LOGGER"] == "true"
+    logger = ActiveSupport::Logger.new($stdout)
+    logger.formatter = Formatters::JsonFormatter.new
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  else
+    config.logger = ActiveSupport::Logger.new($stdout)
+      .tap  { |log| log.formatter = ::Logger::Formatter.new }
+      .then { |log| ActiveSupport::TaggedLogging.new(log) }
+  end
 
   # Prepend all log lines with the following tags.
   config.log_tags = %i[request_id]

--- a/lib/formatters/json_formatter.rb
+++ b/lib/formatters/json_formatter.rb
@@ -1,0 +1,9 @@
+module Formatters
+  class JsonFormatter < ::Logger::Formatter
+    def call(_severity, _time, _progname, msg)
+      # Output only the message (which should be JSON) without Rails logger prefix
+      # This removes the "I, [2025-04-30T13:55:43.349479 #1] INFO -- : [905c0821-f6ac-431e-8e46-0a55d862e2b4]" prefix
+      "#{msg}\n"
+    end
+  end
+end

--- a/spec/lib/formatters/json_formatter_spec.rb
+++ b/spec/lib/formatters/json_formatter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Formatters::JsonFormatter do
+  let(:formatter) { described_class.new }
+  let(:severity) { "INFO" }
+  let(:time) { Time.zone.now }
+  let(:progname) { "test" }
+  let(:message) { '{"key":"value"}' }
+
+  describe "#call" do
+    it "outputs the message without Rails logger prefix" do
+      formatted_output = formatter.call(severity, time, progname, message)
+      expect(formatted_output).to eq("#{message}\n")
+    end
+
+    it "does not include severity in the output" do
+      formatted_output = formatter.call(severity, time, progname, message)
+      expect(formatted_output).not_to include(severity)
+    end
+
+    it "does not include time in the output" do
+      formatted_output = formatter.call(severity, time, progname, message)
+      expect(formatted_output).not_to include(time.to_s)
+    end
+
+    it "does not include progname in the output" do
+      formatted_output = formatter.call(severity, time, progname, message)
+      expect(formatted_output).not_to include(progname)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a custom JSON formatter that outputs only the pure JSON part without this prefix. When the ASIM logger is enabled, this formatter will be used to ensure logs are in valid JSON format.

## Changes

- Created a custom `JsonFormatter` class that outputs only the message without the standard Rails logger prefix
- Updated application configuration to use this formatter when ASIM logging is enabled
- Updated production environment configuration to use the custom formatter
- Added comprehensive tests for the new formatter

## Ticket

- [PSD-5603](https://officedigital.atlassian.net/browse/PSD-5603)