### PR TITLE
bug/psd-5711-exclude-dev-from-csp-https

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,7 +16,6 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src :none
   policy.child_src :self
   policy.frame_ancestors :none
-  policy.upgrade_insecure_requests true
   policy.block_all_mixed_content true
 
   # Script handling with nonce support
@@ -36,6 +35,10 @@ Rails.application.config.content_security_policy do |policy|
 
   # Connect-src directive for Google Analytics
   policy.connect_src(*trusted_connect_sources)
+
+  if Rails.env.production?
+    policy.upgrade_insecure_requests true
+  end
 end
 
 # CSP nonce configuration


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5711

## Description

Excludes the dev environment from mandatory HTTPS.

## Screen-shots or screen-capture of UI changes

N/A

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
