### PR TITLE
fix/psd-5603-remove_request_id_from_asim_logs

### DIFF
--- a/lib/formatters/json_formatter.rb
+++ b/lib/formatters/json_formatter.rb
@@ -1,8 +1,9 @@
 module Formatters
   class JsonFormatter < ::Logger::Formatter
     def call(_severity, _time, _progname, msg)
+      # Remove any request ID prefix from the message
+      msg = msg.gsub(/^\[[^\]]+\]\s*/, "")
       # Output only the message (which should be JSON) without Rails logger prefix
-      # This removes the "I, [2025-04-30T13:55:43.349479 #1] INFO -- : [905c0821-f6ac-431e-8e46-0a55d862e2b4]" prefix
       "#{msg}\n"
     end
   end

--- a/spec/lib/formatters/json_formatter_spec.rb
+++ b/spec/lib/formatters/json_formatter_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Formatters::JsonFormatter do
       expect(formatted_output).to eq("#{message}\n")
     end
 
+    it "removes request ID prefix from the message" do
+      message_with_prefix = "[9fab6652-fc16-445e-ae55-14d8a9fea00c] #{message}"
+      formatted_output = formatter.call(severity, time, progname, message_with_prefix)
+      expect(formatted_output).to eq("#{message}\n")
+    end
+
     it "does not include severity in the output" do
       formatted_output = formatter.call(severity, time, progname, message)
       expect(formatted_output).not_to include(severity)


### PR DESCRIPTION
# Remove request ID prefix from ASIM logs

## Description
This PR fixes an issue with the ASIM log format where the request ID prefix was being included in the logs. The request ID prefix (e.g., `[9fab6652-fc16-445e-ae55-14d8a9fea00c]`) was being added to the logs, which was causing issues with log parsing and analysis.

## Changes
- Updated `JsonFormatter` to remove the request ID prefix from log messages
- Added test case to verify the request ID prefix removal

## Testing
1. Enable ASIM logging locally:
   ```bash
   ENABLE_ASIM_LOGGER=true rails server
   ```
2. Make a request to the application:
   ```bash
   curl -v http://localhost:3000/
   ```
3. Verify in the logs that:
   - The request ID prefix is removed
   - The logs are properly formatted JSON
   - All required ASIM fields are present

## QA Steps
1. Deploy to staging environment
2. Enable ASIM logging
3. Make a request to the application
4. Verify in the ECS logs that:
   - The request ID prefix is removed
   - The logs are properly formatted JSON
   - All required ASIM fields are present
   - The format matches the expected format from the IPFilter container