### PR TITLE
chore/psd-5605-update-accessible-autocomplete-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "accessible-autocomplete": "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main",
+    "accessible-autocomplete": "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multiselect/tarball/main",
     "esbuild": "^0.25.3",
     "govuk-frontend": "5.10.0",
     "postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,11 +342,9 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"accessible-autocomplete@https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main":
-  version "2.0.6"
-  resolved "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multi/tarball/main#5c026e81bf51391c2270f24e18058ae07a31d862"
-  dependencies:
-    preact "^8.3.1"
+"accessible-autocomplete@https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multiselect/tarball/main":
+  version "3.0.1"
+  resolved "https://github.com/OfficeForProductSafetyAndStandards/accessible-autocomplete-multiselect/tarball/main#c3432606e1f5df990efcee76a2c72178ab97366b"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2288,11 +2286,6 @@ postcss@^8.4.19, postcss@^8.5.3:
     nanoid "^3.3.8"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
-
-preact@^8.3.1:
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
-  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5605

## Description

Updates the version of `accessible-autocomplete` to use our latest fork.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
