### PR TITLE
Refactor antivirus checks to be fully async

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -13,8 +13,8 @@ OPENSEARCH_URL=http://localhost:9200
 
 EMAIL_WHITELIST_ENABLED=false
 
-ANTIVIRUS_URL=http://localhost:3006/safe
-ANTIVIRUS_USERNAME=av
+ANTIVIRUS_URL=https://staging.clamav.uktrade.digital
+ANTIVIRUS_USERNAME=username
 ANTIVIRUS_PASSWORD=password
 
 TWO_FACTOR_AUTHENTICATION_ENABLED=false

--- a/.env.test.example
+++ b/.env.test.example
@@ -13,8 +13,8 @@ OPENSEARCH_URL=http://localhost:9200
 
 EMAIL_WHITELIST_ENABLED=false
 
-ANTIVIRUS_URL=http://localhost:3006/safe
-ANTIVIRUS_USERNAME=av
+ANTIVIRUS_URL=https://staging.clamav.uktrade.digital
+ANTIVIRUS_USERNAME=username
 ANTIVIRUS_PASSWORD=password
 
 TWO_FACTOR_AUTHENTICATION_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ env:
   OPENSEARCH_URL: http://localhost:9200
   REDIS_URL: redis://localhost:6379
   RAILS_ENV: test
-  ANTIVIRUS_URL: http://localhost:3006/safe
-  ANTIVIRUS_USERNAME: av
+  ANTIVIRUS_URL: https://staging.clamav.uktrade.digital
+  ANTIVIRUS_USERNAME: username
   ANTIVIRUS_PASSWORD: password
   PSD_HOST: example.com
   PSD_HOST_SUPPORT: example.com

--- a/.github/workflows/erd.yml
+++ b/.github/workflows/erd.yml
@@ -10,8 +10,8 @@ env:
   OPENSEARCH_URL: http://localhost:9200
   REDIS_URL: redis://localhost:6379
   RAILS_ENV: test
-  ANTIVIRUS_URL: http://localhost:3006/safe
-  ANTIVIRUS_USERNAME: av
+  ANTIVIRUS_URL: https://staging.clamav.uktrade.digital
+  ANTIVIRUS_USERNAME: username
   ANTIVIRUS_PASSWORD: password
   PSD_HOST: example.com
   PSD_HOST_SUPPORT: example.com

--- a/.github/workflows/publish-production-redacted-export.yml
+++ b/.github/workflows/publish-production-redacted-export.yml
@@ -66,8 +66,8 @@ jobs:
           OPENSEARCH_URL: http://localhost:9200
           REDIS_URL: redis://localhost:6379
           RAILS_ENV: test
-          ANTIVIRUS_URL: http://localhost:3006/safe
-          ANTIVIRUS_USERNAME: av
+          ANTIVIRUS_URL: https://staging.clamav.uktrade.digital
+          ANTIVIRUS_USERNAME: username
           ANTIVIRUS_PASSWORD: password
           PSD_HOST: example.com
           PSD_HOST_SUPPORT: example.com

--- a/.github/workflows/publish-staging-redacted-export.yml
+++ b/.github/workflows/publish-staging-redacted-export.yml
@@ -66,8 +66,8 @@ jobs:
           OPENSEARCH_URL: http://localhost:9200
           REDIS_URL: redis://localhost:6379
           RAILS_ENV: test
-          ANTIVIRUS_URL: http://localhost:3006/safe
-          ANTIVIRUS_USERNAME: av
+          ANTIVIRUS_URL: https://staging.clamav.uktrade.digital
+          ANTIVIRUS_USERNAME: username
           ANTIVIRUS_PASSWORD: password
           PSD_HOST: example.com
           PSD_HOST_SUPPORT: example.com

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ The application is written in [Ruby on Rails](https://rubyonrails.org/).
 
 We're using ERB as our HTML templating language, ES6 JavaScript and [Sass](https://sass-lang.com/) for styling.
 
-We're using [Sidekiq](https://github.com/sidekiq/sidekiq) as our background processor to do things like send emails and handle attachments.
-
-We're processing attachments using our [antivirus API](https://github.com/OfficeForProductSafetyAndStandards/antivirus) for antivirus checking and [Imagemagick](https://imagemagick.org/) for thumbnailing.
+We're using [Sidekiq](https://github.com/sidekiq/sidekiq) as our background processor to do things like send emails and handle attachments, and [Imagemagick](https://imagemagick.org/) for thumbnailing.
 
 ## Getting started
 

--- a/app/analyzers/anti_virus_analyzer.rb
+++ b/app/analyzers/anti_virus_analyzer.rb
@@ -7,7 +7,7 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
     download_blob_to_tempfile do |file|
       file_obj = nil
       begin
-        antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+        antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "https://staging.clamav.uktrade.digital/v2/scan-chunked"
 
         file_obj = File.new(file.path, "rb")
         file_content = file_obj.read

--- a/app/controllers/bulk_products_controller.rb
+++ b/app/controllers/bulk_products_controller.rb
@@ -108,11 +108,17 @@ class BulkProductsController < ApplicationController
       @bulk_products_upload_products_file_form.load_products_file
       @bulk_products_upload.products_file.attach(@bulk_products_upload_products_file_form.products_file)
 
-      if @bulk_products_upload_products_file_form.valid?
+      if @bulk_products_upload_products_file_form.valid? && @bulk_products_upload.products_file&.safe?
         @bulk_products_upload.update!(products_cache: @bulk_products_upload_products_file_form.products)
 
+        flash[:information] = nil
+        flash[:warning] = nil
         redirect_to resolve_duplicate_products_bulk_upload_products_path(@bulk_products_upload)
+      elsif @bulk_products_upload.products_file&.virus?
+        flash[:warning] = "The file failed the virus scan. Please upload a virus-free file."
+        @bulk_products_upload.update!(products_cache: [])
       else
+        flash[:information] = "The file has not yet been scanned for viruses. Press the Continue button to re-check the status."
         @bulk_products_upload.update!(products_cache: [])
       end
     else

--- a/app/forms/document_form.rb
+++ b/app/forms/document_form.rb
@@ -14,7 +14,6 @@ class DocumentForm
   validates :document, presence: true, if: -> { existing_document_file_id.blank? }
   validate :file_size_below_max, if: -> { document.present? && existing_document_file_id.present? }
   validate :file_size_above_min, if: -> { document.present? && existing_document_file_id.present? }
-  validate :file_is_free_of_viruses, if: -> { document.present? && existing_document_file_id.present? }
   validates :title, presence: true
   validates :description, length: { maximum: 10_000 }
 
@@ -81,14 +80,5 @@ private
 
   def min_file_byte_size
     1.byte
-  end
-
-  def file_is_free_of_viruses
-    # don't run this validation unless document has been analyzed by antivirus analyzer
-    return unless document.metadata&.key?("safe")
-
-    return if document.metadata&.dig("safe") == true
-
-    errors.add(:base, :virus, message: "Files must be virus free")
   end
 end

--- a/app/jobs/delete_unsafe_files_job.rb
+++ b/app/jobs/delete_unsafe_files_job.rb
@@ -19,9 +19,12 @@ private
     attachments.each do |attachment|
       NotifyMailer.unsafe_attachment(user:, record_type: attachment.record_type, id: attachment.record_id).deliver_later if user && attachment.record_type != "Activity"
       attachment.purge
-      if attachment.record_type == "Activity"
+      case attachment.record_type
+      when "Activity"
         Activity.find(attachment.record_id).destroy!
-      elsif attachment.record_type == "ImageUpload"
+      when "DocumentUpload"
+        DocumentUpload.find(attachment.record_id).destroy!
+      when "ImageUpload"
         ImageUpload.find(attachment.record_id).destroy!
       end
     end

--- a/app/models/concerns/antivirusable.rb
+++ b/app/models/concerns/antivirusable.rb
@@ -1,0 +1,19 @@
+module Antivirusable
+  extend ActiveSupport::Concern
+
+  def safe?
+    return unless metadata&.key?("safe")
+
+    metadata&.dig("safe") == true
+  end
+
+  def virus?
+    return unless metadata&.key?("safe")
+
+    metadata&.dig("safe") == false
+  end
+
+  def virus_scanned?
+    metadata&.key?("analyzed") && metadata.key?("safe")
+  end
+end

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -11,20 +11,8 @@ class DocumentUpload < ApplicationRecord
   validates :file_upload, attached: true, size: { greater_than: 1.byte, message: "File must be larger than 0MB" }
   validates :title, presence: true
   validates :description, length: { maximum: 10_000 }
-  validate :file_is_free_of_viruses
 
   before_validation do
     trim_line_endings(:description)
-  end
-
-private
-
-  def file_is_free_of_viruses
-    # Don't run this validation unless document has been analyzed by antivirus analyzer
-    return unless file_upload&.metadata&.key?("safe")
-
-    return if file_upload&.metadata&.dig("safe") == true
-
-    errors.add(:file_upload, :virus, message: "File upload must be virus free")
   end
 end

--- a/app/models/image_upload.rb
+++ b/app/models/image_upload.rb
@@ -12,16 +12,4 @@ class ImageUpload < ApplicationRecord
   validates :file_upload, size: { greater_than: 1.byte, message: "Image must be larger than 0MB" }
   # Allow standard GIF/JPEG/PNG files as well as WEBP (if downloaded from the web) or HEIC/HEIF (if taken by a smartphone)
   validates :file_upload, content_type: { in: ["image/gif", "image/jpeg", "image/png", "image/heic", "image/heif", "image/webp"], message: "Image must be a GIF, JPEG, PNG, WEBP or HEIC/HEIF file" }
-  validate :file_is_free_of_viruses
-
-private
-
-  def file_is_free_of_viruses
-    # Don't run this validation unless document has been analyzed by antivirus analyzer
-    return unless file_upload&.metadata&.key?("safe")
-
-    return if file_upload&.metadata&.dig("safe") == true
-
-    errors.add(:base, :virus, message: "File upload must be virus free")
-  end
 end

--- a/app/models/investigation/notification.rb
+++ b/app/models/investigation/notification.rb
@@ -81,7 +81,7 @@ class Investigation < ApplicationRecord
     end
 
     def virus_free_images
-      image_uploads.select { |image_upload| image_upload&.file_upload&.metadata&.dig("safe") }
+      image_uploads.select { |image_upload| image_upload&.file_upload&.safe? }
     end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -82,7 +82,7 @@ class Product < ApplicationRecord
   end
 
   def virus_free_images
-    image_uploads.select { |image_upload| image_upload&.file_upload&.metadata&.dig("safe") }
+    image_uploads.select { |image_upload| image_upload&.file_upload&.safe? }
   end
 
   # Expose document uploads similarly to other model attributes while managing them as an

--- a/app/models/product_taxonomy_import.rb
+++ b/app/models/product_taxonomy_import.rb
@@ -21,7 +21,6 @@ class ProductTaxonomyImport < ApplicationRecord
 
   validates :import_file, attached: true, size: { less_than: 10.megabytes, message: "The selected file must be smaller than 10MB" }
   validates :import_file, attached: true, size: { greater_than: 1.byte, message: "The selected file must be larger than 0MB" }
-  validate :file_is_free_of_viruses
   validate :file_is_an_excel_workbook
   validate :file_is_in_expected_format, on: :validate_format
 
@@ -84,15 +83,6 @@ class ProductTaxonomyImport < ApplicationRecord
   end
 
 private
-
-  def file_is_free_of_viruses
-    # Don't run this validation unless document has been analyzed by antivirus analyzer
-    return unless import_file&.metadata&.key?("safe")
-
-    return if import_file&.metadata&.dig("safe") == true
-
-    errors.add(:import_file, :virus, message: "The selected file must be virus free")
-  end
 
   def file_is_an_excel_workbook
     return unless import_file.attached?

--- a/app/views/bulk_products/upload_products_file.html.erb
+++ b/app/views/bulk_products/upload_products_file.html.erb
@@ -16,9 +16,9 @@
       <% if @bulk_products_upload_products_file_form.products_file.present? %>
         <p class="govuk-body opss-file-attachment">
           Current file:
-          <% if @bulk_products_upload_products_file_form.products_file&.metadata&.dig("safe") == true %>
+          <% if @bulk_products_upload.products_file&.safe? %>
             <a href="<%= rails_storage_proxy_path(@bulk_products_upload_products_file_form.products_file) %>" class="govuk-link" rel="noreferrer noopener" target="_blank"><%= @bulk_products_upload_products_file_form.products_file.filename %></a>
-          <% elsif @bulk_products_upload_products_file_form.products_file&.metadata&.dig("safe") == false %>
+          <% elsif @bulk_products_upload.products_file&.virus? %>
             <%= @bulk_products_upload_products_file_form.products_file.filename %> (failed virus scan)
           <% else %>
             <%= @bulk_products_upload_products_file_form.products_file.filename %> (pending virus scan)

--- a/app/views/document_uploads/_document_preview.html.erb
+++ b/app/views/document_uploads/_document_preview.html.erb
@@ -2,8 +2,6 @@
   hide_link ||= false
   class_name ||= ""
   custom_image_classes ||= ""
-  analyzed = document.file_upload&.metadata&.dig("analyzed")
-  safe = document.file_upload&.metadata&.dig("safe")
   image_class = if document.file_upload.variable?
                   "app-document-preview__image"
                 else
@@ -13,7 +11,7 @@
 %>
 
 <div class="app-document-preview <%= class_name %>">
-  <% if analyzed && safe %>
+  <% if document.file_upload&.safe? %>
     <% if document.file_upload.image? %>
       <div class="<%= image_classes %>">
         <% if hide_link %>

--- a/app/views/documents/_document_preview.html.erb
+++ b/app/views/documents/_document_preview.html.erb
@@ -2,8 +2,6 @@
   hide_link ||= false
   class_name ||= ""
   custom_image_classes ||= ""
-  analyzed = document.metadata&.dig("analyzed")
-  safe = document.metadata&.dig("safe")
   image_class = if document.variable?
                   "app-document-preview__image"
                 else
@@ -12,7 +10,7 @@
   image_classes = class_names(image_class, custom_image_classes)
 %>
 <div class="app-document-preview <%= class_name %>">
-  <% if analyzed && safe %>
+  <% if document&.safe? %>
     <% if document.image? %>
       <div class="<%= image_classes %>">
         <% if hide_link %>

--- a/app/views/image_uploads/_image_preview.html.erb
+++ b/app/views/image_uploads/_image_preview.html.erb
@@ -2,8 +2,6 @@
   hide_link ||= false
   class_name ||= ""
   custom_image_classes ||= ""
-  analyzed = image.file_upload&.metadata&.dig("analyzed")
-  safe = image.file_upload&.metadata&.dig("safe")
   image_class = if image.file_upload.variable?
                   "app-document-preview__image"
                 else
@@ -13,7 +11,7 @@
 %>
 
 <div class="app-document-preview <%= class_name %>">
-  <% if analyzed && safe %>
+  <% if image.file_upload&.safe? %>
     <div class="<%= image_classes %>">
       <% if hide_link %>
         <%= render("image_uploads/image_tag", image:, dimensions: dimensions) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,7 @@ module ProductSafetyDatabase
     config.email_whitelist_enabled = ENV.fetch("EMAIL_WHITELIST_ENABLED", "true") == "true"
     config.notify_api_key = ENV.fetch("NOTIFY_API_KEY", "")
 
-    config.antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://localhost:3006/safe")
+    config.antivirus_url = ENV.fetch("ANTIVIRUS_URL", "https://staging.clamav.uktrade.digital")
 
     # Always default to secure configuration - 2FA enabled
     config.secondary_authentication_enabled = true

--- a/config/initializers/active_storage_attachment.rb
+++ b/config/initializers/active_storage_attachment.rb
@@ -1,0 +1,3 @@
+Rails.configuration.to_prepare do
+  ActiveStorage::Attachment.include Antivirusable
+end

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -12,7 +12,7 @@ Add the required hosts in `/etc/hosts`:
 127.0.0.1       psd-report
 ```
 
-To start all the required dependencies, run `docker compose up antivirus db redis opensearch`.
+To start all the required dependencies, run `docker compose up db redis opensearch`.
 
 Make a copy of the environment files for development and test:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,6 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
 
-  antivirus:
-    image: beisopss/antivirus:master
-    env_file:
-      - ./docker/env.antivirus
-    environment:
-      - PORT=3006
-    ports:
-      - "3006:3006"
-
   opensearch:
     image: opensearchproject/opensearch:2.15.0
     environment:

--- a/docker/env.antivirus
+++ b/docker/env.antivirus
@@ -1,5 +1,0 @@
-# Note: These are DEVELOPMENT values only - not used in production
-
-# Antivirus API details
-ANTIVIRUS_USERNAME=av
-ANTIVIRUS_PASSWORD=password

--- a/prism/README.md
+++ b/prism/README.md
@@ -25,10 +25,6 @@ Once your migrations are ready, from the PSD application root, run `bundle exec 
 You can then run the migrations as usual. All PRISM table names must be prefixed with `prism_` to avoid potential clashes
 with PSD tables.
 
-### Antivirus API
-
-The [antivirus API](https://github.com/OfficeForProductSafetyAndStandards/antivirus) is used to virus scan user-uploaded files.
-
 ### Accounts
 
 #### GOV.UK Platform as a Service

--- a/prism/app/helpers/prism/tasks/create_helper.rb
+++ b/prism/app/helpers/prism/tasks/create_helper.rb
@@ -159,7 +159,7 @@ module Prism
         harm_scenario_step.description,
         "Probability of harm: #{probability_of_harm(**harm_scenario_step.probability_of_harm)}",
         "Evidence: #{t("prism.harm_scenario_steps.probability_evidence.#{harm_scenario_step.probability_evidence}")}",
-        ("<a href=\"#{main_app.rails_storage_proxy_path(file)}\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">#{file.blob.filename}</a>" if file && file.metadata&.dig("safe") == true),
+        ("<a href=\"#{main_app.rails_storage_proxy_path(file)}\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">#{file.blob.filename}</a>" if file && file.safe?),
       ].join("<br>")
     end
 

--- a/prism/app/views/prism/application/_attachment.html.erb
+++ b/prism/app/views/prism/application/_attachment.html.erb
@@ -1,9 +1,9 @@
 <% if file.attached? %>
   <p class="govuk-body opss-file-attachment">
     <img src="<%= file_icon_url(file.blob.content_type) %>" width="32" height="32" alt="">
-    <% if file.metadata&.dig("safe") == true %>
+    <% if file&.safe? %>
       <a href="<%= main_app.rails_storage_proxy_path(file) %>" class="govuk-link" rel="noreferrer noopener" target="_blank"><%= file.blob.filename %></a>
-    <% elsif file.metadata&.dig("safe") == false %>
+    <% elsif file&.virus? %>
       <%= file.blob.filename %> (failed virus scan)
     <% else %>
       <%= file.blob.filename %> (pending virus scan)

--- a/spec/analyzers/anti_virus_analyzer_spec.rb
+++ b/spec/analyzers/anti_virus_analyzer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AntiVirusAnalyzer do
   before do
     env_vars = {
       "ANTIVIRUS_URL" => antivirus_url,
-      "ANTIVIRUS_USERNAME" => "av",
+      "ANTIVIRUS_USERNAME" => "username",
       "ANTIVIRUS_PASSWORD" => "password",
       "TMPDIR" => "/tmp"
     }
@@ -25,7 +25,7 @@ RSpec.describe AntiVirusAnalyzer do
         headers: {
           "Content-Type" => "application/octet-stream",
           "Transfer-Encoding" => "chunked",
-          "Authorization" => "Basic YXY6cGFzc3dvcmQ="
+          "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         }
       )
       .to_return(status: 200, body: { malware: false, reason: nil, time: 0.001 }.to_json)
@@ -67,7 +67,7 @@ RSpec.describe AntiVirusAnalyzer do
                 headers: {
                   "Content-Type" => "application/octet-stream",
                   "Transfer-Encoding" => "chunked",
-                  "Authorization" => "Basic YXY6cGFzc3dvcmQ="
+                  "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
                 }
               )
               .to_return(status: 200, body: { malware: true, reason: "Test-Virus-Found", time: 0.001 }.to_json)
@@ -101,7 +101,7 @@ RSpec.describe AntiVirusAnalyzer do
               headers: {
                 "Content-Type" => "application/octet-stream",
                 "Transfer-Encoding" => "chunked",
-                "Authorization" => "Basic YXY6cGFzc3dvcmQ="
+                "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
               }
             )
             .to_return(status: 200, body: "Invalid JSON")

--- a/spec/features/add_attachment_to_a_notification_spec.rb
+++ b/spec/features/add_attachment_to_a_notification_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature "Add an attachment to a notification", :with_stubbed_antivirus, :w
 
       click_button "Upload"
 
-      expect_warning_banner("File upload must be virus free")
+      expect_warning_banner("The image is infected with a virus and will be deleted - please upload again")
     end
   end
 

--- a/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
+++ b/spec/features/add_edit_remove_attachment_for_a_product_spec.rb
@@ -57,28 +57,6 @@ RSpec.feature "Add/edit/remove an attachment for a product", :with_stubbed_antiv
     expect_confirmation_banner("The image was successfully removed")
   end
 
-  context "when an image fails the antivirus check", :with_stubbed_failing_antivirus do
-    it "shows error" do
-      sign_in user
-      visit "/products/#{product.id}"
-
-      expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
-
-      click_link "Add an image"
-      expect_to_be_on_add_attachment_to_a_product_page(product_id: product.id)
-
-      click_button "Upload"
-
-      expect(page).to have_error_summary("Select a file")
-
-      attach_file "image_upload[file_upload]", image
-
-      click_button "Upload"
-
-      expect_warning_banner("File upload must be virus free")
-    end
-  end
-
   context "when the product is owned by another team" do
     let(:owning_team) { create(:team) }
     let(:owning_user) { create(:user, :activated, has_viewed_introduction: true, team: owning_team) }

--- a/spec/features/bulk_upload_products_spec.rb
+++ b/spec/features/bulk_upload_products_spec.rb
@@ -120,6 +120,9 @@ RSpec.feature "Bulk upload products", :with_opensearch, :with_stubbed_antivirus,
     attach_file "bulk_products_upload_products_file_form[products_file_upload]", "spec/fixtures/files/bulk_products_upload_complete_product.xlsx"
     click_button "Continue"
 
+    expect_warning_banner("The file has not yet been scanned for viruses. Press the Continue button to re-check the status.")
+    click_button "Continue"
+
     expect(page).to have_content("We found duplicate product records")
 
     click_button "Continue"
@@ -235,6 +238,9 @@ RSpec.feature "Bulk upload products", :with_opensearch, :with_stubbed_antivirus,
     attach_file "bulk_products_upload_products_file_form[products_file_upload]", "spec/fixtures/files/bulk_products_upload_empty_rows.xlsx"
     click_button "Continue"
 
+    expect_warning_banner("The file has not yet been scanned for viruses. Press the Continue button to re-check the status.")
+    click_button "Continue"
+
     expect(page).to have_content("Review details of the products you are uploading")
   end
 
@@ -305,6 +311,9 @@ RSpec.feature "Bulk upload products", :with_opensearch, :with_stubbed_antivirus,
     expect(page).to have_error_summary("The selected file contains one or more products with errors")
 
     attach_file "bulk_products_upload_products_file_form[products_file_upload]", "spec/fixtures/files/bulk_products_upload_complete_product.xlsx"
+    click_button "Continue"
+
+    expect_warning_banner("The file has not yet been scanned for viruses. Press the Continue button to re-check the status.")
     click_button "Continue"
 
     expect(page).to have_content("We found duplicate product records")

--- a/spec/forms/document_form_spec.rb
+++ b/spec/forms/document_form_spec.rb
@@ -136,39 +136,6 @@ RSpec.describe DocumentForm, :with_test_queue_adapter do
         end
       end
     end
-
-    context "with antivirus validation" do
-      context "when file is not yet scanned" do
-        before do
-          allow(form.document).to receive(:metadata).and_return({})
-        end
-
-        it "skips the validation" do
-          expect(form).to be_valid
-        end
-      end
-
-      context "when file is marked as safe" do
-        before do
-          allow(form.document).to receive(:metadata).and_return({ "safe" => true })
-        end
-
-        it "is valid" do
-          expect(form).to be_valid
-        end
-      end
-
-      context "when file is marked as unsafe" do
-        before do
-          allow(form.document).to receive(:metadata).and_return({ "safe" => false })
-        end
-
-        it "is invalid" do
-          expect(form).to be_invalid
-          expect(form.errors[:base]).to include("Files must be virus free")
-        end
-      end
-    end
   end
 
   describe "#initialize" do

--- a/spec/support/antivirus.rb
+++ b/spec/support/antivirus.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
   before do
-    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "https://staging.clamav.uktrade.digital/v2/scan-chunked"
 
     # For clamav-rest API, the opposite of "safe: true" is "malware: false"
     stubbed_response = '{"malware": false, "reason": null, "time": 0.001}'
@@ -16,7 +16,7 @@ end
 
 RSpec.shared_context "with stubbed failing Antivirus API", shared_context: :metadata do
   before do
-    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "https://staging.clamav.uktrade.digital/v2/scan-chunked"
 
     # For clamav-rest API, this would be "malware: true"
     stubbed_response = '{"malware": true, "reason": "Test-Virus-Found", "time": 0.001}'

--- a/spec/support/shared_contexts/antivirus_stub.rb
+++ b/spec/support/shared_contexts/antivirus_stub.rb
@@ -1,6 +1,7 @@
 RSpec.shared_context "with stubbed antivirus" do
   before do
-    stub_request(:post, "http://localhost:3006/safe")
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "https://staging.clamav.uktrade.digital/v2/scan-chunked"
+    stub_request(:post, antivirus_url)
       .with(
         headers: {
           "Accept" => "*/*",

--- a/support_portal/app/views/support_portal/product_taxonomy/index.html.erb
+++ b/support_portal/app/views/support_portal/product_taxonomy/index.html.erb
@@ -24,8 +24,8 @@
             row.with_cell(text: "Bulk upload template file")
           end
         end
-        table.with_body do |body|
-          @records.each do |record|
+        @records.each do |record|
+          table.with_body do |body|
             body.with_row do |row|
               row.with_cell(text: record.user.name)
               row.with_cell(text: display_date_time(record.created_at))
@@ -38,6 +38,11 @@
               end
               row.with_cell do
                 render "file_link", file: record.bulk_upload_template_file
+              end
+            end
+            if record.error_message.present?
+              body.with_row do |row|
+                row.with_cell(text: record.error_message, colspan: 6, classes: "govuk-hint")
               end
             end
           end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5159

## Description

Refactors antivirus checks for all uploaded files to be fully async.

* For document/image uploads for notifications/products, we already only displayed safe files and infected files are automatically deleted. Remove the sleep.
* For bulk product uploads, the process continued regardless of the antivirus status. Add a step to force the check to complete before the user can continue.
* For product taxonomy uploads, add a retry mechanism in the existing asynchronous job to keep checking for a safe status before continuing, and expose any errors in the UI.

Also removes the dev antivirus container since it doesn't work with the new chunked scanning method. Defaults to the staging antivirus service instead. Credentials still need to be supplied in the relevant `.env` file.

## Screen-shots or screen-capture of UI changes

![Screenshot 2025-05-13 at 16 28 18](https://github.com/user-attachments/assets/214fc960-9769-45f0-9986-358eaf03ab81)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
