### PR TITLE
feat/psd-3909-summary-to-new-ra-landing-page

### DIFF
--- a/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
+++ b/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
@@ -2,7 +2,7 @@ class AuditActivity::RiskAssessment::RiskAssessmentAddedDecorator < ApplicationD
   delegate_all
 
   def title(*)
-    "Risk assessment"
+    "Other risk assessment"
   end
 
   def assessed_on

--- a/app/decorators/risk_assessment_decorator.rb
+++ b/app/decorators/risk_assessment_decorator.rb
@@ -24,7 +24,7 @@ class RiskAssessmentDecorator < ApplicationDecorator
   end
 
   def supporting_information_type
-    "Risk assessment"
+    "Other risk assessment"
   end
 
   def date_of_activity

--- a/app/helpers/notifications/create_helper.rb
+++ b/app/helpers/notifications/create_helper.rb
@@ -153,8 +153,8 @@ module Notifications
         (prism_risk_assessments.decorate + risk_assessments.decorate).map { |assessment| sanitize(assessment.supporting_information_full_title) }.compact.join("<br>")
       else
         risk_assessment_list = Investigation.find_by(pretty_id: notification_id).risk_assessments
-        if risk_assessment_list.nil?
-          "Not Provided"
+        if risk_assessment_list.blank?
+          "Not provided"
         else
           hyperlinks = ""
           risk_assessment_list.each_with_index do |risk, index|

--- a/app/views/notifications/create/check_notification_details_and_submit.html.erb
+++ b/app/views/notifications/create/check_notification_details_and_submit.html.erb
@@ -155,7 +155,7 @@
               ]
             },
             {
-              key: { text: "Risk assessments" },
+              key: { text: "Other risk assessment" },
               value: { text: sanitize(formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments, nil)).html_safe.presence || "Not provided" },
               actions: [
                 {

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -186,7 +186,7 @@
               ] : []
             },
             {
-              key: { text: "Risk assessments" },
+              key: { text: "Other risk assessment" },
               value: { text: formatted_risk_assessments(investigation_product.prism_risk_assessments, investigation_product.risk_assessments.order(created_at: :asc), @notification.pretty_id).html_safe.presence || "Not provided" },
               actions: show_edit_link? ? [
                 {

--- a/spec/services/add_risk_assessment_to_notification_spec.rb
+++ b/spec/services/add_risk_assessment_to_notification_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe AddRiskAssessmentToNotification, :with_stubbed_mailer, :with_test
       expect(last_added_activity.added_by_user_id).to eql(user.id)
       expect(last_added_activity.metadata).to be_present
 
-      expect(last_added_activity.decorate.title(nil)).to eql("Risk assessment")
+      expect(last_added_activity.decorate.title(nil)).to eql("Other risk assessment")
     end
 
     it_behaves_like "a service which notifies the notification owner"


### PR DESCRIPTION
# PSD-3909: Change 'Risk assessment' to 'Other risk assessment' and display 'Not provided' when no risk assessment exists

## Description
This PR implements changes for ticket PSD-3909 to improve the user experience when viewing risk assessment information on legacy screens.

Changes include:
- Updated references from "Risk assessment" to "Other risk assessment" in views and decorators
- Modified RiskAssessmentDecorator to return "Other risk assessment" instead of "Risk assessment"
- Changed title method in RiskAssessmentAddedDecorator to return "Other risk assessment"
- Updated view files to display "Not provided" when no risk assessment exists
- Fixed affected tests to expect the updated terminology

## QA Steps
1. Navigate to a notification with an existing risk assessment
2. Verify that "Risk assessment" has been changed to "Other risk assessment" in the UI
3. Verify that clicking on a risk assessment filename navigates to the risk assessment landing page
4. Navigate to a notification without a risk assessment
5. Verify that "Not provided" is displayed in the risk assessment section