### PR TITLE
bug/psd-5695-fix-product-category-subcategory-form-ui

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -16,9 +16,11 @@
       <%= form.govuk_text_field :subcategory, label: { text: "Sub-category", size: "m" }, disabled: true %>
     </div>
   <% else %>
-    <%= form.govuk_collection_select :category, category_items, :value, :text, label: { text: "Main category", size: "m" }, hint: { text: category_hint }, "aria-controls": "product-category-conditional" %>
-    <div class="opss-select__conditional govuk-radios__conditional" id="product-category-conditional">
-      <%= form.govuk_collection_select :subcategory, subcategory_items, :value, :text, label: { text: "Sub-category", size: "m" }, hint: { text: "Filtered by your main category selection" } %>
+    <%= form.govuk_collection_select :category, category_items, :value, :text, label: { text: "Main category", size: "m" }, hint: { text: category_hint }, "aria-controls": "product-category-conditional", class: "govuk-!-width-full" %>
+    <div class="govuk-form-group">
+      <div class="opss-select__conditional govuk-radios__conditional" id="product-category-conditional">
+        <%= form.govuk_collection_select :subcategory, subcategory_items, :value, :text, label: { text: "Sub-category", size: "m" }, hint: { text: "Filtered by your main category selection" }, class: "govuk-!-width-full" %>
+      </div>
     </div>
   <% end %>
 <% else %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/PSD-5695

## Description

Tweaks the add product page form layout to fix the width and spacing of the product category/sub-category drop-downs.

## Screen-shots or screen-capture of UI changes

### Before

![Screenshot 2025-05-16 at 13 51 20](https://github.com/user-attachments/assets/229bbc03-c346-400a-9253-3320d3cf6a78)

![Screenshot 2025-05-16 at 13 55 16](https://github.com/user-attachments/assets/9df738be-254e-4a4b-830d-65fb26eb1933)

### After

![Screenshot 2025-05-16 at 13 51 33](https://github.com/user-attachments/assets/c5b4151a-1f57-42f7-b6fe-e6d3ffe1646b)

![Screenshot 2025-05-16 at 13 55 29](https://github.com/user-attachments/assets/2cf04ae3-ff6f-4812-8c8f-a140e35245ca)

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Reviewed by Designer (if required)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
