### PR TITLE
PSD-5701_update_code_to_use_new_varaibles_for_AWS

### DIFF
--- a/config/redacted_export.yml
+++ b/config/redacted_export.yml
@@ -1,7 +1,7 @@
 shared:
   account_id: <%= ENV["AWS_ACCOUNT_ID"] %>
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKET_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] || ENV["BUCKET_SECRET_ACCESS_KEY"] %>
   region: <%= ENV["AWS_REGION"] %>
   source_bucket: <%= ENV["AWS_S3_BUCKET"] %>
   destination_bucket: <%= ENV["REDACTED_EXPORT_BUCKET"] %>


### PR DESCRIPTION
with respect to DBT migration we are supposed to use BUCKET_ACCESS_KEY_ID and BUCKET_SECRET_ACCESS_KEY instead of the existing AWS prefix variables .